### PR TITLE
Added GUI color customizability through lang file

### DIFF
--- a/src/main/java/appeng/client/gui/AEBaseGui.java
+++ b/src/main/java/appeng/client/gui/AEBaseGui.java
@@ -32,6 +32,7 @@ import appeng.container.slot.AppEngSlot.hasCalculatedValidness;
 import appeng.core.AELog;
 import appeng.core.AppEng;
 import appeng.core.localization.GuiText;
+import appeng.core.localization.GuiColors;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketInventoryAction;
 import appeng.core.sync.packets.PacketSwapSlots;
@@ -821,7 +822,7 @@ public abstract class AEBaseGui extends GuiContainer
 				if( !this.isPowered() )
 				{
 					GL11.glDisable( GL11.GL_LIGHTING );
-					drawRect( s.xDisplayPosition, s.yDisplayPosition, 16 + s.xDisplayPosition, 16 + s.yDisplayPosition, 0x66111111 );
+					drawRect( s.xDisplayPosition, s.yDisplayPosition, 16 + s.xDisplayPosition, 16 + s.yDisplayPosition, GuiColors.ItemSlotOverlayUnpowered.getColor() );
 					GL11.glEnable( GL11.GL_LIGHTING );
 				}
 
@@ -915,7 +916,7 @@ public abstract class AEBaseGui extends GuiContainer
 						itemRender.zLevel = 100.0F;
 
 						GL11.glDisable( GL11.GL_LIGHTING );
-						drawRect( s.xDisplayPosition, s.yDisplayPosition, 16 + s.xDisplayPosition, 16 + s.yDisplayPosition, 0x66ff6666 );
+						drawRect( s.xDisplayPosition, s.yDisplayPosition, 16 + s.xDisplayPosition, 16 + s.yDisplayPosition, GuiColors.ItemSlotOverlayInvalid.getColor() );
 						GL11.glEnable( GL11.GL_LIGHTING );
 
 						this.zLevel = 0.0F;

--- a/src/main/java/appeng/client/gui/implementations/GuiChest.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiChest.java
@@ -23,6 +23,7 @@ import appeng.client.gui.AEBaseGui;
 import appeng.client.gui.widgets.GuiTabButton;
 import appeng.container.implementations.ContainerChest;
 import appeng.core.localization.GuiText;
+import appeng.core.localization.GuiColors;
 import appeng.core.sync.GuiBridge;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketSwitchGuis;
@@ -64,8 +65,8 @@ public class GuiChest extends AEBaseGui
 	@Override
 	public void drawFG( final int offsetX, final int offsetY, final int mouseX, final int mouseY )
 	{
-		this.fontRendererObj.drawString( this.getGuiDisplayName( GuiText.Chest.getLocal() ), 8, 6, 4210752 );
-		this.fontRendererObj.drawString( GuiText.inventory.getLocal(), 8, this.ySize - 96 + 3, 4210752 );
+		this.fontRendererObj.drawString( this.getGuiDisplayName( GuiText.Chest.getLocal() ), 8, 6, GuiColors.ChestTitle.getColor() );
+		this.fontRendererObj.drawString( GuiText.inventory.getLocal(), 8, this.ySize - 96 + 3, GuiColors.ChestInventory.getColor() );
 	}
 
 	@Override

--- a/src/main/java/appeng/client/gui/implementations/GuiCondenser.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCondenser.java
@@ -26,6 +26,7 @@ import appeng.client.gui.widgets.GuiProgressBar;
 import appeng.client.gui.widgets.GuiProgressBar.Direction;
 import appeng.container.implementations.ContainerCondenser;
 import appeng.core.localization.GuiText;
+import appeng.core.localization.GuiColors;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketConfigButton;
 import appeng.tile.misc.TileCondenser;
@@ -77,8 +78,8 @@ public class GuiCondenser extends AEBaseGui
 	@Override
 	public void drawFG( final int offsetX, final int offsetY, final int mouseX, final int mouseY )
 	{
-		this.fontRendererObj.drawString( this.getGuiDisplayName( GuiText.Condenser.getLocal() ), 8, 6, 4210752 );
-		this.fontRendererObj.drawString( GuiText.inventory.getLocal(), 8, this.ySize - 96 + 3, 4210752 );
+		this.fontRendererObj.drawString( this.getGuiDisplayName( GuiText.Condenser.getLocal() ), 8, 6, GuiColors.CondenserTitle.getColor() );
+		this.fontRendererObj.drawString( GuiText.inventory.getLocal(), 8, this.ySize - 96 + 3, GuiColors.CondenserInventory.getColor() );
 
 		this.mode.set( this.cvc.getOutput() );
 		this.mode.setFillVar( String.valueOf( this.cvc.getOutput().requiredPower ) );

--- a/src/main/java/appeng/client/gui/implementations/GuiCraftAmount.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCraftAmount.java
@@ -29,6 +29,7 @@ import appeng.container.AEBaseContainer;
 import appeng.container.implementations.ContainerCraftAmount;
 import appeng.core.AEConfig;
 import appeng.core.localization.GuiText;
+import appeng.core.localization.GuiColors;
 import appeng.core.sync.GuiBridge;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketCraftRequest;
@@ -153,7 +154,7 @@ public class GuiCraftAmount extends AEBaseGui
 		this.amountToCraft = new GuiTextField( this.fontRendererObj, this.guiLeft + 62, this.guiTop + 57, 59, this.fontRendererObj.FONT_HEIGHT);
 		this.amountToCraft.setEnableBackgroundDrawing( false );
 		this.amountToCraft.setMaxStringLength( 16 );
-		this.amountToCraft.setTextColor( 0xFFFFFF );
+		this.amountToCraft.setTextColor( GuiColors.CraftAmountToCraft.getColor() );
 		this.amountToCraft.setVisible( true );
 		this.amountToCraft.setFocused( true );
 		this.amountToCraft.setText( "1" );
@@ -163,7 +164,7 @@ public class GuiCraftAmount extends AEBaseGui
 	@Override
 	public void drawFG( final int offsetX, final int offsetY, final int mouseX, final int mouseY )
 	{
-		this.fontRendererObj.drawString( GuiText.SelectAmount.getLocal(), 8, 6, 4210752 );
+		this.fontRendererObj.drawString( GuiText.SelectAmount.getLocal(), 8, 6, GuiColors.CraftAmountSelectAmount.getColor() );
 	}
 
 	@Override

--- a/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
@@ -28,6 +28,7 @@ import appeng.client.gui.widgets.GuiScrollbar;
 import appeng.container.implementations.ContainerCraftConfirm;
 import appeng.core.AELog;
 import appeng.core.localization.GuiText;
+import appeng.core.localization.GuiColors;
 import appeng.core.sync.GuiBridge;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketSwitchGuis;
@@ -346,7 +347,7 @@ public class GuiCraftConfirm extends AEBaseGui
 				{
 					final int startX = x * ( 1 + sectionLength ) + xo;
 					final int startY = posY - 4;
-					drawRect( startX, startY, startX + sectionLength, startY + offY, 0x1AFF0000 );
+					drawRect( startX, startY, startX + sectionLength, startY + offY, GuiColors.CraftConfirmMissingItem.getColor() );
 				}
 
 				x++;

--- a/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
@@ -215,7 +215,7 @@ public class GuiCraftConfirm extends AEBaseGui
 		final long BytesUsed = this.ccc.getUsedBytes();
 		final String byteUsed = NumberFormat.getInstance().format( BytesUsed );
 		final String Add = BytesUsed > 0 ? ( byteUsed + ' ' + GuiText.BytesUsed.getLocal() ) : GuiText.CalculatingWait.getLocal();
-		this.fontRendererObj.drawString( GuiText.CraftingPlan.getLocal() + " - " + Add, 8, 7, 4210752 );
+		this.fontRendererObj.drawString( GuiText.CraftingPlan.getLocal() + " - " + Add, 8, 7, GuiColors.CraftConfirmCraftingPlan.getColor() );
 
 		String dsp = null;
 
@@ -229,7 +229,7 @@ public class GuiCraftConfirm extends AEBaseGui
 		}
 
 		final int offset = ( 219 - this.fontRendererObj.getStringWidth( dsp ) ) / 2;
-		this.fontRendererObj.drawString( dsp, offset, 165, 4210752 );
+		this.fontRendererObj.drawString( dsp, offset, 165, GuiColors.CraftConfirmSimulation.getColor() );
 
 		final int sectionLength = 67;
 
