### PR TITLE
Expose an "isFocused()" property to GUIs with search fields

### DIFF
--- a/src/main/java/appeng/client/gui/IFocusableGui.java
+++ b/src/main/java/appeng/client/gui/IFocusableGui.java
@@ -1,0 +1,12 @@
+package appeng.client.gui;
+
+/**
+ * Interface for exposing the isFocused() property.
+ */
+public interface IFocusableGui
+{
+    /**
+     * Gets whether the Gui has a search field in focus.
+     */
+    boolean hasFocused();
+}

--- a/src/main/java/appeng/client/gui/implementations/GuiInterfaceTerminal.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiInterfaceTerminal.java
@@ -26,6 +26,7 @@ import appeng.api.config.TerminalStyle;
 import appeng.api.util.DimensionalCoord;
 import appeng.api.util.WorldCoord;
 import appeng.client.gui.AEBaseGui;
+import appeng.client.gui.IFocusableGui;
 import appeng.client.gui.widgets.GuiImgButton;
 import appeng.client.gui.widgets.GuiScrollbar;
 import appeng.client.gui.widgets.IDropToFillTextField;
@@ -60,7 +61,7 @@ import org.lwjgl.opengl.GL11;
 import java.util.*;
 
 
-public class GuiInterfaceTerminal extends AEBaseGui implements IDropToFillTextField
+public class GuiInterfaceTerminal extends AEBaseGui implements IDropToFillTextField, IFocusableGui
 {
 
 	private static final int MAGIC_HEIGHT_NUMBER = 52 + 99;
@@ -737,4 +738,9 @@ public class GuiInterfaceTerminal extends AEBaseGui implements IDropToFillTextFi
 
 	}
 
+    @Override
+    public boolean hasFocused()
+    {
+        return searchFieldInputs.isFocused() || searchFieldOutputs.isFocused() || searchFieldNames.isFocused();
+    }
 }

--- a/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
@@ -29,6 +29,7 @@ import appeng.api.util.IConfigManager;
 import appeng.api.util.IConfigurableObject;
 import appeng.client.ActionKey;
 import appeng.client.gui.AEBaseMEGui;
+import appeng.client.gui.IFocusableGui;
 import appeng.client.gui.widgets.*;
 import appeng.client.me.InternalSlotME;
 import appeng.client.me.ItemRepo;
@@ -68,7 +69,7 @@ import java.lang.reflect.Field;
 import java.util.List;
 
 
-public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfigManagerHost, IDropToFillTextField
+public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfigManagerHost, IDropToFillTextField, IFocusableGui
 {
 
 	public static int craftingGridOffsetX;
@@ -651,4 +652,9 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
         return false;
     }
 
+    @Override
+    public boolean hasFocused()
+    {
+        return searchField.isFocused();
+    }
 }

--- a/src/main/java/appeng/client/gui/implementations/GuiOreFilter.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiOreFilter.java
@@ -1,6 +1,7 @@
 package appeng.client.gui.implementations;
 
 import appeng.client.gui.AEBaseGui;
+import appeng.client.gui.IFocusableGui;
 import appeng.client.gui.widgets.IDropToFillTextField;
 import appeng.client.gui.widgets.MEGuiTextField;
 import appeng.container.AEBaseContainer;
@@ -22,7 +23,7 @@ import net.minecraftforge.oredict.OreDictionary;
 
 import java.io.IOException;
 
-public class GuiOreFilter extends AEBaseGui implements IDropToFillTextField
+public class GuiOreFilter extends AEBaseGui implements IDropToFillTextField, IFocusableGui
 {
     private MEGuiTextField textField;
 
@@ -128,4 +129,9 @@ public class GuiOreFilter extends AEBaseGui implements IDropToFillTextField
 
 	}
 
+    @Override
+    public boolean hasFocused()
+    {
+        return textField.isFocused();
+    }
 }

--- a/src/main/java/appeng/client/gui/implementations/GuiQuartzKnife.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiQuartzKnife.java
@@ -20,6 +20,7 @@ package appeng.client.gui.implementations;
 
 
 import appeng.client.gui.AEBaseGui;
+import appeng.client.gui.IFocusableGui;
 import appeng.client.gui.widgets.IDropToFillTextField;
 import appeng.client.gui.widgets.MEGuiTextField;
 import appeng.container.implementations.ContainerQuartzKnife;
@@ -35,7 +36,7 @@ import net.minecraft.item.ItemStack;
 import java.io.IOException;
 
 
-public class GuiQuartzKnife extends AEBaseGui implements IDropToFillTextField
+public class GuiQuartzKnife extends AEBaseGui implements IDropToFillTextField, IFocusableGui
 {
 
 	private MEGuiTextField textField;
@@ -114,4 +115,9 @@ public class GuiQuartzKnife extends AEBaseGui implements IDropToFillTextField
 		textField.setText(displayName);
 	}
 
+    @Override
+    public boolean hasFocused()
+    {
+        return textField.isFocused();
+    }
 }

--- a/src/main/java/appeng/client/gui/implementations/GuiRenamer.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiRenamer.java
@@ -1,6 +1,7 @@
 package appeng.client.gui.implementations;
 
 import appeng.client.gui.AEBaseGui;
+import appeng.client.gui.IFocusableGui;
 import appeng.client.gui.widgets.IDropToFillTextField;
 import appeng.client.gui.widgets.MEGuiTextField;
 import appeng.container.implementations.ContainerRenamer;
@@ -15,7 +16,7 @@ import net.minecraft.item.ItemStack;
 
 import java.io.IOException;
 
-public class GuiRenamer extends AEBaseGui implements IDropToFillTextField
+public class GuiRenamer extends AEBaseGui implements IDropToFillTextField, IFocusableGui
 {
     private MEGuiTextField textField;
 
@@ -100,4 +101,9 @@ public class GuiRenamer extends AEBaseGui implements IDropToFillTextField
 		textField.setText(displayName);
 	}
 
+    @Override
+    public boolean hasFocused()
+    {
+        return textField.isFocused();
+    }
 }


### PR DESCRIPTION
I've been trying to fix a bug regarding FindIt (or Extra Utilities in prev versions) with the "Search in World" feature. When a search field is focused, FindIt should not be allowed to work. To accomplish this with AE2, it is necessary to figure out when any ME search bar is focused, which would let FindIt apply an extra check before sending it decides to send a ping to the server.

This commit adds an interface method, `IFocusableGui#hasFocused()`, for exposing this property.