### PR TITLE
CPU table enhancements: cycling, show in crafting confirmation dialog

### DIFF
--- a/src/main/java/appeng/client/gui/AEBaseGui.java
+++ b/src/main/java/appeng/client/gui/AEBaseGui.java
@@ -796,7 +796,7 @@ public abstract class AEBaseGui extends GuiContainer
 		this.mc.getTextureManager().bindTexture( loc );
 	}
 
-	protected void drawItem( final int x, final int y, final ItemStack is )
+	public void drawItem( final int x, final int y, final ItemStack is )
 	{
 		this.zLevel = 100.0F;
 		itemRender.zLevel = 100.0F;

--- a/src/main/java/appeng/client/gui/implementations/GuiCraftingStatus.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCraftingStatus.java
@@ -53,7 +53,7 @@ public class GuiCraftingStatus extends GuiCraftingCPU implements ICraftingCPUTab
 {
 	private final ContainerCraftingStatus status;
 	private GuiButton selectCPU;
-    private GuiCraftingCPUTable cpuTable;
+    private final GuiCraftingCPUTable cpuTable;
 
 	private GuiTabButton originalGuiBtn;
 	private GuiBridge originalGui;
@@ -67,6 +67,8 @@ public class GuiCraftingStatus extends GuiCraftingCPU implements ICraftingCPUTab
 		final Object target = this.status.getTarget();
 		final IDefinitions definitions = AEApi.instance().definitions();
 		final IParts parts = definitions.parts();
+
+        cpuTable = new GuiCraftingCPUTable(this, this.status.getCPUTable() );
 
 		if( target instanceof WirelessTerminalGuiObject )
 		{
@@ -129,7 +131,7 @@ public class GuiCraftingStatus extends GuiCraftingCPU implements ICraftingCPUTab
 
         if( btn == this.selectCPU )
         {
-            cpuTable.cycleCPU();
+            cpuTable.cycleCPU(backwards);
         }
 
 		if( btn == this.originalGuiBtn )
@@ -146,8 +148,6 @@ public class GuiCraftingStatus extends GuiCraftingCPU implements ICraftingCPUTab
 		this.selectCPU = new GuiButton( 0, this.guiLeft + 8, this.guiTop + this.ySize - 25, 150, 20, GuiText.CraftingCPU.getLocal() + ": " + GuiText.NoCraftingCPUs );
 		this.buttonList.add( this.selectCPU );
 
-        cpuTable = new GuiCraftingCPUTable(this, this.status.getCPUTable() );
-
 		if( this.myIcon != null )
 		{
 			this.buttonList.add( this.originalGuiBtn = new GuiTabButton( this.guiLeft + 213, this.guiTop - 4, this.myIcon, this.myIcon.getDisplayName(), itemRender ) );
@@ -158,10 +158,7 @@ public class GuiCraftingStatus extends GuiCraftingCPU implements ICraftingCPUTab
 	@Override
 	public void drawScreen( final int mouseX, final int mouseY, final float btn )
 	{
-        if (this.cpuTable != null)
-        {
-            this.cpuTable.drawScreen( mouseX, mouseY, btn );
-        }
+        this.cpuTable.drawScreen(  );
 		this.updateCPUButtonText();
 		super.drawScreen( mouseX, mouseY, btn );
 	}
@@ -170,36 +167,28 @@ public class GuiCraftingStatus extends GuiCraftingCPU implements ICraftingCPUTab
     public void drawFG( int offsetX, int offsetY, int mouseX, int mouseY )
     {
         super.drawFG( offsetX, offsetY, mouseX, mouseY );
-        if (this.cpuTable != null) {
-            this.cpuTable.drawFG( offsetX, offsetY, mouseX, mouseY );
-        }
+        this.cpuTable.drawFG( offsetX, offsetY, mouseX, mouseY, guiLeft, guiTop );
     }
 
     @Override
     public void drawBG( int offsetX, int offsetY, int mouseX, int mouseY )
     {
         super.drawBG( offsetX, offsetY, mouseX, mouseY );
-        if (this.cpuTable != null) {
-            this.cpuTable.drawBG( offsetX, offsetY, mouseX, mouseY );
-        }
+        this.cpuTable.drawBG( offsetX, offsetY );
     }
 
     @Override
     protected void mouseClicked( int xCoord, int yCoord, int btn )
     {
         super.mouseClicked( xCoord, yCoord, btn );
-        if (cpuTable != null) {
-            cpuTable.mouseClicked( xCoord - guiLeft, yCoord - guiTop, btn );
-        }
+        cpuTable.mouseClicked( xCoord - guiLeft, yCoord - guiTop, btn );
     }
 
     @Override
     protected void mouseClickMove( int x, int y, int c, long d )
     {
         super.mouseClickMove( x, y, c, d );
-        if( cpuTable != null ) {
-            cpuTable.mouseClickMove( x - guiLeft, y - guiTop, c );
-        }
+        cpuTable.mouseClickMove( x - guiLeft, y - guiTop );
     }
 
     @Override

--- a/src/main/java/appeng/client/gui/widgets/GuiCraftingCPUTable.java
+++ b/src/main/java/appeng/client/gui/widgets/GuiCraftingCPUTable.java
@@ -330,6 +330,20 @@ public class GuiCraftingCPUTable
                 break;
             }
         }
+        final boolean preferBusy = container.isBusyCPUsPreferred();
+        for (int i = 0; i < cpus.size(); i++)
+        {
+            next = next % cpus.size();
+            final boolean cpuBusy = cpus.get(next).getRemainingItems() > 0;
+            if (cpuBusy == preferBusy)
+            {
+                break;
+            }
+            else
+            {
+                next++;
+            }
+        }
         next = next % cpus.size();
         sendCPUSwitch( cpus.get( next ).getSerial() );
         if( next < cpuScrollbar.getCurrentScroll() || next >= cpuScrollbar.getCurrentScroll() + CPU_TABLE_SLOTS )

--- a/src/main/java/appeng/client/gui/widgets/GuiCraftingCpuTable.java
+++ b/src/main/java/appeng/client/gui/widgets/GuiCraftingCpuTable.java
@@ -1,0 +1,282 @@
+package appeng.client.gui.widgets;
+
+import appeng.api.storage.data.IAEItemStack;
+import appeng.client.gui.AEBaseGui;
+import appeng.container.implementations.CraftingCPUStatus;
+import appeng.core.localization.GuiColors;
+import appeng.core.localization.GuiText;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.FontRenderer;
+import org.lwjgl.input.Mouse;
+import org.lwjgl.opengl.GL11;
+
+import java.util.List;
+import java.util.function.IntSupplier;
+import java.util.function.Supplier;
+
+public class GuiCraftingCpuTable
+{
+    public AEBaseGui parent;
+
+    public static final int CPU_TABLE_WIDTH = 94;
+    public static final int CPU_TABLE_HEIGHT = 164;
+    public static final int CPU_TABLE_SLOT_XOFF = 100;
+    public static final int CPU_TABLE_SLOT_YOFF = 0;
+    public static final int CPU_TABLE_SLOT_WIDTH = 67;
+    public static final int CPU_TABLE_SLOT_HEIGHT = 23;
+
+    private final GuiScrollbar cpuScrollbar;
+
+    private String selectedCPUName = "";
+    private final IntSupplier selectedCpuSerialProvider;
+    private final Supplier<List<CraftingCPUStatus>> cpuListProvider;
+
+    public GuiCraftingCpuTable( AEBaseGui parent, IntSupplier selectedCpuSerialProvider, Supplier<List<CraftingCPUStatus>> cpuListProvider )
+    {
+        this.parent = parent;
+        this.cpuScrollbar = new GuiScrollbar();
+        this.cpuScrollbar.setLeft( -16 );
+        this.cpuScrollbar.setTop( 19 );
+        this.cpuScrollbar.setWidth( 12 );
+        this.cpuScrollbar.setHeight( 137 );
+
+        this.selectedCpuSerialProvider = selectedCpuSerialProvider;
+        this.cpuListProvider = cpuListProvider;
+    }
+
+    public String getSelectedCPUName()
+    {
+        return selectedCPUName;
+    }
+
+    public void drawScreen( final int mouseX, final int mouseY, final float btn )
+    {
+        final List<CraftingCPUStatus> cpus = cpuListProvider.get();
+        final int selectedCpuSerial = selectedCpuSerialProvider.getAsInt();
+
+        this.selectedCPUName = null;
+        this.cpuScrollbar.setRange( 0, Integer.max( 0, cpus.size() - 6 ), 1 );
+        for( CraftingCPUStatus cpu : cpus )
+        {
+            if( cpu.getSerial() == selectedCpuSerial )
+            {
+                this.selectedCPUName = cpu.getName();
+            }
+        }
+    }
+
+    public void drawFG( int offsetX, int offsetY, int mouseX, int mouseY )
+    {
+        if( this.cpuScrollbar != null )
+        {
+            this.cpuScrollbar.draw( parent );
+        }
+        final List<CraftingCPUStatus> cpus = cpuListProvider.get();
+        final int selectedCpuSerial = selectedCpuSerialProvider.getAsInt();
+        final int firstCpu = this.cpuScrollbar.getCurrentScroll();
+        CraftingCPUStatus hoveredCpu = hitCpu( mouseX, mouseY );
+        {
+            FontRenderer font = Minecraft.getMinecraft().fontRenderer;
+            for( int i = firstCpu; i < firstCpu + 6; i++ )
+            {
+                if( i < 0 || i >= cpus.size() )
+                {
+                    continue;
+                }
+                CraftingCPUStatus cpu = cpus.get( i );
+                if( cpu == null )
+                {
+                    continue;
+                }
+                int x = -CPU_TABLE_WIDTH + 9;
+                int y = 19 + ( i - firstCpu ) * CPU_TABLE_SLOT_HEIGHT;
+                if( cpu.getSerial() == selectedCpuSerial )
+                {
+                    GL11.glColor4f( 0.0F, 0.8352F, 1.0F, 1.0F );
+                } else if( hoveredCpu != null && hoveredCpu.getSerial() == cpu.getSerial() )
+                {
+                    GL11.glColor4f( 0.65F, 0.9F, 1.0F, 1.0F );
+                } else
+                {
+                    GL11.glColor4f( 1.0F, 1.0F, 1.0F, 1.0F );
+                }
+                parent.bindTexture( "guis/cpu_selector.png" );
+                parent.drawTexturedModalRect( x, y, CPU_TABLE_SLOT_XOFF, CPU_TABLE_SLOT_YOFF, CPU_TABLE_SLOT_WIDTH, CPU_TABLE_SLOT_HEIGHT );
+                GL11.glColor4f( 1.0F, 1.0F, 1.0F, 1.0F );
+
+                String name = cpu.getName();
+                if( name == null || name.isEmpty() )
+                {
+                    name = GuiText.CPUs.getLocal() + " #" + cpu.getSerial();
+                }
+                if( name.length() > 12 )
+                {
+                    name = name.substring( 0, 11 ) + "..";
+                }
+                GL11.glPushMatrix();
+                GL11.glTranslatef( x + 3, y + 3, 0 );
+                GL11.glScalef( 0.8f, 0.8f, 1.0f );
+                font.drawString( name, 0, 0, GuiColors.CraftingStatusCPUName.getColor() );
+                GL11.glPopMatrix();
+
+                GL11.glPushMatrix();
+                GL11.glTranslatef( x + 3, y + 11, 0 );
+                final IAEItemStack craftingStack = cpu.getCrafting();
+                if( craftingStack != null )
+                {
+                    final int iconIndex = 16 * 11 + 2;
+                    parent.bindTexture( "guis/states.png" );
+                    final int uv_y = iconIndex / 16;
+                    final int uv_x = iconIndex - uv_y * 16;
+
+                    GL11.glScalef( 0.5f, 0.5f, 1.0f );
+                    GL11.glColor4f( 1.0F, 1.0F, 1.0F, 1.0F );
+                    parent.drawTexturedModalRect( 0, 0, uv_x * 16, uv_y * 16, 16, 16 );
+                    GL11.glTranslatef( 18.0f, 2.0f, 0.0f );
+                    String amount = Long.toString( craftingStack.getStackSize() );
+                    if( amount.length() > 5 )
+                    {
+                        amount = amount.substring( 0, 5 ) + "..";
+                    }
+                    GL11.glScalef( 1.5f, 1.5f, 1.0f );
+                    font.drawString( amount, 0, 0, GuiColors.CraftingStatusCPUAmount.getColor() );
+                    GL11.glPopMatrix();
+                    GL11.glPushMatrix();
+                    GL11.glTranslatef( x + CPU_TABLE_SLOT_WIDTH - 19, y + 3, 0 );
+                    parent.drawItem( 0, 0, craftingStack.getItemStack() );
+                } else
+                {
+                    final int iconIndex = 16 * 4 + 3;
+                    parent.bindTexture( "guis/states.png" );
+                    final int uv_y = iconIndex / 16;
+                    final int uv_x = iconIndex - uv_y * 16;
+
+                    GL11.glScalef( 0.5f, 0.5f, 1.0f );
+                    GL11.glColor4f( 1.0F, 1.0F, 1.0F, 1.0F );
+                    parent.drawTexturedModalRect( 0, 0, uv_x * 16, uv_y * 16, 16, 16 );
+                    GL11.glTranslatef( 18.0f, 2.0f, 0.0f );
+                    GL11.glScalef( 1.5f, 1.5f, 1.0f );
+                    font.drawString( cpu.formatStorage(), 0, 0, GuiColors.CraftingStatusCPUStorage.getColor() );
+                }
+                GL11.glPopMatrix();
+            }
+            GL11.glColor4f( 1.0F, 1.0F, 1.0F, 1.0F );
+        }
+        if( hoveredCpu != null )
+        {
+            StringBuilder tooltip = new StringBuilder();
+            String name = hoveredCpu.getName();
+            if( name != null && !name.isEmpty() )
+            {
+                tooltip.append( name );
+                tooltip.append( '\n' );
+            } else
+            {
+                tooltip.append( GuiText.CPUs.getLocal() );
+                tooltip.append( " #" );
+                tooltip.append( hoveredCpu.getSerial() );
+                tooltip.append( '\n' );
+            }
+            IAEItemStack crafting = hoveredCpu.getCrafting();
+            if( crafting != null && crafting.getStackSize() > 0 )
+            {
+                tooltip.append( GuiText.Crafting.getLocal() );
+                tooltip.append( ": " );
+                tooltip.append( crafting.getStackSize() );
+                tooltip.append( ' ' );
+                tooltip.append( crafting.getItemStack().getDisplayName() );
+                tooltip.append( '\n' );
+                tooltip.append( hoveredCpu.getRemainingItems() );
+                tooltip.append( " / " );
+                tooltip.append( hoveredCpu.getTotalItems() );
+                tooltip.append( '\n' );
+            }
+            if( hoveredCpu.getStorage() > 0 )
+            {
+                tooltip.append( GuiText.Bytes.getLocal() );
+                tooltip.append( ": " );
+                tooltip.append( hoveredCpu.formatStorage() );
+                tooltip.append( '\n' );
+            }
+            if( hoveredCpu.getCoprocessors() > 0 )
+            {
+                tooltip.append( GuiText.CoProcessors.getLocal() );
+                tooltip.append( ": " );
+                tooltip.append( hoveredCpu.getCoprocessors() );
+                tooltip.append( '\n' );
+            }
+            if( tooltip.length() > 0 )
+            {
+                parent.drawTooltip( mouseX - offsetX, mouseY - offsetY, 0, tooltip.toString() );
+            }
+        }
+    }
+
+    public void drawBG( int offsetX, int offsetY, int mouseX, int mouseY )
+    {
+        parent.bindTexture( "guis/cpu_selector.png" );
+        parent.drawTexturedModalRect( offsetX - CPU_TABLE_WIDTH, offsetY, 0, 0, CPU_TABLE_WIDTH, CPU_TABLE_HEIGHT );
+    }
+
+    /**
+     * Tests if a cpu button is under the cursor. Subtract guiLeft, guiTop from x, y before calling
+     */
+    public CraftingCPUStatus hitCpu( int x, int y )
+    {
+        x -= -CPU_TABLE_WIDTH;
+        if( !( x >= 9 && x < CPU_TABLE_SLOT_WIDTH + 9 && y >= 19 && y < 19 + 6 * CPU_TABLE_SLOT_HEIGHT ) )
+        {
+            return null;
+        }
+        int scrollOffset = this.cpuScrollbar != null ? this.cpuScrollbar.getCurrentScroll() : 0;
+        int cpuId = scrollOffset + ( y - 19 ) / CPU_TABLE_SLOT_HEIGHT;
+        List<CraftingCPUStatus> cpus = cpuListProvider.get();
+        return ( cpuId >= 0 && cpuId < cpus.size() ) ? cpus.get( cpuId ) : null;
+    }
+
+    /**
+     * Subtract guiLeft, guiTop from x, y before calling
+     */
+    public void mouseClicked( int xCoord, int yCoord, int btn )
+    {
+        if( cpuScrollbar != null )
+        {
+            cpuScrollbar.click( parent, xCoord, yCoord );
+        }
+    }
+
+    /**
+     * @return True if event was handled
+     */
+    public boolean handleMouseInput( int guiLeft, int guiTop )
+    {
+        int x = Mouse.getEventX() * parent.width / parent.mc.displayWidth;
+        int y = parent.height - Mouse.getEventY() * parent.height / parent.mc.displayHeight - 1;
+        x -= guiLeft - CPU_TABLE_WIDTH;
+        y -= guiTop;
+        int dwheel = Mouse.getEventDWheel();
+        if( x >= 9 && x < CPU_TABLE_SLOT_WIDTH + 9 && y >= 19 && y < 19 + 6 * CPU_TABLE_SLOT_HEIGHT )
+        {
+            if( this.cpuScrollbar != null && dwheel != 0 )
+            {
+                this.cpuScrollbar.wheel( dwheel );
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean hideItemPanelSlot( int x, int y, int w, int h )
+    {
+        x += CPU_TABLE_WIDTH;
+        boolean xInside =
+                ( x >= 0 && x < CPU_TABLE_SLOT_WIDTH + 9 )
+                        || ( x + w >= 0 && x + w < CPU_TABLE_SLOT_WIDTH + 9 )
+                        || ( x <= 0 && x + w >= CPU_TABLE_SLOT_WIDTH + 9 );
+        boolean yInside =
+                ( y >= 0 && y < 19 + 6 * CPU_TABLE_SLOT_HEIGHT )
+                        || ( y + h >= 0 && y + h < 19 + 6 * CPU_TABLE_SLOT_HEIGHT )
+                        || ( y < 0 && y + h >= 19 + 6 * CPU_TABLE_SLOT_HEIGHT );
+        return xInside && yInside;
+    }
+}

--- a/src/main/java/appeng/client/gui/widgets/ICraftingCPUTableHolder.java
+++ b/src/main/java/appeng/client/gui/widgets/ICraftingCPUTableHolder.java
@@ -1,0 +1,6 @@
+package appeng.client.gui.widgets;
+
+public interface ICraftingCPUTableHolder
+{
+    GuiCraftingCPUTable getCPUTable();
+}

--- a/src/main/java/appeng/container/guisync/GuiSync.java
+++ b/src/main/java/appeng/container/guisync/GuiSync.java
@@ -29,10 +29,20 @@ import java.lang.annotation.Target;
  * Annotates that this field should be synchronized between the server and client.
  * Requires the field to be public.
  */
-@Retention( RetentionPolicy.RUNTIME )
-@Target( ElementType.FIELD )
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
 public @interface GuiSync
 {
 
-	int value();
+    int value();
+
+    /**
+     * Recurse into the class in search of more @GuiSync-ed values. The child IDs are offset by the value.
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    public static @interface Recurse
+    {
+        int value();
+    }
 }

--- a/src/main/java/appeng/container/guisync/SyncData.java
+++ b/src/main/java/appeng/container/guisync/SyncData.java
@@ -35,175 +35,190 @@ import java.util.EnumSet;
 public class SyncData
 {
 
-	private final AEBaseContainer source;
-	private final Field field;
-	private final int channel;
-	private Object clientVersion;
+    private final AEBaseContainer source;
+    private final Field[] indirections;
+    private final Field field;
+    private final String fieldName;
+    private final int channel;
+    private Object clientVersion;
 
-	public SyncData( final AEBaseContainer container, final Field field, final GuiSync annotation )
-	{
-		this.clientVersion = null;
-		this.source = container;
-		this.field = field;
-		this.channel = annotation.value();
-	}
+    public SyncData( final AEBaseContainer container, final Field field, final GuiSync annotation )
+    {
+        this( container, new Field[0], field, annotation.value() );
+    }
 
-	public int getChannel()
-	{
-		return this.channel;
-	}
+    public SyncData( final AEBaseContainer container, final Field[] indirections, final Field field, final int channel )
+    {
+        this.clientVersion = null;
+        this.source = container;
+        this.indirections = indirections;
+        this.field = field;
+        this.channel = channel;
+        StringBuilder nameBuilder = new StringBuilder();
+        for( Field indirection : this.indirections )
+        {
+            nameBuilder.append( indirection.getName() );
+            nameBuilder.append( '.' );
+        }
+        nameBuilder.append( this.field.getName() );
+        this.fieldName = nameBuilder.toString();
+    }
 
-	public void tick( final ICrafting c )
-	{
-		try
-		{
-			final Object val = this.field.get( this.source );
-			if( val != null && this.clientVersion == null )
-			{
-				this.send( c, val );
-			}
-			else if( !val.equals( this.clientVersion ) )
-			{
-				this.send( c, val );
-			}
-		}
-		catch( final IllegalArgumentException e )
-		{
-			AELog.debug( e );
-		}
-		catch( final IllegalAccessException e )
-		{
-			AELog.debug( e );
-		}
-		catch( final IOException e )
-		{
-			AELog.debug( e );
-		}
-	}
+    public int getChannel()
+    {
+        return this.channel;
+    }
 
-	private void send( final ICrafting o, final Object val ) throws IOException
-	{
-		if( val instanceof String )
-		{
-			if( o instanceof EntityPlayerMP )
-			{
-				NetworkHandler.instance.sendTo( new PacketValueConfig( "SyncDat." + this.channel, (String) val ), (EntityPlayerMP) o );
-			}
-		}
-		else if( this.field.getType().isEnum() )
-		{
-			o.sendProgressBarUpdate( this.source, this.channel, ( (Enum) val ).ordinal() );
-		}
-		else if( val instanceof Long || val.getClass() == long.class )
-		{
-			NetworkHandler.instance.sendTo( new PacketProgressBar( this.channel, (Long) val ), (EntityPlayerMP) o );
-		}
-		else if( val instanceof Boolean || val.getClass() == boolean.class )
-		{
-			o.sendProgressBarUpdate( this.source, this.channel, ( (Boolean) val ) ? 1 : 0 );
-		}
-		else
-		{
-			o.sendProgressBarUpdate( this.source, this.channel, (Integer) val );
-		}
+    private Object getValue() throws IllegalAccessException
+    {
+        Object currentObject = source;
+        for( Field indirection : indirections )
+        {
+            currentObject = indirection.get( currentObject );
+        }
+        return field.get( currentObject );
+    }
 
-		this.clientVersion = val;
-	}
+    private void setValue( Object newVal ) throws IllegalAccessException
+    {
+        Object currentObject = source;
+        for( Field indirection : indirections )
+        {
+            currentObject = indirection.get( currentObject );
+        }
+        field.set( currentObject, newVal );
+    }
 
-	public void update( final Object val )
-	{
-		try
-		{
-			final Object oldValue = this.field.get( this.source );
-			if( val instanceof String )
-			{
-				this.updateString( oldValue, (String) val );
-			}
-			else
-			{
-				this.updateValue( oldValue, (Long) val );
-			}
-		}
-		catch( final IllegalArgumentException e )
-		{
-			AELog.debug( e );
-		}
-		catch( final IllegalAccessException e )
-		{
-			AELog.debug( e );
-		}
-	}
+    public void tick( final ICrafting c )
+    {
+        try
+        {
+            final Object val = getValue();
+            if( val != null && this.clientVersion == null )
+            {
+                this.send( c, val );
+            } else if( !val.equals( this.clientVersion ) )
+            {
+                this.send( c, val );
+            }
+        } catch( final IllegalArgumentException e )
+        {
+            AELog.debug( e );
+        } catch( final IllegalAccessException e )
+        {
+            AELog.debug( e );
+        } catch( final IOException e )
+        {
+            AELog.debug( e );
+        }
+    }
 
-	private void updateString( final Object oldValue, final String val )
-	{
-		try
-		{
-			this.field.set( this.source, val );
-			this.source.onUpdate( this.field.getName(), oldValue, this.field.get( this.source ) );
-		}
-		catch( final IllegalArgumentException e )
-		{
-			AELog.debug( e );
-		}
-		catch( final IllegalAccessException e )
-		{
-			AELog.debug( e );
-		}
-	}
+    private void send( final ICrafting o, final Object val ) throws IOException
+    {
+        if( val instanceof String )
+        {
+            if( o instanceof EntityPlayerMP )
+            {
+                NetworkHandler.instance.sendTo( new PacketValueConfig( "SyncDat." + this.channel, (String) val ), (EntityPlayerMP) o );
+            }
+        } else if( this.field.getType().isEnum() )
+        {
+            o.sendProgressBarUpdate( this.source, this.channel, ( (Enum) val ).ordinal() );
+        } else if( val instanceof Long || val.getClass() == long.class )
+        {
+            NetworkHandler.instance.sendTo( new PacketProgressBar( this.channel, (Long) val ), (EntityPlayerMP) o );
+        } else if( val instanceof Boolean || val.getClass() == boolean.class )
+        {
+            o.sendProgressBarUpdate( this.source, this.channel, ( (Boolean) val ) ? 1 : 0 );
+        } else
+        {
+            o.sendProgressBarUpdate( this.source, this.channel, (Integer) val );
+        }
 
-	private void updateValue( final Object oldValue, final long val )
-	{
-		try
-		{
-			if( this.field.getType().isEnum() )
-			{
-				final EnumSet<? extends Enum> valList = EnumSet.allOf( (Class<? extends Enum>) this.field.getType() );
-				for( final Enum e : valList )
-				{
-					if( e.ordinal() == val )
-					{
-						this.field.set( this.source, e );
-						break;
-					}
-				}
-			}
-			else
-			{
-				if( this.field.getType().equals( int.class ) )
-				{
-					this.field.set( this.source, (int) val );
-				}
-				else if( this.field.getType().equals( long.class ) )
-				{
-					this.field.set( this.source, val );
-				}
-				else if( this.field.getType().equals( boolean.class ) )
-				{
-					this.field.set( this.source, val == 1 );
-				}
-				else if( this.field.getType().equals( Integer.class ) )
-				{
-					this.field.set( this.source, (int) val );
-				}
-				else if( this.field.getType().equals( Long.class ) )
-				{
-					this.field.set( this.source, val );
-				}
-				else if( this.field.getType().equals( Boolean.class ) )
-				{
-					this.field.set( this.source, val == 1 );
-				}
-			}
+        this.clientVersion = val;
+    }
 
-			this.source.onUpdate( this.field.getName(), oldValue, this.field.get( this.source ) );
-		}
-		catch( final IllegalArgumentException e )
-		{
-			AELog.debug( e );
-		}
-		catch( final IllegalAccessException e )
-		{
-			AELog.debug( e );
-		}
-	}
+    public void update( final Object val )
+    {
+        try
+        {
+            final Object oldValue = this.getValue();
+            if( val instanceof String )
+            {
+                this.updateString( oldValue, (String) val );
+            } else
+            {
+                this.updateValue( oldValue, (Long) val );
+            }
+        } catch( final IllegalArgumentException e )
+        {
+            AELog.debug( e );
+        } catch( final IllegalAccessException e )
+        {
+            AELog.debug( e );
+        }
+    }
+
+    private void updateString( final Object oldValue, final String val )
+    {
+        try
+        {
+            this.setValue( val );
+            this.source.onUpdate( this.fieldName, oldValue, this.getValue() );
+        } catch( final IllegalArgumentException e )
+        {
+            AELog.debug( e );
+        } catch( final IllegalAccessException e )
+        {
+            AELog.debug( e );
+        }
+    }
+
+    private void updateValue( final Object oldValue, final long val )
+    {
+        try
+        {
+            if( this.field.getType().isEnum() )
+            {
+                final EnumSet<? extends Enum> valList = EnumSet.allOf( (Class<? extends Enum>) this.field.getType() );
+                for( final Enum e : valList )
+                {
+                    if( e.ordinal() == val )
+                    {
+                        this.setValue( e );
+                        break;
+                    }
+                }
+            } else
+            {
+                if( this.field.getType().equals( int.class ) )
+                {
+                    this.setValue( (int) val );
+                } else if( this.field.getType().equals( long.class ) )
+                {
+                    this.setValue( val );
+                } else if( this.field.getType().equals( boolean.class ) )
+                {
+                    this.setValue( val == 1 );
+                } else if( this.field.getType().equals( Integer.class ) )
+                {
+                    this.setValue( (int) val );
+                } else if( this.field.getType().equals( Long.class ) )
+                {
+                    this.setValue( val );
+                } else if( this.field.getType().equals( Boolean.class ) )
+                {
+                    this.setValue( val == 1 );
+                }
+            }
+
+            this.source.onUpdate( this.fieldName, oldValue, this.getValue() );
+        } catch( final IllegalArgumentException e )
+        {
+            AELog.debug( e );
+        } catch( final IllegalAccessException e )
+        {
+            AELog.debug( e );
+        }
+    }
 }

--- a/src/main/java/appeng/container/implementations/ContainerCPUTable.java
+++ b/src/main/java/appeng/container/implementations/ContainerCPUTable.java
@@ -1,0 +1,163 @@
+package appeng.container.implementations;
+
+import appeng.api.networking.IGrid;
+import appeng.api.networking.crafting.ICraftingCPU;
+import appeng.api.networking.crafting.ICraftingGrid;
+import appeng.container.AEBaseContainer;
+import appeng.container.guisync.GuiSync;
+import appeng.container.interfaces.ICraftingCPUSelectorContainer;
+import appeng.core.AELog;
+import appeng.core.sync.network.NetworkHandler;
+import appeng.core.sync.packets.PacketCraftingCPUsUpdate;
+import appeng.util.Platform;
+import com.google.common.collect.ImmutableSet;
+import net.minecraft.entity.player.EntityPlayerMP;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.function.Consumer;
+
+public class ContainerCPUTable implements ICraftingCPUSelectorContainer
+{
+    AEBaseContainer parent;
+
+    private ImmutableSet<ICraftingCPU> lastCpuSet = null;
+    private List<CraftingCPUStatus> cpus = new ArrayList<CraftingCPUStatus>();
+    private final WeakHashMap<ICraftingCPU, Integer> cpuSerialMap = new WeakHashMap<>();
+    private int nextCpuSerial = 1;
+    private int lastUpdate = 0;
+    @GuiSync( 5 )
+    public int selectedCpuSerial = -1;
+    private Consumer<ICraftingCPU> onCPUChange;
+
+    private static final Comparator<CraftingCPUStatus> CPU_COMPARATOR = Comparator
+            .comparing((CraftingCPUStatus e) -> e.getName() == null || e.getName().isEmpty())
+            .thenComparing(e -> e.getName() != null ? e.getName() : "")
+            .thenComparingInt(CraftingCPUStatus::getSerial);
+
+    public ContainerCPUTable(ContainerCraftingCPU parent, Consumer<ICraftingCPU> onCPUChange)
+    {
+        this.parent = parent;
+        this.onCPUChange = onCPUChange;
+    }
+
+    public void detectAndSendChanges(IGrid network, List<?> crafters) {
+        if( Platform.isServer() && network != null )
+        {
+            final ICraftingGrid cc = network.getCache( ICraftingGrid.class );
+            final ImmutableSet<ICraftingCPU> cpuSet = cc.getCpus();
+            // Update at least once a second
+            ++lastUpdate;
+            if (!cpuSet.equals( lastCpuSet ) || lastUpdate > 20) {
+                lastUpdate = 0;
+                lastCpuSet = cpuSet;
+                updateCpuList();
+                sendCPUs(crafters);
+            }
+        }
+
+        // Clear selection if CPU is no longer in list
+        if (selectedCpuSerial != -1) {
+            if (cpus.stream().noneMatch(c -> c.getSerial() == selectedCpuSerial)) {
+                selectCPU(-1);
+            }
+        }
+
+        // Select a suitable CPU if none is selected
+        if (selectedCpuSerial == -1) {
+            // Try busy CPUs first
+            for (CraftingCPUStatus cpu : cpus) {
+                if (cpu.getRemainingItems() > 0) {
+                    selectCPU(cpu.getSerial());
+                    break;
+                }
+            }
+            // If we couldn't find a busy one, just select the first
+            if (selectedCpuSerial == -1 && !cpus.isEmpty()) {
+                selectCPU(cpus.get(0).getSerial());
+            }
+        }
+    }
+
+    private void updateCpuList()
+    {
+        this.cpus.clear();
+        for (ICraftingCPU cpu : lastCpuSet)
+        {
+            int serial = getOrAssignCpuSerial(cpu);
+            this.cpus.add( new CraftingCPUStatus( cpu, serial ) );
+        }
+        this.cpus.sort(CPU_COMPARATOR);
+    }
+
+    private int getOrAssignCpuSerial( ICraftingCPU cpu )
+    {
+        return cpuSerialMap.computeIfAbsent( cpu, unused -> nextCpuSerial++ );
+    }
+
+    private void sendCPUs(List<?> crafters)
+    {
+        final PacketCraftingCPUsUpdate update;
+        for( final Object player : crafters )
+        {
+            if( player instanceof EntityPlayerMP )
+            {
+                try
+                {
+                    NetworkHandler.instance.sendTo( new PacketCraftingCPUsUpdate( this.cpus ), (EntityPlayerMP) player );
+                }
+                catch( IOException e )
+                {
+                    AELog.debug( e );
+                }
+            }
+        }
+    }
+
+    @Override
+    public void selectCPU( int serial )
+    {
+        if (Platform.isServer())
+        {
+            if( serial < -1 )
+            {
+                serial = -1;
+            }
+
+            final int searchedSerial = serial;
+            if( serial > -1 && cpus.stream().noneMatch(c -> c.getSerial() == searchedSerial) )
+            {
+                serial = -1;
+            }
+
+            ICraftingCPU newSelectedCpu = null;
+            if( serial != -1 )
+            {
+                for( ICraftingCPU cpu : lastCpuSet )
+                {
+                    if( cpuSerialMap.getOrDefault( cpu, -1 ) == serial )
+                    {
+                        newSelectedCpu = cpu;
+                        break;
+                    }
+                }
+            }
+
+            this.selectedCpuSerial = serial;
+            if (onCPUChange != null)
+            {
+                onCPUChange.accept( newSelectedCpu );
+            }
+        }
+    }
+
+    public List<CraftingCPUStatus> getCPUs()
+    {
+        return Collections.unmodifiableList( cpus );
+    }
+
+    public void handleCPUUpdate( CraftingCPUStatus[] cpus )
+    {
+        this.cpus = Arrays.asList( cpus );
+    }
+}

--- a/src/main/java/appeng/container/implementations/ContainerCraftingStatus.java
+++ b/src/main/java/appeng/container/implementations/ContainerCraftingStatus.java
@@ -45,7 +45,7 @@ public class ContainerCraftingStatus extends ContainerCraftingCPU implements ICr
 	public ContainerCraftingStatus( final InventoryPlayer ip, final ITerminalHost te )
 	{
 		super( ip, te );
-        cpuTable = new ContainerCPUTable( this, this::setCPU, true );
+        cpuTable = new ContainerCPUTable( this, this::setCPU, true, c -> true );
 	}
 
     public ContainerCPUTable getCPUTable()

--- a/src/main/java/appeng/container/implementations/ContainerCraftingStatus.java
+++ b/src/main/java/appeng/container/implementations/ContainerCraftingStatus.java
@@ -45,7 +45,7 @@ public class ContainerCraftingStatus extends ContainerCraftingCPU implements ICr
 	public ContainerCraftingStatus( final InventoryPlayer ip, final ITerminalHost te )
 	{
 		super( ip, te );
-        cpuTable = new ContainerCPUTable( this, this::setCPU );
+        cpuTable = new ContainerCPUTable( this, this::setCPU, true );
 	}
 
     public ContainerCPUTable getCPUTable()

--- a/src/main/java/appeng/container/implementations/ContainerCraftingStatus.java
+++ b/src/main/java/appeng/container/implementations/ContainerCraftingStatus.java
@@ -24,14 +24,12 @@ import appeng.api.networking.crafting.ICraftingCPU;
 import appeng.api.networking.crafting.ICraftingGrid;
 import appeng.api.storage.ITerminalHost;
 import appeng.container.guisync.GuiSync;
+import appeng.container.interfaces.ICraftingCPUSelectorContainer;
 import appeng.core.AELog;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketCraftingCPUsUpdate;
 import appeng.util.Platform;
-import com.google.common.collect.ImmutableCollection;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.entity.player.InventoryPlayer;
 
@@ -39,153 +37,37 @@ import java.io.IOException;
 import java.util.*;
 
 
-public class ContainerCraftingStatus extends ContainerCraftingCPU
+public class ContainerCraftingStatus extends ContainerCraftingCPU implements ICraftingCPUSelectorContainer
 {
-
-    private ImmutableSet<ICraftingCPU> lastCpuSet = null;
-	private List<CraftingCPUStatus> cpus = new ArrayList<CraftingCPUStatus>();
-    private final WeakHashMap<ICraftingCPU, Integer> cpuSerialMap = new WeakHashMap<>();
-    private int nextCpuSerial = 1;
-    private int lastUpdate = 0;
-	@GuiSync( 5 )
-	public int selectedCpuSerial = -1;
+    @GuiSync.Recurse( 5 )
+    public ContainerCPUTable cpuTable;
 
 	public ContainerCraftingStatus( final InventoryPlayer ip, final ITerminalHost te )
 	{
 		super( ip, te );
+        cpuTable = new ContainerCPUTable( this, this::setCPU );
 	}
 
-	@Override
+    public ContainerCPUTable getCPUTable()
+    {
+        return cpuTable;
+    }
+
+    @Override
 	public void detectAndSendChanges()
 	{
-        IGrid network = this.getNetwork();
-		if( Platform.isServer() && network != null )
-		{
-			final ICraftingGrid cc = network.getCache( ICraftingGrid.class );
-			final ImmutableSet<ICraftingCPU> cpuSet = cc.getCpus();
-            // Update at least once a second
-            ++lastUpdate;
-            if (!cpuSet.equals( lastCpuSet ) || lastUpdate > 20) {
-                lastUpdate = 0;
-                lastCpuSet = cpuSet;
-                updateCpuList();
-                sendCPUs();
-            }
-		}
-
-        // Clear selection if CPU is no longer in list
-        if (selectedCpuSerial != -1) {
-            if (cpus.stream().noneMatch(c -> c.getSerial() == selectedCpuSerial)) {
-                selectCPU(-1);
-            }
-        }
-
-        // Select a suitable CPU if none is selected
-        if (selectedCpuSerial == -1) {
-            // Try busy CPUs first
-            for (CraftingCPUStatus cpu : cpus) {
-                if (cpu.getRemainingItems() > 0) {
-                    selectCPU(cpu.getSerial());
-                    break;
-                }
-            }
-            // If we couldn't find a busy one, just select the first
-            if (selectedCpuSerial == -1 && !cpus.isEmpty()) {
-                selectCPU(cpus.get(0).getSerial());
-            }
-        }
-
+        cpuTable.detectAndSendChanges(getNetwork(), crafters);
 		super.detectAndSendChanges();
 	}
 
-    private static final Comparator<CraftingCPUStatus> CPU_COMPARATOR = Comparator
-            .comparing((CraftingCPUStatus e) -> e.getName() == null || e.getName().isEmpty())
-            .thenComparing(e -> e.getName() != null ? e.getName() : "")
-            .thenComparingInt(CraftingCPUStatus::getSerial);
-
-    private void updateCpuList()
-    {
-        this.cpus.clear();
-        for (ICraftingCPU cpu : lastCpuSet)
-        {
-            int serial = getOrAssignCpuSerial(cpu);
-            this.cpus.add( new CraftingCPUStatus( cpu, serial ) );
-        }
-        this.cpus.sort(CPU_COMPARATOR);
-    }
-
-    private int getOrAssignCpuSerial( ICraftingCPU cpu )
-    {
-        return cpuSerialMap.computeIfAbsent( cpu, unused -> nextCpuSerial++ );
-    }
-
-    private boolean cpuMatches( final ICraftingCPU c )
-	{
-		return c.isBusy();
-	}
-
-	private void sendCPUs()
-	{
-        final PacketCraftingCPUsUpdate update;
-        for( final Object player : this.crafters )
-        {
-            if( player instanceof EntityPlayerMP )
-            {
-                try
-                {
-                    NetworkHandler.instance.sendTo( new PacketCraftingCPUsUpdate( this.cpus ), (EntityPlayerMP) player );
-                }
-                catch( IOException e )
-                {
-                    AELog.debug( e );
-                }
-            }
-        }
-    }
-
+    @Override
 	public void selectCPU( int serial )
 	{
-        if (Platform.isServer())
-        {
-            if( serial < -1 )
-            {
-                serial = -1;
-            }
-
-            final int searchedSerial = serial;
-            if( serial > -1 && cpus.stream().noneMatch(c -> c.getSerial() == searchedSerial) )
-            {
-                serial = -1;
-            }
-
-            ICraftingCPU newSelectedCpu = null;
-            if( serial != -1 )
-            {
-                for( ICraftingCPU cpu : lastCpuSet )
-                {
-                    if( cpuSerialMap.getOrDefault( cpu, -1 ) == serial )
-                    {
-                        newSelectedCpu = cpu;
-                        break;
-                    }
-                }
-            }
-
-            if( newSelectedCpu != getMonitor() )
-            {
-                this.selectedCpuSerial = serial;
-                setCPU( newSelectedCpu );
-            }
-        }
+        cpuTable.selectCPU( serial );
 	}
 
     public List<CraftingCPUStatus> getCPUs()
     {
-        return Collections.unmodifiableList( cpus );
-    }
-
-    public void postCPUUpdate( CraftingCPUStatus[] cpus )
-    {
-        this.cpus = Arrays.asList( cpus );
+        return cpuTable.getCPUs();
     }
 }

--- a/src/main/java/appeng/container/implementations/CraftingCPUStatus.java
+++ b/src/main/java/appeng/container/implementations/CraftingCPUStatus.java
@@ -22,6 +22,7 @@ public class CraftingCPUStatus implements Comparable<CraftingCPUStatus>
     private final int serial;
     private final long storage;
     private final long coprocessors;
+    private final boolean isBusy;
     private final long totalItems;
     private final long remainingItems;
     private final IAEItemStack crafting;
@@ -33,6 +34,7 @@ public class CraftingCPUStatus implements Comparable<CraftingCPUStatus>
         this.serial = 0;
         this.storage = 0;
         this.coprocessors = 0;
+        this.isBusy = false;
         this.totalItems = 0;
         this.remainingItems = 0;
         this.crafting = null;
@@ -43,7 +45,8 @@ public class CraftingCPUStatus implements Comparable<CraftingCPUStatus>
         this.serverCluster = cluster;
         this.name = cluster.getName();
         this.serial = serial;
-        if (cluster.isBusy())
+        this.isBusy = cluster.isBusy();
+        if (isBusy)
         {
             crafting = cluster.getFinalOutput();
             totalItems = cluster.getStartItemCount();
@@ -66,6 +69,7 @@ public class CraftingCPUStatus implements Comparable<CraftingCPUStatus>
         this.serial = i.getInteger( "serial" );
         this.storage = i.getLong("storage");
         this.coprocessors = i.getLong("coprocessors");
+        this.isBusy = i.getBoolean("isBusy");
         this.totalItems = i.getLong("totalItems");
         this.remainingItems = i.getLong("remainingItems");
         this.crafting = i.hasKey( "crafting" ) ? AEItemStack.loadItemStackFromNBT( i.getCompoundTag( "crafting" ) ) : null;
@@ -94,6 +98,7 @@ public class CraftingCPUStatus implements Comparable<CraftingCPUStatus>
         i.setInteger( "serial", serial );
         i.setLong( "storage", storage );
         i.setLong( "coprocessors", coprocessors );
+        i.setBoolean( "isBusy", isBusy );
         i.setLong( "totalItems", totalItems );
         i.setLong( "remainingItems", remainingItems );
         if (crafting != null)
@@ -159,6 +164,11 @@ public class CraftingCPUStatus implements Comparable<CraftingCPUStatus>
     public IAEItemStack getCrafting()
     {
         return crafting;
+    }
+
+    public boolean isBusy()
+    {
+        return isBusy;
     }
 
     @Override

--- a/src/main/java/appeng/container/interfaces/ICraftingCPUSelectorContainer.java
+++ b/src/main/java/appeng/container/interfaces/ICraftingCPUSelectorContainer.java
@@ -1,0 +1,6 @@
+package appeng.container.interfaces;
+
+public interface ICraftingCPUSelectorContainer
+{
+    void selectCPU(int cpu);
+}

--- a/src/main/java/appeng/core/sync/packets/PacketCraftingCPUsUpdate.java
+++ b/src/main/java/appeng/core/sync/packets/PacketCraftingCPUsUpdate.java
@@ -1,6 +1,7 @@
 package appeng.core.sync.packets;
 
 import appeng.client.gui.implementations.GuiCraftingStatus;
+import appeng.client.gui.widgets.ICraftingCPUTableHolder;
 import appeng.container.implementations.CraftingCPUStatus;
 import appeng.core.sync.AppEngPacket;
 import appeng.core.sync.network.INetworkInfo;
@@ -53,10 +54,10 @@ public class PacketCraftingCPUsUpdate extends AppEngPacket
     {
         final GuiScreen gs = Minecraft.getMinecraft().currentScreen;
 
-        if( gs instanceof GuiCraftingStatus )
+        if( gs instanceof ICraftingCPUTableHolder )
         {
-            GuiCraftingStatus gui = (GuiCraftingStatus) gs;
-            gui.postCPUUpdate( this.cpus );
+            ICraftingCPUTableHolder gui = (ICraftingCPUTableHolder) gs;
+            gui.getCPUTable().getContainer().handleCPUUpdate( this.cpus );
         }
 
     }

--- a/src/main/java/appeng/core/sync/packets/PacketValueConfig.java
+++ b/src/main/java/appeng/core/sync/packets/PacketValueConfig.java
@@ -93,11 +93,6 @@ public class PacketValueConfig extends AppEngPacket
 			final ICraftingCPUSelectorContainer qk = (ICraftingCPUSelectorContainer) c;
 			qk.selectCPU( Integer.parseInt( this.Value ) );
 		}
-		else if( this.Name.equals( "Terminal.Cpu" ) && c instanceof ContainerCraftConfirm )
-		{
-			final ContainerCraftConfirm qk = (ContainerCraftConfirm) c;
-			qk.cycleCpu( this.Value.equals( "Next" ) );
-		}
 		else if( this.Name.equals( "Terminal.Start" ) && c instanceof ContainerCraftConfirm )
 		{
 			final ContainerCraftConfirm qk = (ContainerCraftConfirm) c;

--- a/src/main/java/appeng/core/sync/packets/PacketValueConfig.java
+++ b/src/main/java/appeng/core/sync/packets/PacketValueConfig.java
@@ -26,6 +26,7 @@ import appeng.api.util.IConfigurableObject;
 import appeng.client.gui.implementations.GuiCraftingCPU;
 import appeng.container.AEBaseContainer;
 import appeng.container.implementations.*;
+import appeng.container.interfaces.ICraftingCPUSelectorContainer;
 import appeng.core.sync.AppEngPacket;
 import appeng.core.sync.network.INetworkInfo;
 import appeng.helpers.IMouseWheelItem;
@@ -87,9 +88,9 @@ public class PacketValueConfig extends AppEngPacket
 			final IMouseWheelItem si = (IMouseWheelItem) is.getItem();
 			si.onWheel( is, this.Value.equals( "WheelUp" ) );
 		}
-		else if( this.Name.equals( "Terminal.Cpu.Set" ) && c instanceof ContainerCraftingStatus )
+		else if( this.Name.equals( "CPUTable.Cpu.Set" ) && c instanceof ICraftingCPUSelectorContainer )
 		{
-			final ContainerCraftingStatus qk = (ContainerCraftingStatus) c;
+			final ICraftingCPUSelectorContainer qk = (ICraftingCPUSelectorContainer) c;
 			qk.selectCPU( Integer.parseInt( this.Value ) );
 		}
 		else if( this.Name.equals( "Terminal.Cpu" ) && c instanceof ContainerCraftConfirm )

--- a/src/main/java/appeng/integration/modules/NEIHelpers/NEIGuiHandler.java
+++ b/src/main/java/appeng/integration/modules/NEIHelpers/NEIGuiHandler.java
@@ -1,5 +1,6 @@
 package appeng.integration.modules.NEIHelpers;
 
+import appeng.client.gui.implementations.GuiCraftConfirm;
 import appeng.client.gui.implementations.GuiCraftingStatus;
 import appeng.client.gui.implementations.GuiMEMonitorable;
 import appeng.client.gui.widgets.IDropToFillTextField;
@@ -37,6 +38,8 @@ public class NEIGuiHandler extends INEIGuiAdapter
     {
         if (gui instanceof GuiCraftingStatus) {
             return ((GuiCraftingStatus) gui).hideItemPanelSlot(x, y, w, h);
+        } else if (gui instanceof GuiCraftConfirm ) {
+            return ((GuiCraftConfirm) gui).hideItemPanelSlot(x, y, w, h);
         } else if (gui instanceof GuiMEMonitorable) {
             return ((GuiMEMonitorable) gui).hideItemPanelSlot(x, y, w, h);
         }


### PR DESCRIPTION
 * Adds back cycling of the visible cpu via the big button on the screen
 * General cleanup refactor of the widget into its own separate classes
 * Adds the widget to the craft confirmation dialog too:

![Craft confirmation dialog with cpu selector widget](https://i.ibb.co/M8KJxG9/2022-08-23-19-43-26.png)

Github seems to be breaking the image so here's a direct link: <https://i.ibb.co/M8KJxG9/2022-08-23-19-43-26.png>