### PR TITLE
Fix potential missed updates in the level emitter.

### DIFF
--- a/src/main/java/appeng/me/cache/NetworkMonitor.java
+++ b/src/main/java/appeng/me/cache/NetworkMonitor.java
@@ -56,7 +56,6 @@ public class NetworkMonitor<T extends IAEStack<T>> implements IMEMonitor<T>
 
 	private boolean sendEvent = false;
 	private boolean hasChanged = false;
-	private boolean ticked = true;
 	@Nonnegative
 	private int localDepthSemaphore = 0;
 
@@ -134,10 +133,9 @@ public class NetworkMonitor<T extends IAEStack<T>> implements IMEMonitor<T>
 	@Override
 	public IItemList<T> getStorageList()
 	{
-		if( hasChanged && ticked )
+		if( this.hasChanged )
 		{
 			this.hasChanged = false;
-			ticked = false;
 			this.cachedList.resetStatus();
 			return this.getAvailableItems( this.cachedList );
 		}
@@ -331,7 +329,6 @@ public class NetworkMonitor<T extends IAEStack<T>> implements IMEMonitor<T>
 
 	void onTick()
 	{
-		ticked = true;
 		if( this.sendEvent )
 		{
 			this.sendEvent = false;

--- a/src/main/java/appeng/parts/automation/PartLevelEmitter.java
+++ b/src/main/java/appeng/parts/automation/PartLevelEmitter.java
@@ -95,8 +95,8 @@ public class PartLevelEmitter extends PartUpgradeable
 	private double centerY;
 	private double centerZ;
 
-    private int lastWorkingTick = 0;
-    private boolean delayedUpdatesQueued = false;
+	private int lastWorkingTick = 0;
+	private boolean delayedUpdatesQueued = false;
 
 	@Reflected
 	public PartLevelEmitter( final ItemStack is )
@@ -108,9 +108,9 @@ public class PartLevelEmitter extends PartUpgradeable
 		this.getConfigManager().registerSetting( Settings.LEVEL_TYPE, LevelType.ITEM_LEVEL );
 		this.getConfigManager().registerSetting( Settings.CRAFT_VIA_REDSTONE, YesNo.NO );
 
-        // Workaround the emitter randomly breaking on world load
-        delayedUpdatesQueued = true;
-        lastWorkingTick = MinecraftServer.getServer().getTickCounter();
+		// Workaround the emitter randomly breaking on world load
+		delayedUpdatesQueued = true;
+		lastWorkingTick = MinecraftServer.getServer().getTickCounter();
 	}
 
 	public long getReportingValue()
@@ -380,60 +380,60 @@ public class PartLevelEmitter extends PartUpgradeable
 		}
 	}
 
-    @Override
-    public TickingRequest getTickingRequest( IGridNode node )
-    {
-        return new TickingRequest( AEConfig.instance.levelEmitterDelay / 2, AEConfig.instance.levelEmitterDelay, !delayedUpdatesQueued, true );
-    }
+	@Override
+	public TickingRequest getTickingRequest( IGridNode node )
+	{
+		return new TickingRequest( AEConfig.instance.levelEmitterDelay / 2, AEConfig.instance.levelEmitterDelay, !delayedUpdatesQueued, true );
+	}
 
-    private boolean canDoWork()
-    {
-        int currentTick = MinecraftServer.getServer().getTickCounter();
-        return ( currentTick - lastWorkingTick ) > AEConfig.instance.levelEmitterDelay;
-    }
+	private boolean canDoWork()
+	{
+		int currentTick = MinecraftServer.getServer().getTickCounter();
+		return ( currentTick - lastWorkingTick ) > AEConfig.instance.levelEmitterDelay;
+	}
 