@@ -282,7 +282,7 @@ public class GuiCraftConfirm extends AEBaseGui
 				{
 					String str = GuiText.FromStorage.getLocal() + ": " + converter.toWideReadableForm(stored.getStackSize());
 					final int w = 4 + this.fontRendererObj.getStringWidth( str );
-					this.fontRendererObj.drawString( str, (int) ( ( x * ( 1 + sectionLength ) + xo + sectionLength - 19 - ( w * 0.5 ) ) * 2 ), ( y * offY + yo + 6 - negY + downY ) * 2, 4210752 );
+					this.fontRendererObj.drawString( str, (int) ( ( x * ( 1 + sectionLength ) + xo + sectionLength - 19 - ( w * 0.5 ) ) * 2 ), ( y * offY + yo + 6 - negY + downY ) * 2, GuiColors.CraftConfirmFromStorage.getColor() );
 
 					if( this.tooltip == z - viewStart )
 					{
@@ -297,7 +297,7 @@ public class GuiCraftConfirm extends AEBaseGui
 				{
 					String str = GuiText.Missing.getLocal() + ": " + converter.toWideReadableForm( missingStack.getStackSize() );
 					final int w = 4 + this.fontRendererObj.getStringWidth( str );
-					this.fontRendererObj.drawString( str, (int) ( ( x * ( 1 + sectionLength ) + xo + sectionLength - 19 - ( w * 0.5 ) ) * 2 ), ( y * offY + yo + 6 - negY + downY ) * 2, 4210752 );
+					this.fontRendererObj.drawString( str, (int) ( ( x * ( 1 + sectionLength ) + xo + sectionLength - 19 - ( w * 0.5 ) ) * 2 ), ( y * offY + yo + 6 - negY + downY ) * 2, GuiColors.CraftConfirmMissing.getColor());
 
 					if( this.tooltip == z - viewStart )
 					{
@@ -312,7 +312,7 @@ public class GuiCraftConfirm extends AEBaseGui
 				{
 					String str = GuiText.ToCraft.getLocal() + ": " + converter.toWideReadableForm( pendingStack.getStackSize() );
 					final int w = 4 + this.fontRendererObj.getStringWidth( str );
-					this.fontRendererObj.drawString( str, (int) ( ( x * ( 1 + sectionLength ) + xo + sectionLength - 19 - ( w * 0.5 ) ) * 2 ), ( y * offY + yo + 6 - negY + downY ) * 2, 4210752 );
+					this.fontRendererObj.drawString( str, (int) ( ( x * ( 1 + sectionLength ) + xo + sectionLength - 19 - ( w * 0.5 ) ) * 2 ), ( y * offY + yo + 6 - negY + downY ) * 2, GuiColors.CraftConfirmToCraft.getColor() );
 
 					if( this.tooltip == z - viewStart )
 					{

--- a/src/main/java/appeng/client/gui/implementations/GuiCraftingCPU.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCraftingCPU.java
@@ -33,6 +33,7 @@ import appeng.container.implementations.ContainerCraftingCPU;
 import appeng.core.AEConfig;
 import appeng.core.AELog;
 import appeng.core.localization.GuiText;
+import appeng.core.localization.GuiColors;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketValueConfig;
 import appeng.util.Platform;
@@ -250,7 +251,7 @@ public class GuiCraftingCPU extends AEBaseGui implements ISortSource
 
 				if( AEConfig.instance.useColoredCraftingStatus && ( active || scheduled ) )
 				{
-					final int bgColor = ( active ? AEColor.Green.blackVariant : AEColor.Yellow.blackVariant ) | BACKGROUND_ALPHA;
+					final int bgColor = active ? GuiColors.CraftingCPUActive.getColor() : GuiColors.CraftingCPUScheduled.getColor();
 					final int startX = ( x * ( 1 + SECTION_LENGTH ) + ITEMSTACK_LEFT_OFFSET ) * 2;
 					final int startY = ( ( y * offY + ITEMSTACK_TOP_OFFSET ) - 3 ) * 2;
 					drawRect( startX, startY, startX + ( SECTION_LENGTH * 2 ), startY + ( offY * 2 ) - 2, bgColor );

--- a/src/main/java/appeng/client/gui/implementations/GuiCraftingCPU.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCraftingCPU.java
@@ -60,9 +60,6 @@ public class GuiCraftingCPU extends AEBaseGui implements ISortSource
 
 	private static final int DISPLAYED_ROWS = 6;
 
-	private static final int TEXT_COLOR = 0x404040;
-	private static final int BACKGROUND_ALPHA = 0x5A000000;
-
 	private static final int SECTION_LENGTH = 67;
 
 	private static final int SCROLLBAR_TOP = 19;
@@ -201,7 +198,7 @@ public class GuiCraftingCPU extends AEBaseGui implements ISortSource
 			title += " - " + etaTimeText;
 		}
 
-		this.fontRendererObj.drawString( title, TITLE_LEFT_OFFSET, TITLE_TOP_OFFSET, TEXT_COLOR );
+		this.fontRendererObj.drawString( title, TITLE_LEFT_OFFSET, TITLE_TOP_OFFSET, GuiColors.CraftingCPUTitle.getColor() );
 
 		int x = 0;
 		int y = 0;
@@ -251,7 +248,7 @@ public class GuiCraftingCPU extends AEBaseGui implements ISortSource
 
 				if( AEConfig.instance.useColoredCraftingStatus && ( active || scheduled ) )
 				{
-					final int bgColor = active ? GuiColors.CraftingCPUActive.getColor() : GuiColors.CraftingCPUScheduled.getColor();
+					final int bgColor = active ? GuiColors.CraftingCPUActive.getColor() : GuiColors.CraftingCPUInactive.getColor();
 					final int startX = ( x * ( 1 + SECTION_LENGTH ) + ITEMSTACK_LEFT_OFFSET ) * 2;
 					final int startY = ( ( y * offY + ITEMSTACK_TOP_OFFSET ) - 3 ) * 2;
 					drawRect( startX, startY, startX + ( SECTION_LENGTH * 2 ), startY + ( offY * 2 ) - 2, bgColor );
@@ -264,7 +261,7 @@ public class GuiCraftingCPU extends AEBaseGui implements ISortSource
 				{
 					final String str = GuiText.Stored.getLocal() + ": " + converter.toWideReadableForm( stored.getStackSize() );
 					final int w = 4 + this.fontRendererObj.getStringWidth( str );
-					this.fontRendererObj.drawString( str, (int) ( ( x * ( 1 + SECTION_LENGTH ) + ITEMSTACK_LEFT_OFFSET + SECTION_LENGTH - 19 - ( w * 0.5 ) ) * 2 ), ( y * offY + ITEMSTACK_TOP_OFFSET + 6 - negY + downY ) * 2, TEXT_COLOR );
+					this.fontRendererObj.drawString( str, (int) ( ( x * ( 1 + SECTION_LENGTH ) + ITEMSTACK_LEFT_OFFSET + SECTION_LENGTH - 19 - ( w * 0.5 ) ) * 2 ), ( y * offY + ITEMSTACK_TOP_OFFSET + 6 - negY + downY ) * 2, GuiColors.CraftingCPUStored.getColor() );
 
 					if( this.tooltip == z - viewStart )
 					{
@@ -279,7 +276,7 @@ public class GuiCraftingCPU extends AEBaseGui implements ISortSource
 					final String str = GuiText.Crafting.getLocal() + ": " + converter.toWideReadableForm( activeStack.getStackSize() );
 					final int w = 4 + this.fontRendererObj.getStringWidth( str );
 
-					this.fontRendererObj.drawString( str, (int) ( ( x * ( 1 + SECTION_LENGTH ) + ITEMSTACK_LEFT_OFFSET + SECTION_LENGTH - 19 - ( w * 0.5 ) ) * 2 ), ( y * offY + ITEMSTACK_TOP_OFFSET + 6 - negY + downY ) * 2, TEXT_COLOR );
+					this.fontRendererObj.drawString( str, (int) ( ( x * ( 1 + SECTION_LENGTH ) + ITEMSTACK_LEFT_OFFSET + SECTION_LENGTH - 19 - ( w * 0.5 ) ) * 2 ), ( y * offY + ITEMSTACK_TOP_OFFSET + 6 - negY + downY ) * 2, GuiColors.CraftingCPUAmount.getColor() );
 
 					if( this.tooltip == z - viewStart )
 					{
@@ -294,7 +291,7 @@ public class GuiCraftingCPU extends AEBaseGui implements ISortSource
 					final String str = GuiText.Scheduled.getLocal() + ": " + converter.toWideReadableForm( pendingStack.getStackSize() );
 					final int w = 4 + this.fontRendererObj.getStringWidth( str );
 
-					this.fontRendererObj.drawString( str, (int) ( ( x * ( 1 + SECTION_LENGTH ) + ITEMSTACK_LEFT_OFFSET + SECTION_LENGTH - 19 - ( w * 0.5 ) ) * 2 ), ( y * offY + ITEMSTACK_TOP_OFFSET + 6 - negY + downY ) * 2, TEXT_COLOR );
+					this.fontRendererObj.drawString( str, (int) ( ( x * ( 1 + SECTION_LENGTH ) + ITEMSTACK_LEFT_OFFSET + SECTION_LENGTH - 19 - ( w * 0.5 ) ) * 2 ), ( y * offY + ITEMSTACK_TOP_OFFSET + 6 - negY + downY ) * 2, GuiColors.CraftingCPUScheduled.getColor() );
 
 					if( this.tooltip == z - viewStart )
 					{

--- a/src/main/java/appeng/client/gui/implementations/GuiCraftingStatus.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCraftingStatus.java
@@ -34,6 +34,7 @@ import appeng.container.implementations.ContainerCraftingStatus;
 import appeng.container.implementations.CraftingCPUStatus;
 import appeng.core.AELog;
 import appeng.core.localization.GuiText;
+import appeng.core.localization.GuiColors;
 import appeng.core.sync.GuiBridge;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketSwitchGuis;
@@ -194,7 +195,6 @@ public class GuiCraftingStatus extends GuiCraftingCPU
         CraftingCPUStatus hoveredCpu = hitCpu( mouseX, mouseY );
         {
             FontRenderer font = Minecraft.getMinecraft().fontRenderer;
-            final int TEXT_COLOR = 0x202020;
             for( int i = firstCpu; i < firstCpu + 6; i++ )
             {
                 if( i < 0 || i >= cpus.size() )
@@ -235,7 +235,7 @@ public class GuiCraftingStatus extends GuiCraftingCPU
                 GL11.glPushMatrix();
                 GL11.glTranslatef( x + 3, y + 3, 0 );
                 GL11.glScalef( 0.8f, 0.8f, 1.0f );
-                font.drawString( name, 0, 0, TEXT_COLOR );
+                font.drawString( name, 0, 0, GuiColors.CraftingStatusCPUName.getColor() );
                 GL11.glPopMatrix();
 
                 GL11.glPushMatrix();
@@ -258,7 +258,7 @@ public class GuiCraftingStatus extends GuiCraftingCPU
                         amount = amount.substring( 0, 5 ) + "..";
                     }
                     GL11.glScalef( 1.5f, 1.5f, 1.0f );
-                    font.drawString( amount, 0, 0, 0x009000 );
+                    font.drawString( amount, 0, 0, GuiColors.CraftingStatusCPUAmount.getColor() );
                     GL11.glPopMatrix();
                     GL11.glPushMatrix();
                     GL11.glTranslatef( x + CPU_TABLE_SLOT_WIDTH - 19, y + 3, 0 );
@@ -276,7 +276,7 @@ public class GuiCraftingStatus extends GuiCraftingCPU
                     this.drawTexturedModalRect( 0, 0, uv_x * 16, uv_y * 16, 16, 16 );
                     GL11.glTranslatef( 18.0f, 2.0f, 0.0f );
                     GL11.glScalef( 1.5f, 1.5f, 1.0f );
-                    font.drawString( cpu.formatStorage(), 0, 0, TEXT_COLOR );
+                    font.drawString( cpu.formatStorage(), 0, 0, GuiColors.CraftingStatusCPUStorage.getColor() );
                 }
                 GL11.glPopMatrix();
             }

--- a/src/main/java/appeng/client/gui/implementations/GuiCraftingTerm.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCraftingTerm.java
@@ -26,6 +26,7 @@ import appeng.client.gui.widgets.GuiImgButton;
 import appeng.container.implementations.ContainerCraftingTerm;
 import appeng.container.slot.SlotCraftingMatrix;
 import appeng.core.localization.GuiText;
+import appeng.core.localization.GuiColors;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketInventoryAction;
 import appeng.helpers.InventoryAction;
@@ -83,7 +84,7 @@ public class GuiCraftingTerm extends GuiMEMonitorable
 	public void drawFG( final int offsetX, final int offsetY, final int mouseX, final int mouseY )
 	{
 		super.drawFG( offsetX, offsetY, mouseX, mouseY );
-		this.fontRendererObj.drawString( GuiText.CraftingTerminal.getLocal(), 8, this.ySize - 96 + 1 - this.getReservedSpace(), 4210752 );
+		this.fontRendererObj.drawString( GuiText.CraftingTerminal.getLocal(), 8, this.ySize - 96 + 1 - this.getReservedSpace(), GuiColors.CraftingTerminalTitle.getColor() );
 	}
 
 	@Override

--- a/src/main/java/appeng/client/gui/implementations/GuiDrive.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiDrive.java
@@ -23,6 +23,7 @@ import appeng.client.gui.AEBaseGui;
 import appeng.client.gui.widgets.GuiTabButton;
 import appeng.container.implementations.ContainerDrive;
 import appeng.core.localization.GuiText;
+import appeng.core.localization.GuiColors;
 import appeng.core.sync.GuiBridge;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketSwitchGuis;
@@ -64,8 +65,8 @@ public class GuiDrive extends AEBaseGui
 	@Override
 	public void drawFG( final int offsetX, final int offsetY, final int mouseX, final int mouseY )
 	{
-		this.fontRendererObj.drawString( this.getGuiDisplayName( GuiText.Drive.getLocal() ), 8, 6, 4210752 );
-		this.fontRendererObj.drawString( GuiText.inventory.getLocal(), 8, this.ySize - 96 + 3, 4210752 );
+		this.fontRendererObj.drawString( this.getGuiDisplayName( GuiText.Drive.getLocal() ), 8, 6, GuiColors.DriveTitle.getColor() );
+		this.fontRendererObj.drawString( GuiText.inventory.getLocal(), 8, this.ySize - 96 + 3, GuiColors.DriveInventory.getColor() );
 	}
 
 	@Override

--- a/src/main/java/appeng/client/gui/implementations/GuiFormationPlane.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiFormationPlane.java
@@ -26,6 +26,7 @@ import appeng.client.gui.widgets.GuiImgButton;
 import appeng.client.gui.widgets.GuiTabButton;
 import appeng.container.implementations.ContainerFormationPlane;
 import appeng.core.localization.GuiText;
+import appeng.core.localization.GuiColors;
 import appeng.core.sync.GuiBridge;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketConfigButton;
@@ -63,8 +64,8 @@ public class GuiFormationPlane extends GuiUpgradeable
 	@Override
 	public void drawFG( final int offsetX, final int offsetY, final int mouseX, final int mouseY )
 	{
-		this.fontRendererObj.drawString( this.getGuiDisplayName( GuiText.FormationPlane.getLocal() ), 8, 6, 4210752 );
-		this.fontRendererObj.drawString( GuiText.inventory.getLocal(), 8, this.ySize - 96 + 3, 4210752 );
+		this.fontRendererObj.drawString( this.getGuiDisplayName( GuiText.FormationPlane.getLocal() ), 8, 6, GuiColors.FormationPlaneTitle.getColor() );
+		this.fontRendererObj.drawString( GuiText.inventory.getLocal(), 8, this.ySize - 96 + 3, GuiColors.FormationPlaneInventory.getColor() );
 
 		if( this.fuzzyMode != null )
 		{

--- a/src/main/java/appeng/client/gui/implementations/GuiGrinder.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiGrinder.java
@@ -22,6 +22,7 @@ package appeng.client.gui.implementations;
 import appeng.client.gui.AEBaseGui;
 import appeng.container.implementations.ContainerGrinder;
 import appeng.core.localization.GuiText;
+import appeng.core.localization.GuiColors;
 import appeng.tile.grindstone.TileGrinder;
 import net.minecraft.entity.player.InventoryPlayer;
 
@@ -38,8 +39,8 @@ public class GuiGrinder extends AEBaseGui
 	@Override
 	public void drawFG( final int offsetX, final int offsetY, final int mouseX, final int mouseY )
 	{
-		this.fontRendererObj.drawString( this.getGuiDisplayName( GuiText.GrindStone.getLocal() ), 8, 6, 4210752 );
-		this.fontRendererObj.drawString( GuiText.inventory.getLocal(), 8, this.ySize - 96 + 3, 4210752 );
+		this.fontRendererObj.drawString( this.getGuiDisplayName( GuiText.GrindStone.getLocal() ), 8, 6, GuiColors.GrindStoneTitle.getColor() );
+		this.fontRendererObj.drawString( GuiText.inventory.getLocal(), 8, this.ySize - 96 + 3, GuiColors.GrindStoneInventory.getColor() );
 	}
 
 	@Override

--- a/src/main/java/appeng/client/gui/implementations/GuiIOPort.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiIOPort.java
@@ -28,6 +28,7 @@ import appeng.api.definitions.IDefinitions;
 import appeng.client.gui.widgets.GuiImgButton;
 import appeng.container.implementations.ContainerIOPort;
 import appeng.core.localization.GuiText;
+import appeng.core.localization.GuiColors;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketConfigButton;
 import appeng.tile.storage.TileIOPort;
@@ -64,8 +65,8 @@ public class GuiIOPort extends GuiUpgradeable
 	@Override
 	public void drawFG( final int offsetX, final int offsetY, final int mouseX, final int mouseY )
 	{
-		this.fontRendererObj.drawString( this.getGuiDisplayName( GuiText.IOPort.getLocal() ), 8, 6, 4210752 );
-		this.fontRendererObj.drawString( GuiText.inventory.getLocal(), 8, this.ySize - 96 + 3, 4210752 );
+		this.fontRendererObj.drawString( this.getGuiDisplayName( GuiText.IOPort.getLocal() ), 8, 6, GuiColors.IOPortTitle.getColor() );
+		this.fontRendererObj.drawString( GuiText.inventory.getLocal(), 8, this.ySize - 96 + 3, GuiColors.IOPortInventory.getColor() );
 
 		if( this.redstoneMode != null )
 		{

--- a/src/main/java/appeng/client/gui/implementations/GuiInscriber.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiInscriber.java
@@ -25,6 +25,7 @@ import appeng.client.gui.widgets.GuiProgressBar.Direction;
 import appeng.container.implementations.ContainerInscriber;
 import appeng.container.implementations.ContainerUpgradeable;
 import appeng.core.localization.GuiText;
+import appeng.core.localization.GuiColors;
 import appeng.tile.misc.TileInscriber;
 import net.minecraft.entity.player.InventoryPlayer;
 
@@ -62,8 +63,8 @@ public class GuiInscriber extends AEBaseGui
 	{
 		this.pb.setFullMsg( this.cvc.getCurrentProgress() * 100 / this.cvc.getMaxProgress() + "%" );
 
-		this.fontRendererObj.drawString( this.getGuiDisplayName( GuiText.Inscriber.getLocal() ), 8, 6, 4210752 );
-		this.fontRendererObj.drawString( GuiText.inventory.getLocal(), 8, this.ySize - 96 + 3, 4210752 );
+		this.fontRendererObj.drawString( this.getGuiDisplayName( GuiText.Inscriber.getLocal() ), 8, 6, GuiColors.InscriberTitle.getColor() );
+		this.fontRendererObj.drawString( GuiText.inventory.getLocal(), 8, this.ySize - 96 + 3, GuiColors.InscriberInventory.getColor() );
 	}
 
 	@Override

--- a/src/main/java/appeng/client/gui/implementations/GuiInterface.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiInterface.java
@@ -27,6 +27,7 @@ import appeng.client.gui.widgets.GuiTabButton;
 import appeng.client.gui.widgets.GuiToggleButton;
 import appeng.container.implementations.ContainerInterface;
 import appeng.core.localization.GuiText;
+import appeng.core.localization.GuiColors;
 import appeng.core.sync.GuiBridge;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketConfigButton;
@@ -85,7 +86,7 @@ public class GuiInterface extends GuiUpgradeable
 			this.insertionMode.set( ( (ContainerInterface) this.cvb ).getInsertionMode());
 		}
 
-		this.fontRendererObj.drawString( this.getGuiDisplayName( GuiText.Interface.getLocal() ), 8, 6, 4210752 );
+		this.fontRendererObj.drawString( this.getGuiDisplayName( GuiText.Interface.getLocal() ), 8, 6, GuiColors.InterfaceTitle.getColor() );
 	}
 
 	@Override

--- a/src/main/java/appeng/client/gui/implementations/GuiInterfaceTerminal.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiInterfaceTerminal.java
@@ -202,8 +202,8 @@ public class GuiInterfaceTerminal extends AEBaseGui implements IDropToFillTextFi
 	@Override
 	public void drawFG( final int offsetX, final int offsetY, final int mouseX, final int mouseY )
 	{
-		fontRendererObj.drawString( getGuiDisplayName( GuiText.InterfaceTerminal.getLocal() ), 8, 6, 4210752 );
-		fontRendererObj.drawString( GuiText.inventory.getLocal(), GuiInterfaceTerminal.offsetX + 2, this.ySize - 96, 4210752 );
+		fontRendererObj.drawString( getGuiDisplayName( GuiText.InterfaceTerminal.getLocal() ), 8, 6, GuiColors.InterfaceTerminalTitle.getColor() );
+		fontRendererObj.drawString( GuiText.inventory.getLocal(), GuiInterfaceTerminal.offsetX + 2, this.ySize - 96, GuiColors.InterfaceTerminalInventory.getColor() );
 
 		int offset = 51;
 		final int ex = getScrollBar().getCurrentScroll();
@@ -235,7 +235,7 @@ public class GuiInterfaceTerminal extends AEBaseGui implements IDropToFillTextFi
 					name = name.substring( 0, name.length() - 1 );
 				}
 
-				this.fontRendererObj.drawString( name + postfix, GuiInterfaceTerminal.offsetX + 3, 6 + offset, 4210752 );
+				this.fontRendererObj.drawString( name + postfix, GuiInterfaceTerminal.offsetX + 3, 6 + offset, GuiColors.InterfaceTerminalName.getColor() );
 			}
 
 			offset += 18;

--- a/src/main/java/appeng/client/gui/implementations/GuiInterfaceTerminal.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiInterfaceTerminal.java
@@ -39,6 +39,7 @@ import appeng.core.AEConfig;
 import appeng.core.CommonHelper;
 import appeng.core.localization.ButtonToolTips;
 import appeng.core.localization.GuiText;
+import appeng.core.localization.GuiColors;
 import appeng.core.localization.PlayerMessages;
 import appeng.helpers.PatternHelper;
 import appeng.integration.IntegrationRegistry;
@@ -215,7 +216,7 @@ public class GuiInterfaceTerminal extends AEBaseGui implements IDropToFillTextFi
 				for( int z = 0; z < inv.getInventory().getSizeInventory(); z++ )
 				{
 					if (this.matchedStacks.contains(inv.getInventory().getStackInSlot(z)))
-						drawRect( z * 18 + 22, 1 + offset, z * 18 + 22 + 16, 1 + offset + 16, 0x2A00FF00 );
+						drawRect( z * 18 + 22, 1 + offset, z * 18 + 22 + 16, 1 + offset + 16, GuiColors.InterfaceTerminalMatch.getColor() );
 				}
 			}
 			else if( lineObj instanceof String )

--- a/src/main/java/appeng/client/gui/implementations/GuiLevelEmitter.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiLevelEmitter.java
@@ -26,6 +26,7 @@ import appeng.container.implementations.ContainerLevelEmitter;
 import appeng.core.AEConfig;
 import appeng.core.AELog;
 import appeng.core.localization.GuiText;
+import appeng.core.localization.GuiColors;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketConfigButton;
 import appeng.core.sync.packets.PacketValueConfig;
@@ -67,7 +68,7 @@ public class GuiLevelEmitter extends GuiUpgradeable
 		this.level = new GuiNumberBox( this.fontRendererObj, this.guiLeft + 24, this.guiTop + 43, 79, this.fontRendererObj.FONT_HEIGHT, Long.class );
 		this.level.setEnableBackgroundDrawing( false );
 		this.level.setMaxStringLength( 16 );
-		this.level.setTextColor( 0xFFFFFF );
+		this.level.setTextColor( GuiColors.LevelEmitterValue.getColor() );
 		this.level.setVisible( true );
 		this.level.setFocused( true );
 		( (ContainerLevelEmitter) this.inventorySlots ).setTextField( this.level );

--- a/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
@@ -41,6 +41,7 @@ import appeng.core.AELog;
 import appeng.core.CommonHelper;
 import appeng.core.localization.ButtonToolTips;
 import appeng.core.localization.GuiText;
+import appeng.core.localization.GuiColors;
 import appeng.core.sync.GuiBridge;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketSwitchGuis;
@@ -379,8 +380,8 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
 	@Override
 	public void drawFG( final int offsetX, final int offsetY, final int mouseX, final int mouseY )
 	{
-		this.fontRendererObj.drawString( this.getGuiDisplayName( this.myName.getLocal() ), 8, 6, 4210752 );
-		this.fontRendererObj.drawString( GuiText.inventory.getLocal(), 8, this.ySize - 96 + 3, 4210752 );
+		this.fontRendererObj.drawString( this.getGuiDisplayName( this.myName.getLocal() ), 8, 6, GuiColors.MEMonitorableTitle.getColor() );
+		this.fontRendererObj.drawString( GuiText.inventory.getLocal(), 8, this.ySize - 96 + 3, GuiColors.MEMonitorableInventory.getColor() );
 
 		this.currentMouseX = mouseX;
 		this.currentMouseY = mouseY;

--- a/src/main/java/appeng/client/gui/implementations/GuiNetworkStatus.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiNetworkStatus.java
@@ -34,6 +34,7 @@ import appeng.client.me.SlotME;
 import appeng.container.implementations.ContainerNetworkStatus;
 import appeng.core.AEConfig;
 import appeng.core.localization.GuiText;
+import appeng.core.localization.GuiColors;
 import appeng.util.Platform;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.entity.player.InventoryPlayer;
@@ -130,13 +131,13 @@ public class GuiNetworkStatus extends AEBaseGui implements ISortSource
 	{
 		final ContainerNetworkStatus ns = (ContainerNetworkStatus) this.inventorySlots;
 
-		this.fontRendererObj.drawString( GuiText.NetworkDetails.getLocal(), 8, 6, 4210752 );
+		this.fontRendererObj.drawString( GuiText.NetworkDetails.getLocal(), 8, 6, GuiColors.NetworkStatusDetails.getColor() );
 
-		this.fontRendererObj.drawString( GuiText.StoredPower.getLocal() + ": " + Platform.formatPowerLong( ns.getCurrentPower(), false ), 13, 16, 4210752 );
-		this.fontRendererObj.drawString( GuiText.MaxPower.getLocal() + ": " + Platform.formatPowerLong( ns.getMaxPower(), false ), 13, 26, 4210752 );
+		this.fontRendererObj.drawString( GuiText.StoredPower.getLocal() + ": " + Platform.formatPowerLong( ns.getCurrentPower(), false ), 13, 16, GuiColors.NetworkStatusStoredPower.getColor() );
+		this.fontRendererObj.drawString( GuiText.MaxPower.getLocal() + ": " + Platform.formatPowerLong( ns.getMaxPower(), false ), 13, 26, GuiColors.NetworkStatusMaxPower.getColor() );
 
-		this.fontRendererObj.drawString( GuiText.PowerInputRate.getLocal() + ": " + Platform.formatPowerLong( ns.getAverageAddition(), true ), 13, 143 - 10, 4210752 );
-		this.fontRendererObj.drawString( GuiText.PowerUsageRate.getLocal() + ": " + Platform.formatPowerLong( ns.getPowerUsage(), true ), 13, 143 - 20, 4210752 );
+		this.fontRendererObj.drawString( GuiText.PowerInputRate.getLocal() + ": " + Platform.formatPowerLong( ns.getAverageAddition(), true ), 13, 143 - 10, GuiColors.NetworkStatusPowerInputRate.getColor() );
+		this.fontRendererObj.drawString( GuiText.PowerUsageRate.getLocal() + ": " + Platform.formatPowerLong( ns.getPowerUsage(), true ), 13, 143 - 20, GuiColors.NetworkStatusPowerUsageRate.getColor() );
 
 		final int sectionLength = 30;
 
@@ -166,7 +167,7 @@ public class GuiNetworkStatus extends AEBaseGui implements ISortSource
 				}
 
 				final int w = this.fontRendererObj.getStringWidth( str );
-				this.fontRendererObj.drawString( str, (int) ( ( x * sectionLength + xo + sectionLength - 19 - ( w * 0.5 ) ) * 2 ), ( y * 18 + yo + 6 ) * 2, 4210752 );
+				this.fontRendererObj.drawString( str, (int) ( ( x * sectionLength + xo + sectionLength - 19 - ( w * 0.5 ) ) * 2 ), ( y * 18 + yo + 6 ) * 2, GuiColors.NetworkStatusItemCount.getColor() );
 
 				GL11.glPopMatrix();
 				final int posX = x * sectionLength + xo + sectionLength - 18;

--- a/src/main/java/appeng/client/gui/implementations/GuiNetworkTool.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiNetworkTool.java
@@ -25,6 +25,7 @@ import appeng.client.gui.widgets.GuiToggleButton;
 import appeng.container.implementations.ContainerNetworkTool;
 import appeng.core.AELog;
 import appeng.core.localization.GuiText;
+import appeng.core.localization.GuiColors;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketValueConfig;
 import net.minecraft.client.gui.GuiButton;
@@ -80,8 +81,8 @@ public class GuiNetworkTool extends AEBaseGui
 			this.tFacades.setState( ( (ContainerNetworkTool) this.inventorySlots ).isFacadeMode() );
 		}
 
-		this.fontRendererObj.drawString( this.getGuiDisplayName( GuiText.NetworkTool.getLocal() ), 8, 6, 4210752 );
-		this.fontRendererObj.drawString( GuiText.inventory.getLocal(), 8, this.ySize - 96 + 3, 4210752 );
+		this.fontRendererObj.drawString( this.getGuiDisplayName( GuiText.NetworkTool.getLocal() ), 8, 6, GuiColors.NetworkToolTitle.getColor() );
+		this.fontRendererObj.drawString( GuiText.inventory.getLocal(), 8, this.ySize - 96 + 3, GuiColors.NetworkToolInventory.getColor() );
 	}
 
 	@Override

--- a/src/main/java/appeng/client/gui/implementations/GuiOreFilter.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiOreFilter.java
@@ -7,6 +7,7 @@ import appeng.container.AEBaseContainer;
 import appeng.container.implementations.ContainerOreFilter;
 import appeng.core.AELog;
 import appeng.core.localization.GuiText;
+import appeng.core.localization.GuiColors;
 import appeng.core.sync.GuiBridge;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketSwitchGuis;
@@ -63,7 +64,7 @@ public class GuiOreFilter extends AEBaseGui implements IDropToFillTextField
     @Override
     public void drawFG(int offsetX, int offsetY, int mouseX, int mouseY)
     {
-        this.fontRendererObj.drawString( GuiText.OreFilterLabel.getLocal(), 12, 8, 4210752 );
+        this.fontRendererObj.drawString( GuiText.OreFilterLabel.getLocal(), 12, 8, GuiColors.OreFilterLabel.getColor() );
     }
 
     @Override

--- a/src/main/java/appeng/client/gui/implementations/GuiPatternTerm.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiPatternTerm.java
@@ -28,6 +28,7 @@ import appeng.client.gui.widgets.GuiTabButton;
 import appeng.container.implementations.ContainerPatternTerm;
 import appeng.container.slot.AppEngSlot;
 import appeng.core.localization.GuiText;
+import appeng.core.localization.GuiColors;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketValueConfig;
 import net.minecraft.client.gui.GuiButton;
@@ -159,7 +160,7 @@ public class GuiPatternTerm extends GuiMEMonitorable
 		}
 
 		super.drawFG( offsetX, offsetY, mouseX, mouseY );
-		this.fontRendererObj.drawString( GuiText.PatternTerminal.getLocal(), 8, this.ySize - 96 + 2 - this.getReservedSpace(), 4210752 );
+		this.fontRendererObj.drawString( GuiText.PatternTerminal.getLocal(), 8, this.ySize - 96 + 2 - this.getReservedSpace(), GuiColors.PatternTerminalTitle.getColor() );
 	}
 
 	@Override

--- a/src/main/java/appeng/client/gui/implementations/GuiPatternTermEx.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiPatternTermEx.java
@@ -11,6 +11,7 @@ import appeng.container.implementations.ContainerPatternTermEx;
 import appeng.container.slot.AppEngSlot;
 import appeng.core.AppEng;
 import appeng.core.localization.GuiText;
+import appeng.core.localization.GuiColors;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketValueConfig;
 import net.minecraft.client.gui.GuiButton;
@@ -115,7 +116,7 @@ public class GuiPatternTermEx extends GuiMEMonitorable
     public void drawFG( final int offsetX, final int offsetY, final int mouseX, final int mouseY )
     {
         super.drawFG( offsetX, offsetY, mouseX, mouseY );
-        this.fontRendererObj.drawString( GuiText.PatternTerminalEx.getLocal(), 8, this.ySize - 96 + 2 - this.getReservedSpace(), 4210752 );
+        this.fontRendererObj.drawString( GuiText.PatternTerminalEx.getLocal(), 8, this.ySize - 96 + 2 - this.getReservedSpace(), GuiColors.PatternTerminalEx.getColor() );
         this.processingScrollBar.draw(this);
     }
 

--- a/src/main/java/appeng/client/gui/implementations/GuiPriority.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiPriority.java
@@ -31,6 +31,7 @@ import appeng.container.implementations.ContainerPriority;
 import appeng.core.AEConfig;
 import appeng.core.AELog;
 import appeng.core.localization.GuiText;
+import appeng.core.localization.GuiColors;
 import appeng.core.sync.GuiBridge;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketSwitchGuis;
@@ -162,7 +163,7 @@ public class GuiPriority extends AEBaseGui
 		this.priority = new GuiNumberBox( this.fontRendererObj, this.guiLeft + 62, this.guiTop + 57, 59, this.fontRendererObj.FONT_HEIGHT, Long.class );
 		this.priority.setEnableBackgroundDrawing( false );
 		this.priority.setMaxStringLength( 16 );
-		this.priority.setTextColor( 0xFFFFFF );
+		this.priority.setTextColor( GuiColors.PriorityValue.getColor() );
 		this.priority.setVisible( true );
 		this.priority.setFocused( true );
 		( (ContainerPriority) this.inventorySlots ).setTextField( this.priority );
@@ -171,7 +172,7 @@ public class GuiPriority extends AEBaseGui
 	@Override
 	public void drawFG( final int offsetX, final int offsetY, final int mouseX, final int mouseY )
 	{
-		this.fontRendererObj.drawString( GuiText.Priority.getLocal(), 8, 6, 4210752 );
+		this.fontRendererObj.drawString( GuiText.Priority.getLocal(), 8, 6, GuiColors.PriorityTitle.getColor() );
 	}
 
 	@Override

--- a/src/main/java/appeng/client/gui/implementations/GuiQNB.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiQNB.java
@@ -22,6 +22,7 @@ package appeng.client.gui.implementations;
 import appeng.client.gui.AEBaseGui;
 import appeng.container.implementations.ContainerQNB;
 import appeng.core.localization.GuiText;
+import appeng.core.localization.GuiColors;
 import appeng.tile.qnb.TileQuantumBridge;
 import net.minecraft.entity.player.InventoryPlayer;
 
@@ -38,8 +39,8 @@ public class GuiQNB extends AEBaseGui
 	@Override
 	public void drawFG( final int offsetX, final int offsetY, final int mouseX, final int mouseY )
 	{
-		this.fontRendererObj.drawString( this.getGuiDisplayName( GuiText.QuantumLinkChamber.getLocal() ), 8, 6, 4210752 );
-		this.fontRendererObj.drawString( GuiText.inventory.getLocal(), 8, this.ySize - 96 + 3, 4210752 );
+		this.fontRendererObj.drawString( this.getGuiDisplayName( GuiText.QuantumLinkChamber.getLocal() ), 8, 6, GuiColors.QuantumLinkChamberTitle.getColor() );
+		this.fontRendererObj.drawString( GuiText.inventory.getLocal(), 8, this.ySize - 96 + 3, GuiColors.QuantumLinkChamberInventory.getColor() );
 	}
 
 	@Override

--- a/src/main/java/appeng/client/gui/implementations/GuiQuartzKnife.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiQuartzKnife.java
@@ -25,6 +25,7 @@ import appeng.client.gui.widgets.MEGuiTextField;
 import appeng.container.implementations.ContainerQuartzKnife;
 import appeng.core.AELog;
 import appeng.core.localization.GuiText;
+import appeng.core.localization.GuiColors;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketValueConfig;
 import appeng.items.contents.QuartzKnifeObj;
@@ -76,8 +77,8 @@ public class GuiQuartzKnife extends AEBaseGui implements IDropToFillTextField
 	@Override
 	public void drawFG( final int offsetX, final int offsetY, final int mouseX, final int mouseY )
 	{
-		this.fontRendererObj.drawString( this.getGuiDisplayName( GuiText.QuartzCuttingKnife.getLocal() ), 8, 6, 4210752 );
-		this.fontRendererObj.drawString( GuiText.inventory.getLocal(), 8, this.ySize - 96 + 3, 4210752 );
+		this.fontRendererObj.drawString( this.getGuiDisplayName( GuiText.QuartzCuttingKnife.getLocal() ), 8, 6, GuiColors.QuartzCuttingKnifeTitle.getColor() );
+		this.fontRendererObj.drawString( GuiText.inventory.getLocal(), 8, this.ySize - 96 + 3, GuiColors.QuartzCuttingKnifeInventory.getColor() );
 	}
 
 	@Override

--- a/src/main/java/appeng/client/gui/implementations/GuiRenamer.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiRenamer.java
@@ -6,6 +6,7 @@ import appeng.client.gui.widgets.MEGuiTextField;
 import appeng.container.implementations.ContainerRenamer;
 import appeng.core.AELog;
 import appeng.core.localization.GuiText;
+import appeng.core.localization.GuiColors;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketValueConfig;
 import appeng.helpers.ICustomNameObject;
@@ -55,7 +56,7 @@ public class GuiRenamer extends AEBaseGui implements IDropToFillTextField
     @Override
     public void drawFG(int offsetX, int offsetY, int mouseX, int mouseY)
     {
-        this.fontRendererObj.drawString( GuiText.Renamer.getLocal(), 12, 8, 4210752 );
+        this.fontRendererObj.drawString( GuiText.Renamer.getLocal(), 12, 8, GuiColors.RenamerTitle.getColor() );
     }
 
     @Override

--- a/src/main/java/appeng/client/gui/implementations/GuiSecurity.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiSecurity.java
@@ -26,6 +26,7 @@ import appeng.client.gui.widgets.GuiToggleButton;
 import appeng.container.implementations.ContainerSecurity;
 import appeng.core.AELog;
 import appeng.core.localization.GuiText;
+import appeng.core.localization.GuiColors;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketValueConfig;
 import net.minecraft.entity.player.InventoryPlayer;
@@ -115,7 +116,7 @@ public class GuiSecurity extends GuiMEMonitorable
 	public void drawFG( final int offsetX, final int offsetY, final int mouseX, final int mouseY )
 	{
 		super.drawFG( offsetX, offsetY, mouseX, mouseY );
-		this.fontRendererObj.drawString( GuiText.SecurityCardEditor.getLocal(), 8, this.ySize - 96 + 1 - this.getReservedSpace(), 4210752 );
+		this.fontRendererObj.drawString( GuiText.SecurityCardEditor.getLocal(), 8, this.ySize - 96 + 1 - this.getReservedSpace(), GuiColors.SecurityCardEditorTitle.getColor() );
 	}
 
 	@Override

--- a/src/main/java/appeng/client/gui/implementations/GuiSkyChest.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiSkyChest.java
@@ -22,6 +22,7 @@ package appeng.client.gui.implementations;
 import appeng.client.gui.AEBaseGui;
 import appeng.container.implementations.ContainerSkyChest;
 import appeng.core.localization.GuiText;
+import appeng.core.localization.GuiColors;
 import appeng.integration.IntegrationRegistry;
 import appeng.integration.IntegrationType;
 import appeng.tile.storage.TileSkyChest;
@@ -40,8 +41,8 @@ public class GuiSkyChest extends AEBaseGui
 	@Override
 	public void drawFG( final int offsetX, final int offsetY, final int mouseX, final int mouseY )
 	{
-		this.fontRendererObj.drawString( this.getGuiDisplayName( GuiText.SkyChest.getLocal() ), 8, 8, 4210752 );
-		this.fontRendererObj.drawString( GuiText.inventory.getLocal(), 8, this.ySize - 96 + 2, 4210752 );
+		this.fontRendererObj.drawString( this.getGuiDisplayName( GuiText.SkyChest.getLocal() ), 8, 8, GuiColors.SkyChestTitle.getColor() );
+		this.fontRendererObj.drawString( GuiText.inventory.getLocal(), 8, this.ySize - 96 + 2, GuiColors.SkyChestInventory.getColor() );
 	}
 
 	@Override

--- a/src/main/java/appeng/client/gui/implementations/GuiSpatialIOPort.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiSpatialIOPort.java
@@ -25,6 +25,7 @@ import appeng.client.gui.widgets.GuiImgButton;
 import appeng.container.implementations.ContainerSpatialIOPort;
 import appeng.core.AEConfig;
 import appeng.core.localization.GuiText;
+import appeng.core.localization.GuiColors;
 import appeng.tile.spatial.TileSpatialIOPort;
 import appeng.util.Platform;
 import net.minecraft.client.gui.GuiButton;
@@ -71,13 +72,13 @@ public class GuiSpatialIOPort extends AEBaseGui
 	@Override
 	public void drawFG( final int offsetX, final int offsetY, final int mouseX, final int mouseY )
 	{
-		this.fontRendererObj.drawString( GuiText.StoredPower.getLocal() + ": " + Platform.formatPowerLong( this.container.getCurrentPower(), false ), 13, 21, 4210752 );
-		this.fontRendererObj.drawString( GuiText.MaxPower.getLocal() + ": " + Platform.formatPowerLong( this.container.getMaxPower(), false ), 13, 31, 4210752 );
-		this.fontRendererObj.drawString( GuiText.RequiredPower.getLocal() + ": " + Platform.formatPowerLong( this.container.getRequiredPower(), false ), 13, 78, 4210752 );
-		this.fontRendererObj.drawString( GuiText.Efficiency.getLocal() + ": " + ( ( (float) this.container.getEfficency() ) / 100 ) + '%', 13, 88, 4210752 );
+		this.fontRendererObj.drawString( GuiText.StoredPower.getLocal() + ": " + Platform.formatPowerLong( this.container.getCurrentPower(), false ), 13, 21, GuiColors.SpatialIOStoredPower.getColor() );
+		this.fontRendererObj.drawString( GuiText.MaxPower.getLocal() + ": " + Platform.formatPowerLong( this.container.getMaxPower(), false ), 13, 31, GuiColors.SpatialIOMaxPower.getColor() );
+		this.fontRendererObj.drawString( GuiText.RequiredPower.getLocal() + ": " + Platform.formatPowerLong( this.container.getRequiredPower(), false ), 13, 78, GuiColors.SpatialIORequiredPower.getColor() );
+		this.fontRendererObj.drawString( GuiText.Efficiency.getLocal() + ": " + ( ( (float) this.container.getEfficency() ) / 100 ) + '%', 13, 88, GuiColors.SpatialIOEfficiency.getColor() );
 
-		this.fontRendererObj.drawString( this.getGuiDisplayName( GuiText.SpatialIOPort.getLocal() ), 8, 6, 4210752 );
-		this.fontRendererObj.drawString( GuiText.inventory.getLocal(), 8, this.ySize - 96, 4210752 );
+		this.fontRendererObj.drawString( this.getGuiDisplayName( GuiText.SpatialIOPort.getLocal() ), 8, 6, GuiColors.SpatialIOTitle.getColor() );
+		this.fontRendererObj.drawString( GuiText.inventory.getLocal(), 8, this.ySize - 96, GuiColors.SpatialIOInventory.getColor() );
 	}
 
 	@Override

--- a/src/main/java/appeng/client/gui/implementations/GuiStorageBus.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiStorageBus.java
@@ -25,6 +25,7 @@ import appeng.client.gui.widgets.GuiTabButton;
 import appeng.container.implementations.ContainerStorageBus;
 import appeng.core.AELog;
 import appeng.core.localization.GuiText;
+import appeng.core.localization.GuiColors;
 import appeng.core.sync.GuiBridge;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketConfigButton;
@@ -76,8 +77,8 @@ public class GuiStorageBus extends GuiUpgradeable
 	@Override
 	public void drawFG( final int offsetX, final int offsetY, final int mouseX, final int mouseY )
 	{
-		this.fontRendererObj.drawString( this.getGuiDisplayName( GuiText.StorageBus.getLocal() ), 8, 6, 4210752 );
-		this.fontRendererObj.drawString( GuiText.inventory.getLocal(), 8, this.ySize - 96 + 3, 4210752 );
+		this.fontRendererObj.drawString( this.getGuiDisplayName( GuiText.StorageBus.getLocal() ), 8, 6, GuiColors.StorageBusTitle.getColor() );
+		this.fontRendererObj.drawString( GuiText.inventory.getLocal(), 8, this.ySize - 96 + 3, GuiColors.StorageBusInventory.getColor() );
 
 		if( this.fuzzyMode != null )
 		{

--- a/src/main/java/appeng/client/gui/implementations/GuiUpgradeable.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiUpgradeable.java
@@ -25,6 +25,7 @@ import appeng.client.gui.AEBaseGui;
 import appeng.client.gui.widgets.GuiImgButton;
 import appeng.container.implementations.ContainerUpgradeable;
 import appeng.core.localization.GuiText;
+import appeng.core.localization.GuiColors;
 import appeng.core.sync.GuiBridge;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketConfigButton;
@@ -93,8 +94,8 @@ public class GuiUpgradeable extends AEBaseGui
 	@Override
 	public void drawFG( final int offsetX, final int offsetY, final int mouseX, final int mouseY )
 	{
-		this.fontRendererObj.drawString( this.getGuiDisplayName( this.getName().getLocal() ), 8, 6, 4210752 );
-		this.fontRendererObj.drawString( GuiText.inventory.getLocal(), 8, this.ySize - 96 + 3, 4210752 );
+		this.fontRendererObj.drawString( this.getGuiDisplayName( this.getName().getLocal() ), 8, 6, GuiColors.UpgradableTitle.getColor() );
+		this.fontRendererObj.drawString( GuiText.inventory.getLocal(), 8, this.ySize - 96 + 3, GuiColors.UpgradableInventory.getColor() );
 
 		if( this.redstoneMode != null )
 		{

--- a/src/main/java/appeng/client/gui/implementations/GuiVibrationChamber.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiVibrationChamber.java
@@ -24,6 +24,7 @@ import appeng.client.gui.widgets.GuiProgressBar;
 import appeng.client.gui.widgets.GuiProgressBar.Direction;
 import appeng.container.implementations.ContainerVibrationChamber;
 import appeng.core.localization.GuiText;
+import appeng.core.localization.GuiColors;
 import appeng.tile.misc.TileVibrationChamber;
 import net.minecraft.entity.player.InventoryPlayer;
 import org.lwjgl.opengl.GL11;
@@ -54,8 +55,8 @@ public class GuiVibrationChamber extends AEBaseGui
 	@Override
 	public void drawFG( final int offsetX, final int offsetY, final int mouseX, final int mouseY )
 	{
-		this.fontRendererObj.drawString( this.getGuiDisplayName( GuiText.VibrationChamber.getLocal() ), 8, 6, 4210752 );
-		this.fontRendererObj.drawString( GuiText.inventory.getLocal(), 8, this.ySize - 96 + 3, 4210752 );
+		this.fontRendererObj.drawString( this.getGuiDisplayName( GuiText.VibrationChamber.getLocal() ), 8, 6, GuiColors.VibrationChamberTitle.getColor() );
+		this.fontRendererObj.drawString( GuiText.inventory.getLocal(), 8, this.ySize - 96 + 3, GuiColors.VibrationChamberInventory.getColor() );
 
 		this.pb.setFullMsg( this.cvc.getAePerTick() * this.cvc.getCurrentProgress() / 100 + " AE/t" );
 

--- a/src/main/java/appeng/client/gui/implementations/GuiWireless.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiWireless.java
@@ -25,6 +25,7 @@ import appeng.client.gui.widgets.GuiImgButton;
 import appeng.container.implementations.ContainerWireless;
 import appeng.core.AEConfig;
 import appeng.core.localization.GuiText;
+import appeng.core.localization.GuiColors;
 import appeng.tile.networking.TileWireless;
 import appeng.util.Platform;
 import net.minecraft.client.gui.GuiButton;
@@ -69,8 +70,8 @@ public class GuiWireless extends AEBaseGui
 	@Override
 	public void drawFG( final int offsetX, final int offsetY, final int mouseX, final int mouseY )
 	{
-		this.fontRendererObj.drawString( this.getGuiDisplayName( GuiText.Wireless.getLocal() ), 8, 6, 4210752 );
-		this.fontRendererObj.drawString( GuiText.inventory.getLocal(), 8, this.ySize - 96 + 3, 4210752 );
+		this.fontRendererObj.drawString( this.getGuiDisplayName( GuiText.Wireless.getLocal() ), 8, 6, GuiColors.WirelessTitle.getColor() );
+		this.fontRendererObj.drawString( GuiText.inventory.getLocal(), 8, this.ySize - 96 + 3, GuiColors.WirelessInventory.getColor() );
 
 		final ContainerWireless cw = (ContainerWireless) this.inventorySlots;
 
@@ -81,8 +82,8 @@ public class GuiWireless extends AEBaseGui
 
 			final int strWidth = Math.max( this.fontRendererObj.getStringWidth( firstMessage ), this.fontRendererObj.getStringWidth( secondMessage ) );
 			final int cOffset = ( this.xSize / 2 ) - ( strWidth / 2 );
-			this.fontRendererObj.drawString( firstMessage, cOffset, 20, 4210752 );
-			this.fontRendererObj.drawString( secondMessage, cOffset, 20 + 12, 4210752 );
+			this.fontRendererObj.drawString( firstMessage, cOffset, 20, GuiColors.WirelessRange.getColor() );
+			this.fontRendererObj.drawString( secondMessage, cOffset, 20 + 12, GuiColors.WirelessPowerUsageRate.getColor() );
 		}
 	}
 

--- a/src/main/java/appeng/client/gui/widgets/MEGuiTextField.java
+++ b/src/main/java/appeng/client/gui/widgets/MEGuiTextField.java
@@ -21,11 +21,10 @@ package appeng.client.gui.widgets;
 
 import org.lwjgl.input.Keyboard;
 
-import appeng.core.localization.GuiColors;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiTextField;
-
+import appeng.core.localization.GuiColors;
 
 /**
  * A modified version of the Minecraft text field.
@@ -69,7 +68,7 @@ public class MEGuiTextField implements ITooltip
 
 		field.setEnableBackgroundDrawing( false );
 		field.setMaxStringLength( MAX_INPUT_LENGTH );
-		field.setTextColor( 0xFFFFFF );
+		field.setTextColor( GuiColors.SearchboxText.getColor() );
         field.setCursorPositionZero();
 
 		setMessage(tooltip);

--- a/src/main/java/appeng/client/gui/widgets/MEGuiTextField.java
+++ b/src/main/java/appeng/client/gui/widgets/MEGuiTextField.java
@@ -21,6 +21,7 @@ package appeng.client.gui.widgets;
 
 import org.lwjgl.input.Keyboard;
 
+import appeng.core.localization.GuiColors;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiTextField;
@@ -160,7 +161,7 @@ public class MEGuiTextField implements ITooltip
 	{
 		if (field.getVisible()) {
 			setDimensionsAndColor();
-			GuiTextField.drawRect(this.x + 1, this.y + 1, this.x + this.w - 1, this.y + this.h - 1, isFocused() ? 0xFF606060 : 0xFFA8A8A8);
+			GuiTextField.drawRect(this.x + 1, this.y + 1, this.x + this.w - 1, this.y + this.h - 1, isFocused() ? GuiColors.SearchboxFocused.getColor() : GuiColors.SearchboxUnfocused.getColor());
 			field.drawTextBox();
 		}
 	}

--- a/src/main/java/appeng/core/localization/GuiColors.java
+++ b/src/main/java/appeng/core/localization/GuiColors.java
@@ -26,16 +26,126 @@ public enum GuiColors
 	//ARGB Colors: Name and default value
 	SearchboxFocused			(0x6E000000),
 	SearchboxUnfocused			(0x00000000),
+
 	ItemSlotOverlayUnpowered	(0x66111111),
 	ItemSlotOverlayInvalid		(0x66ff6666),
+
 	CraftConfirmMissingItem		(0x1AFF0000),
+
 	CraftingCPUActive			(0x5A45A021),
-	CraftingCPUScheduled		(0x5AFFF7AA),
+	CraftingCPUInactive			(0x5AFFF7AA),
+
 	InterfaceTerminalMatch		(0x2A00FF00),
 	
 	//RGB Colors: Name and default value
-	SearchboxFont			(0xFFFFFF),
-	CraftingOverviewFont	(0x606060),
+	SearchboxText				(0xFFFFFF),
+
+	CraftingCPUTitle			(0x404040),
+	CraftingCPUStored			(0x404040),
+	CraftingCPUAmount			(0x404040),
+	CraftingCPUScheduled		(0x404040),
+
+	CraftingStatusCPUName		(0x202020),
+	CraftingStatusCPUStorage	(0x202020),
+	CraftingStatusCPUAmount		(0x202020),
+
+	CraftAmountToCraft			(0xFFFFFF),
+	CraftAmountSelectAmount		(0x404040),
+
+	LevelEmitterValue			(0xFFFFFF),
+
+	PriorityTitle				(0x404040),
+	PriorityValue				(0xFFFFFF),
+
+	ChestTitle					(0x404040),
+	ChestInventory				(0x404040),
+
+	CondenserTitle				(0x404040),
+	CondenserInventory			(0x404040),
+
+	CraftConfirmCraftingPlan	(0x404040),
+	CraftConfirmSimulation		(0x404040),
+	CraftConfirmFromStorage		(0x404040),
+	CraftConfirmMissing			(0x404040),
+	CraftConfirmToCraft			(0x404040),
+
+	CraftingTerminalTitle		(0x404040),
+
+	DriveTitle					(0x404040),
+	DriveInventory				(0x404040),
+
+	FormationPlaneTitle			(0x404040),
+	FormationPlaneInventory		(0x404040),
+
+	GrindStoneTitle				(0x404040),
+	GrindStoneInventory			(0x404040),
+
+	InscriberTitle				(0x404040),
+	InscriberInventory			(0x404040),
+
+	InterfaceTitle				(0x404040),
+
+	InterfaceTerminalTitle		(0x404040),
+	InterfaceTerminalInventory	(0x404040),
+	InterfaceTerminalName		(0x404040),
+
+	IOPortTitle					(0x404040),
+	IOPortInventory				(0x404040),
+
+	NetworkStatusDetails		(0x404040),
+	NetworkStatusStoredPower	(0x404040),
+	NetworkStatusMaxPower		(0x404040),
+	NetworkStatusPowerInputRate	(0x404040),
+	NetworkStatusPowerUsageRate	(0x404040),
+	NetworkStatusItemCount		(0x404040),
+	
+	NetworkToolTitle			(0x404040),
+	NetworkToolInventory		(0x404040),
+
+	OreFilterLabel				(0x404040),
+
+	PatternTerminalTitle		(0x404040),
+	PatternTerminalEx			(0x404040),
+
+	QuantumLinkChamberTitle		(0x404040),
+	QuantumLinkChamberInventory	(0x404040),
+
+	QuartzCuttingKnifeTitle		(0x404040),
+	QuartzCuttingKnifeInventory	(0x404040),
+
+	RenamerTitle				(0x404040),
+
+	SecurityCardEditorTitle		(0x404040),
+
+	SkyChestTitle				(0x404040),
+	SkyChestInventory			(0x404040),
+	
+	SpatialIOTitle				(0x404040),
+	SpatialIOInventory			(0x404040),
+	SpatialIOStoredPower		(0x404040),
+	SpatialIOMaxPower			(0x404040),
+	SpatialIORequiredPower		(0x404040),
+	SpatialIOEfficiency			(0x404040),
+
+	StorageBusTitle				(0x404040),
+	StorageBusInventory			(0x404040),
+
+	UpgradableTitle				(0x404040),
+	UpgradableInventory			(0x404040),
+
+	VibrationChamberTitle		(0x404040),
+	VibrationChamberInventory	(0x404040),
+
+	WirelessTitle				(0x404040),
+	WirelessInventory			(0x404040),
+	WirelessRange				(0x404040),
+	WirelessPowerUsageRate		(0x404040),
+	
+	NEIGrindstoneRecipeChance	(0x000000),
+	NEIGrindstoneNoSecondOutput	(0x000000),
+
+	MEMonitorableTitle			(0x404040),
+	MEMonitorableInventory		(0x404040)
 	;
 
 	private final String root;
@@ -56,20 +166,19 @@ public enum GuiColors
 	public int getColor()
 	{
 		String hex = StatCollector.translateToLocal( this.getUnlocalized() );
-		long color = this.color;
+		int color = this.color;
 
 		try
 		{	
-			hex = !hex.contains("0x") ? hex.replace(hex, "0x" + hex) : hex;
-			color = Long.decode(hex);
+			color = Integer.parseUnsignedInt( hex, 16 );
 		}
 
 		catch ( final NumberFormatException e )
 		{
-			AELog.warn( "Couldn't format color correctly for: " + this.root);
+			AELog.warn( "Couldn't format color correctly for: " + this.root );
 		}
 
-		return (int) color;
+		return color;
 	}
 	
 	public String getUnlocalized()

--- a/src/main/java/appeng/core/localization/GuiColors.java
+++ b/src/main/java/appeng/core/localization/GuiColors.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.core.localization;
+
+import appeng.core.AELog;
+import net.minecraft.util.StatCollector;
+
+public enum GuiColors
+{	
+	//ARGB Colors: Name and default value
+	SearchboxFocused			(0x6E000000),
+	SearchboxUnfocused			(0x00000000),
+	ItemSlotOverlayUnpowered	(0x66111111),
+	ItemSlotOverlayInvalid		(0x66ff6666),
+	CraftConfirmMissingItem		(0x1AFF0000),
+	CraftingCPUActive			(0x5A45A021),
+	CraftingCPUScheduled		(0x5AFFF7AA),
+	InterfaceTerminalMatch		(0x2A00FF00),
+	
+	//RGB Colors: Name and default value
+	SearchboxFont			(0xFFFFFF),
+	CraftingOverviewFont	(0x606060),
+	;
+
+	private final String root;
+	private final int color;
+
+	GuiColors()
+	{
+		this.root = "gui.color.appliedenergistics2";
+		this.color = 0x000000;
+	}
+
+	GuiColors( final int hex )
+	{
+		this.root = "gui.color.appliedenergistics2";
+		this.color = hex;
+	}
+
+	public int getColor()
+	{
+		String hex = StatCollector.translateToLocal( this.getUnlocalized() );
+		long color = this.color;
+
+		try
+		{	
+			hex = !hex.contains("0x") ? hex.replace(hex, "0x" + hex) : hex;
+			color = Long.decode(hex);
+		}
+
+		catch ( final NumberFormatException e )
+		{
+			AELog.warn( "Couldn't format color correctly for: " + this.root);
+		}
+
+		return (int) color;
+	}
+	
+	public String getUnlocalized()
+	{
+		return this.root + '.' + this.toString();
+	}
+}

--- a/src/main/java/appeng/core/localization/GuiColors.java
+++ b/src/main/java/appeng/core/localization/GuiColors.java
@@ -168,16 +168,17 @@ public enum GuiColors
 		String hex = StatCollector.translateToLocal( this.getUnlocalized() );
 		int color = this.color;
 
-		try
-		{	
-			color = Integer.parseUnsignedInt( hex, 16 );
-		}
-
-		catch ( final NumberFormatException e )
+		if ( hex.length() <= 8 )
 		{
-			AELog.warn( "Couldn't format color correctly for: " + this.root );
+			try
+			{	
+				color = Integer.parseUnsignedInt( hex, 16 );
+			}
+			catch ( final NumberFormatException e )
+			{
+				AELog.warn( "Couldn't format color correctly for: " + this.root + " -> " + hex);
+			}
 		}
-
 		return color;
 	}
 	

--- a/src/main/java/appeng/integration/modules/NEIHelpers/NEIGrinderRecipeHandler.java
+++ b/src/main/java/appeng/integration/modules/NEIHelpers/NEIGrinderRecipeHandler.java
@@ -23,6 +23,7 @@ import appeng.api.AEApi;
 import appeng.api.features.IGrinderEntry;
 import appeng.client.gui.implementations.GuiGrinder;
 import appeng.core.localization.GuiText;
+import appeng.core.localization.GuiColors;
 import codechicken.lib.gui.GuiDraw;
 import codechicken.nei.NEIServerUtils;
 import codechicken.nei.PositionedStack;
@@ -144,13 +145,13 @@ public class NEIGrinderRecipeHandler extends TemplateRecipeHandler
 				{
 					final FontRenderer fr = Minecraft.getMinecraft().fontRenderer;
 					final int width = fr.getStringWidth( cachedRecipe.displayChance );
-					fr.drawString( cachedRecipe.displayChance, ( 168 - width ) / 2, 5, 0 );
+					fr.drawString( cachedRecipe.displayChance, ( 168 - width ) / 2, 5, GuiColors.NEIGrindstoneRecipeChance.getColor() );
 				}
 				else
 				{
 					final FontRenderer fr = Minecraft.getMinecraft().fontRenderer;
 					final int width = fr.getStringWidth( GuiText.NoSecondOutput.getLocal() );
-					fr.drawString( GuiText.NoSecondOutput.getLocal(), ( 168 - width ) / 2, 5, 0 );
+					fr.drawString( GuiText.NoSecondOutput.getLocal(), ( 168 - width ) / 2, 5, GuiColors.NEIGrindstoneNoSecondOutput.getColor() );
 				}
 			}
 		}

--- a/src/main/resources/assets/appliedenergistics2/lang/en_US.lang
+++ b/src/main/resources/assets/appliedenergistics2/lang/en_US.lang
@@ -245,6 +245,18 @@ gui.appliedenergistics2.OreFilterLabel=Ore dictionary filter
 gui.appliedenergistics2.HoldShiftForTooltip=Hold shift for extended tooltip
 gui.appliedenergistics2.Nothing=Nothing
 
+# GUI Colors - ARGB
+gui.color.appliedenergistics2.SearchboxFocused=6E000000
+gui.color.appliedenergistics2.SearchboxUnfocused=00000000
+gui.color.appliedenergistics2.SearchboxFocused=6E000000
+gui.color.appliedenergistics2.SearchboxUnfocused=00000000
+gui.color.appliedenergistics2.ItemSlotOverlayUnpowered=66111111
+gui.color.appliedenergistics2.ItemSlotOverlayInvalid=66ff6666
+gui.color.appliedenergistics2.CraftConfirmMissingItem=1AFF0000
+gui.color.appliedenergistics2.CraftingCPUActive=5A45A021
+gui.color.appliedenergistics2.CraftingCPUScheduled=5AFFF7AA
+gui.color.appliedenergistics2.InterfaceTerminalMatch=2A00FF00
+
 # GUI Tooltips
 gui.tooltips.appliedenergistics2.Stash=Store Items
 gui.tooltips.appliedenergistics2.StashDesc=Return items on the crafting grid to network storage.


### PR DESCRIPTION
For resourcepacks which touch the UI textures there usually isn't much customizability in regards to ui overlay colors and text colors. There remains the option of adding a standard mc color prefix for texts in the lang file but this is pretty limited. In addition some ui texts don't reference a lang file at all, thus there remain parts of the ui that can't be changed.

This PR introduces a single Enum that allows to change the color parameters through ae2 lang files. Occurences of `drawRect()`, `textColor()` and `drawString()` are affected.