### PR TITLE
Add view cells to wireless terminal

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 aeversion=rv3
 aechannel=beta
-aebuild=53-GTNH
+aebuild=54-GTNH
 #KEEP V6 FOR MOD SUPPORT
 aegroup=appeng
 aebasename=appliedenergistics2

--- a/src/main/java/appeng/container/implementations/ContainerMEMonitorable.java
+++ b/src/main/java/appeng/container/implementations/ContainerMEMonitorable.java
@@ -46,6 +46,7 @@ import appeng.core.AELog;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketMEInventoryUpdate;
 import appeng.core.sync.packets.PacketValueConfig;
+import appeng.helpers.WirelessTerminalGuiObject;
 import appeng.me.helpers.ChannelPowerSrc;
 import appeng.util.ConfigManager;
 import appeng.util.IConfigManagerHost;
@@ -236,7 +237,9 @@ public class ContainerMEMonitorable extends AEBaseContainer implements IConfigMa
 			this.updatePowerStatus();
 
 			final boolean oldAccessible = this.canAccessViewCells;
-			this.canAccessViewCells = this.hasAccess( SecurityPermissions.BUILD, false );
+			this.canAccessViewCells =
+					this.host instanceof WirelessTerminalGuiObject
+							|| this.hasAccess( SecurityPermissions.BUILD, false );
 			if( this.canAccessViewCells != oldAccessible )
 			{
 				for( int y = 0; y < 5; y++ )

--- a/src/main/java/appeng/helpers/WirelessTerminalGuiObject.java
+++ b/src/main/java/appeng/helpers/WirelessTerminalGuiObject.java
@@ -26,6 +26,7 @@ import appeng.api.config.PowerMultiplier;
 import appeng.api.features.ILocatable;
 import appeng.api.features.IWirelessTermHandler;
 import appeng.api.implementations.guiobjects.IPortableCell;
+import appeng.api.implementations.tiles.IViewCellStorage;
 import appeng.api.implementations.tiles.IWirelessAccessPoint;
 import appeng.api.networking.IGrid;
 import appeng.api.networking.IGridHost;
@@ -44,14 +45,16 @@ import appeng.api.util.AECableType;
 import appeng.api.util.DimensionalCoord;
 import appeng.api.util.IConfigManager;
 import appeng.container.interfaces.IInventorySlotAware;
+import appeng.items.contents.WirelessTerminalViewCells;
 import appeng.tile.networking.TileWireless;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
 
-public class WirelessTerminalGuiObject implements IPortableCell, IActionHost, IInventorySlotAware
+public class WirelessTerminalGuiObject implements IPortableCell, IActionHost, IInventorySlotAware, IViewCellStorage
 {
 
 	private final ItemStack effectiveItem;
@@ -65,6 +68,7 @@ public class WirelessTerminalGuiObject implements IPortableCell, IActionHost, II
 	private double sqRange = Double.MAX_VALUE;
 	private double myRange = Double.MAX_VALUE;
 	private final int inventorySlot;
+	private final WirelessTerminalViewCells viewCells;
 
 	public WirelessTerminalGuiObject( final IWirelessTermHandler wh, final ItemStack is, final EntityPlayer ep, final World w, final int x, final int y, final int z )
 	{
@@ -73,6 +77,7 @@ public class WirelessTerminalGuiObject implements IPortableCell, IActionHost, II
 		this.myPlayer = ep;
 		this.wth = wh;
 		this.inventorySlot = x;
+		this.viewCells = new WirelessTerminalViewCells( is );
 
 		ILocatable obj = null;
 
@@ -377,4 +382,9 @@ public class WirelessTerminalGuiObject implements IPortableCell, IActionHost, II
 		return this.inventorySlot;
 	}
 
+	@Override
+	public IInventory getViewCellStorage()
+	{
+		return this.viewCells;
+	}
 }

--- a/src/main/java/appeng/items/contents/WirelessTerminalViewCells.java
+++ b/src/main/java/appeng/items/contents/WirelessTerminalViewCells.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.items.contents;
+
+
+import appeng.tile.inventory.AppEngInternalInventory;
+import appeng.util.Platform;
+import net.minecraft.item.ItemStack;
+
+
+public class WirelessTerminalViewCells extends AppEngInternalInventory
+{
+
+	private final ItemStack is;
+
+	public WirelessTerminalViewCells( final ItemStack is )
+	{
+		super( null, 5 );
+		this.is = is;
+		this.readFromNBT( Platform.openNbtData( is ), "viewCell" );
+	}
+
+	@Override
+	public void markDirty()
+	{
+		this.writeToNBT( Platform.openNbtData( is ), "viewCell" );
+	}
+}

--- a/src/main/java/appeng/tile/inventory/AppEngInternalInventory.java
+++ b/src/main/java/appeng/tile/inventory/AppEngInternalInventory.java
@@ -151,9 +151,9 @@ public class AppEngInternalInventory implements IInventory, Iterable<ItemStack>
 			}
 
 			this.getTileEntity().onChangeInventory( this, slot, InvOperation.setInventorySlotContents, removed, added );
-
-			this.markDirty();
 		}
+
+		this.markDirty();
 	}
 
 	@Override


### PR DESCRIPTION
Add view cell support to the wireless terminal (the default AE2 one, *not* the wireless crafting terminal). The view cells will be saved within the wireless terminal item.

**Known issue**: Sometimes, clicking to pick up a view cell from a GUI slot will cause it to fall into the world rather than be held in the hand. The view cell code is shared with that of the regular terminals, and I tested with an unmodified version of AE2 and saw that this issue also happened with regular terminals, so I think it's a pre-existing issue. My guess is that this happens when the server is still reading or writing view cell data when you try to pick up a view cell. It's likely that the wireless terminals are more likely to be affected by this issue, though, because they do a write every time a view cell is moved, whereas the regular terminals might be buffering their writes.

 * Partial fix for https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8332
   * Adds view cell support to the wireless terminal, but not toggle support. Currently the view cell code is shared with the regular terminals; adding toggle support will mean needing to have separate view cell code.