### PR TITLE
Mark TE chunks as dirty on block updates

### DIFF
--- a/src/main/java/appeng/tile/AEBaseTile.java
+++ b/src/main/java/appeng/tile/AEBaseTile.java
@@ -290,6 +290,7 @@ public class AEBaseTile extends TileEntity implements IOrientable, ICommonTile, 
 			{
 				AELog.blockUpdate( this.xCoord, this.yCoord, this.zCoord, this );
 				this.worldObj.markBlockForUpdate( this.xCoord, this.yCoord, this.zCoord );
+				this.worldObj.markTileEntityChunkModified( this.xCoord, this.yCoord, this.zCoord, this );
 			}
 		}
 	}


### PR DESCRIPTION
markBlockForUpdate only marks it for a network packet, the chunk has to be marked separately

Fixes <https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/issues/147>