### PR TITLE
fix crash when GT is not present

### DIFF
--- a/src/main/java/appeng/tile/powersink/IC2.java
+++ b/src/main/java/appeng/tile/powersink/IC2.java
@@ -33,7 +33,7 @@ import java.util.EnumSet;
 
 
 @Interface( iname = IntegrationType.IC2, iface = "ic2.api.energy.tile.IEnergySink" )
-public abstract class IC2 extends GTPowerSink implements IEnergySink
+public abstract class IC2 extends AERootPoweredTile implements IEnergySink
 {
 
 	private boolean isInIC2 = false;


### PR DESCRIPTION
If GT is not present, AE2 will crash trying to find gregtech.api.interfaces.tileentity.IEnergyConnected, this fixes that issue. AE2 still accepts both GT and IC2 power with this change.