-    @Override
-    public TickRateModulation tickingRequest( IGridNode node, int TicksSinceLastCall )
-    {
-        if( delayedUpdatesQueued && canDoWork() )
-        {
-            delayedUpdatesQueued = false;
-            lastWorkingTick = MinecraftServer.getServer().getTickCounter();
-            this.onListUpdate();
-        }
-        return delayedUpdatesQueued ? TickRateModulation.IDLE : TickRateModulation.SLEEP;
-    }
+	@Override
+	public TickRateModulation tickingRequest( IGridNode node, int TicksSinceLastCall )
+	{
+		if( delayedUpdatesQueued && canDoWork() )
+		{
+			delayedUpdatesQueued = false;
+			lastWorkingTick = MinecraftServer.getServer().getTickCounter();
+			this.onListUpdate();
+		}
+		return delayedUpdatesQueued ? TickRateModulation.IDLE : TickRateModulation.SLEEP;
+	}
 
-    @Override
-    public void postChange( final IBaseMonitor<IAEItemStack> monitor, final Iterable<IAEItemStack> change, final BaseActionSource actionSource )
-    {
-        if( canDoWork() )
-        {
-            if ( delayedUpdatesQueued )
-            {
-                delayedUpdatesQueued = false;
-                try
-                {
-                    this.getProxy().getTick().sleepDevice( this.getProxy().getNode() );
-                } catch( GridAccessException e )
-                {
-                    AELog.error( e, "Couldn't put level emitter to sleep after cancelling delayed updates" );
-                }
-            }
-            lastWorkingTick = MinecraftServer.getServer().getTickCounter();
-            this.updateReportingValue( (IMEMonitor<IAEItemStack>) monitor );
-        } else if( !delayedUpdatesQueued )
-        {
-            delayedUpdatesQueued = true;
-            try
-            {
-                this.getProxy().getTick().alertDevice( this.getProxy().getNode() );
-            } catch( GridAccessException e )
-            {
-                AELog.error( e, "Couldn't wake up level emitter for delayed updates" );
-            }
-        }
-    }
+	@Override
+	public void postChange( final IBaseMonitor<IAEItemStack> monitor, final Iterable<IAEItemStack> change, final BaseActionSource actionSource )
+	{
+		if( canDoWork() )
+		{
+			if ( delayedUpdatesQueued )
+			{
+				delayedUpdatesQueued = false;
+				try
+				{
+					this.getProxy().getTick().sleepDevice( this.getProxy().getNode() );
+				} catch( GridAccessException e )
+				{
+					AELog.error( e, "Couldn't put level emitter to sleep after cancelling delayed updates" );
+				}
+			}
+			lastWorkingTick = MinecraftServer.getServer().getTickCounter();
+			this.updateReportingValue( (IMEMonitor<IAEItemStack>) monitor );
+		} else if( !delayedUpdatesQueued )
+		{
+			delayedUpdatesQueued = true;
+			try
+			{
+				this.getProxy().getTick().alertDevice( this.getProxy().getNode() );
+			} catch( GridAccessException e )
+			{
+				AELog.error( e, "Couldn't wake up level emitter for delayed updates" );
+			}
+		}
+	}
 
 	@Override
 	public void onListUpdate()

--- a/src/main/java/appeng/parts/automation/PartLevelEmitter.java
+++ b/src/main/java/appeng/parts/automation/PartLevelEmitter.java
@@ -107,6 +107,10 @@ public class PartLevelEmitter extends PartUpgradeable
 		this.getConfigManager().registerSetting( Settings.FUZZY_MODE, FuzzyMode.IGNORE_ALL );
 		this.getConfigManager().registerSetting( Settings.LEVEL_TYPE, LevelType.ITEM_LEVEL );
 		this.getConfigManager().registerSetting( Settings.CRAFT_VIA_REDSTONE, YesNo.NO );
+
+        // Workaround the emitter randomly breaking on world load
+        delayedUpdatesQueued = true;
+        lastWorkingTick = MinecraftServer.getServer().getTickCounter();
 	}
 
 	public long getReportingValue()


### PR DESCRIPTION
This makes the emitter tickable, but sleeping most of the time so the performance impact should be minimal.
If an update is ignored due to the configured delay, ticking is scheduled to make sure that the update happens if no further network updates happen until the next delay period.

Tested in dev env, seems to make the emitter work reliably rather than fail on quick changes to item list contents.

Tested with chochom's world, bisected the failure down to #93 - not rebuilding the cache makes the emitters use stale cache on load, and then they never get updated again unless the item list changes. A more complex cache might be possible, but as-is that caching is wrong.

Fixes <https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11075>