### PR TITLE
Add APIs to allow reuse of GUI classes in the Wireless Crafting Terminal mod

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
@@ -142,11 +142,7 @@ public class GuiCraftConfirm extends AEBaseGui implements ICraftingCPUTableHolde
 		this.selectCPU.enabled = false;
 		this.buttonList.add( this.selectCPU );
 
-		if( this.OriginalGui != null )
-		{
-			this.cancel = new GuiButton( 0, this.guiLeft + 6, this.guiTop + this.ySize - 25, 50, 20, GuiText.Cancel.getLocal() );
-		}
-
+        this.cancel = new GuiButton( 0, this.guiLeft + 6, this.guiTop + this.ySize - 25, 50, 20, GuiText.Cancel.getLocal() );
 		this.buttonList.add( this.cancel );
 	}
 
@@ -557,7 +553,7 @@ public class GuiCraftConfirm extends AEBaseGui implements ICraftingCPUTableHolde
 
 		if( btn == this.cancel )
 		{
-			NetworkHandler.instance.sendToServer( new PacketSwitchGuis( this.OriginalGui ) );
+			switchToOriginalGUI();
 		}
 
 		if( btn == this.start )
@@ -572,6 +568,12 @@ public class GuiCraftConfirm extends AEBaseGui implements ICraftingCPUTableHolde
 			}
 		}
 	}
+
+    public void switchToOriginalGUI()
+    {
+        NetworkHandler.instance.sendToServer( new PacketSwitchGuis( this.OriginalGui ) );
+    }
+
 	public ItemStack getHoveredStack() {
 		return hoveredStack;
 	}

--- a/src/main/java/appeng/container/implementations/ContainerCraftAmount.java
+++ b/src/main/java/appeng/container/implementations/ContainerCraftAmount.java
@@ -28,9 +28,13 @@ import appeng.api.storage.ITerminalHost;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.container.AEBaseContainer;
 import appeng.container.slot.SlotInaccessible;
+import appeng.core.sync.GuiBridge;
 import appeng.tile.inventory.AppEngInternalInventory;
+import appeng.util.Platform;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Slot;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
@@ -87,4 +91,9 @@ public class ContainerCraftAmount extends AEBaseContainer
 	{
 		this.itemToCreate = itemToCreate;
 	}
+
+    public void openConfirmationGUI( EntityPlayer player, TileEntity te )
+    {
+        Platform.openGUI( player, te, this.getOpenContext().getSide(), GuiBridge.GUI_CRAFTING_CONFIRM );
+    }
 }

--- a/src/main/java/appeng/container/implementations/ContainerCraftConfirm.java
+++ b/src/main/java/appeng/container/implementations/ContainerCraftConfirm.java
@@ -254,49 +254,57 @@ public class ContainerCraftConfirm extends AEBaseContainer implements ICraftingC
 
 	public void startJob()
 	{
-		GuiBridge originalGui = null;
-
-		final IActionHost ah = this.getActionHost();
-		if( ah instanceof WirelessTerminalGuiObject )
-		{
-			originalGui = GuiBridge.GUI_WIRELESS_TERM;
-		}
-
-		if( ah instanceof PartTerminal )
-		{
-			originalGui = GuiBridge.GUI_ME;
-		}
-
-		if( ah instanceof PartCraftingTerminal )
-		{
-			originalGui = GuiBridge.GUI_CRAFTING_TERMINAL;
-		}
-
-		if( ah instanceof PartPatternTerminal )
-		{
-			originalGui = GuiBridge.GUI_PATTERN_TERMINAL;
-		}
-
-		if( ah instanceof PartPatternTerminalEx)
-		{
-			originalGui = GuiBridge.GUI_PATTERN_TERMINAL_EX;
-		}
-
 		if( this.result != null && !this.isSimulation() && getGrid() != null)
 		{
 			final ICraftingGrid cc = this.getGrid().getCache( ICraftingGrid.class );
             CraftingCPUStatus selected = this.cpuTable.getSelectedCPU();
 			final ICraftingLink g = cc.submitJob( this.result, null, (selected == null) ? null : selected.getServerCluster(), true, this.getActionSrc() );
 			this.setAutoStart( false );
-			if( g != null && originalGui != null && this.getOpenContext() != null )
+			if( g != null )
 			{
-				NetworkHandler.instance.sendTo( new PacketSwitchGuis( originalGui ), (EntityPlayerMP) this.getInventoryPlayer().player );
-
-				final TileEntity te = this.getOpenContext().getTile();
-				Platform.openGUI( this.getInventoryPlayer().player, te, this.getOpenContext().getSide(), originalGui );
+				this.switchToOriginalGUI();
 			}
 		}
 	}
+
+    public void switchToOriginalGUI()
+    {
+        GuiBridge originalGui = null;
+
+        final IActionHost ah = this.getActionHost();
+        if( ah instanceof WirelessTerminalGuiObject )
+        {
+            originalGui = GuiBridge.GUI_WIRELESS_TERM;
+        }
+
+        if( ah instanceof PartTerminal )
+        {
+            originalGui = GuiBridge.GUI_ME;
+        }
+
+        if( ah instanceof PartCraftingTerminal )
+        {
+            originalGui = GuiBridge.GUI_CRAFTING_TERMINAL;
+        }
+
+        if( ah instanceof PartPatternTerminal )
+        {
+            originalGui = GuiBridge.GUI_PATTERN_TERMINAL;
+        }
+
+        if( ah instanceof PartPatternTerminalEx)
+        {
+            originalGui = GuiBridge.GUI_PATTERN_TERMINAL_EX;
+        }
+
+        if (originalGui != null && this.getOpenContext() != null)
+        {
+            NetworkHandler.instance.sendTo( new PacketSwitchGuis( originalGui ), (EntityPlayerMP) this.getInventoryPlayer().player );
+
+            final TileEntity te = this.getOpenContext().getTile();
+            Platform.openGUI( this.getInventoryPlayer().player, te, this.getOpenContext().getSide(), originalGui );
+        }
+    }
 
 	private BaseActionSource getActionSrc()
 	{

--- a/src/main/java/appeng/core/sync/packets/PacketCraftRequest.java
+++ b/src/main/java/appeng/core/sync/packets/PacketCraftRequest.java
@@ -102,9 +102,9 @@ public class PacketCraftRequest extends AppEngPacket
 					if( context != null )
 					{
 						final TileEntity te = context.getTile();
-						Platform.openGUI( player, te, cca.getOpenContext().getSide(), GuiBridge.GUI_CRAFTING_CONFIRM );
+                        cca.openConfirmationGUI( player, te );
 
-						if( player.openContainer instanceof ContainerCraftConfirm )
+                        if( player.openContainer instanceof ContainerCraftConfirm )
 						{
 							final ContainerCraftConfirm ccc = (ContainerCraftConfirm) player.openContainer;
 							ccc.setAutoStart( this.heldShift );


### PR DESCRIPTION
This is needed for a (wip) WCT refactor making it reuse ae2 classes where possible instead of copy-pasting them