### PR TITLE
Allow renaming CPU clusters in world with a knife shift-click

### DIFF
--- a/src/main/java/appeng/container/implementations/ContainerCraftingStatus.java
+++ b/src/main/java/appeng/container/implementations/ContainerCraftingStatus.java
@@ -106,24 +106,42 @@ public class ContainerCraftingStatus extends ContainerCraftingCPU
 	{
 		return c.isBusy();
 	}
+	
+	private void findByName()
+	{
+		int index = 0;
+		for (CraftingCPURecord c: cpus)
+		{
+			if (this.myName.equals(c.getName()))
+			{
+				this.selectedCpu = index;
+				break;
+			}
+			++index;
+		}
+	}
 
 	private void sendCPUs()
 	{
 		Collections.sort( this.cpus );
 
 		if( this.selectedCpu >= this.cpus.size() )
-		{
 			this.selectedCpu = -1;
+
+		if( this.selectedCpu == -1 )
 			this.myName = "";
-		}
-		else if( this.selectedCpu != -1 )
-		{
-			this.myName = this.cpus.get( this.selectedCpu ).getName();
-		}
+
+		if( this.myName != "" )
+			findByName();
 
 		if( this.selectedCpu == -1 && this.cpus.size() > 0 )
 		{
 			this.selectedCpu = 0;
+		}
+
+		if( this.selectedCpu != -1 )
+		{
+			this.myName = this.cpus.get( this.selectedCpu ).getName();
 		}
 
 		if( this.selectedCpu != -1 )

--- a/src/main/java/appeng/items/tools/quartz/ToolQuartzCuttingKnife.java
+++ b/src/main/java/appeng/items/tools/quartz/ToolQuartzCuttingKnife.java
@@ -25,10 +25,13 @@ import appeng.core.features.AEFeature;
 import appeng.core.sync.GuiBridge;
 import appeng.items.AEBaseItem;
 import appeng.items.contents.QuartzKnifeObj;
+import appeng.tile.AEBaseTile;
+import appeng.tile.networking.TileCableBus;
 import appeng.util.Platform;
 import com.google.common.base.Optional;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
@@ -54,7 +57,11 @@ public class ToolQuartzCuttingKnife extends AEBaseItem implements IGuiItem
 	{
 		if( Platform.isServer() )
 		{
-			Platform.openGUI( p, null, ForgeDirection.UNKNOWN, GuiBridge.GUI_QUARTZ_KNIFE );
+			TileEntity te = w.getTileEntity(x,y, z);
+			if (te instanceof AEBaseTile && !(te instanceof TileCableBus))
+				Platform.openGUI( p, te, ForgeDirection.getOrientation( s ), GuiBridge.GUI_RENAMER );
+			else
+				Platform.openGUI( p, null, ForgeDirection.UNKNOWN, GuiBridge.GUI_QUARTZ_KNIFE );
 		}
 		return true;
 	}

--- a/src/main/java/appeng/me/cache/CraftingGridCache.java
+++ b/src/main/java/appeng/me/cache/CraftingGridCache.java
@@ -515,25 +515,23 @@ public class CraftingGridCache implements ICraftingGrid, ICraftingProviderHelper
 
 			Collections.sort( validCpusClusters, new Comparator<CraftingCPUCluster>()
 			{
+				private int compareInternal(CraftingCPUCluster firstCluster, CraftingCPUCluster nextCluster)
+				{
+					int comparison = ItemSorters.compareLong( nextCluster.getCoProcessors(), firstCluster.getCoProcessors() );
+					if( comparison == 0 )
+						comparison = ItemSorters.compareLong( nextCluster.getAvailableStorage(), firstCluster.getAvailableStorage() );
+					if( comparison == 0 )
+						return nextCluster.getName().compareTo(firstCluster.getName());
+					else
+						return comparison;
+				}
 				@Override
 				public int compare( final CraftingCPUCluster firstCluster, final CraftingCPUCluster nextCluster )
 				{
 					if( prioritizePower )
-					{
-						final int comparison = ItemSorters.compareLong( nextCluster.getCoProcessors(), firstCluster.getCoProcessors() );
-						if( comparison != 0 )
-						{
-							return comparison;
-						}
-						return ItemSorters.compareLong( nextCluster.getAvailableStorage(), firstCluster.getAvailableStorage() );
-					}
-
-					final int comparison = ItemSorters.compareLong( firstCluster.getCoProcessors(), nextCluster.getCoProcessors() );
-					if( comparison != 0 )
-					{
-						return comparison;
-					}
-					return ItemSorters.compareLong( firstCluster.getAvailableStorage(), nextCluster.getAvailableStorage() );
+						return compareInternal(firstCluster, nextCluster);
+					else
+						return compareInternal(nextCluster, firstCluster);
 				}
 			} );
 

--- a/src/main/java/appeng/tile/AEBaseTile.java
+++ b/src/main/java/appeng/tile/AEBaseTile.java
@@ -558,7 +558,7 @@ public class AEBaseTile extends TileEntity implements IOrientable, ICommonTile, 
 
 	@Override
 	public void setCustomName(String name) {
-		this.customName = name;
+		setName(name);
 	}
 
 	public void securityBreak()


### PR DESCRIPTION
Make CPU sorting take names into account
Make crafting GUI try to preserve currently selected CPU when
(fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/9510)