### PR TITLE
Unbind toggle focus key by default

### DIFF
--- a/src/main/java/appeng/client/ActionKey.java
+++ b/src/main/java/appeng/client/ActionKey.java
@@ -3,7 +3,7 @@ package appeng.client;
 import org.lwjgl.input.Keyboard;
 
 public enum ActionKey {
-    TOGGLE_FOCUS(Keyboard.KEY_TAB);
+    TOGGLE_FOCUS(Keyboard.KEY_NONE);
 
     private final int defaultKey;
 


### PR DESCRIPTION
It conflicts with MP player list. Maybe we can invent better ways, but for now it's ok for next release I guess.