### PR TITLE
Performance Improvements When Channel Is Disabled

### DIFF
--- a/src/main/java/appeng/block/networking/BlockController.java
+++ b/src/main/java/appeng/block/networking/BlockController.java
@@ -35,7 +35,7 @@ public class BlockController extends AEBaseTileBlock {
         super(Material.iron);
         this.setTileEntity(TileController.class);
         this.setHardness(6);
-        this.setFeature(EnumSet.of(AEFeature.Channels));
+        this.setFeature(EnumSet.of(AEFeature.Core));
     }
 
     @Override

--- a/src/main/java/appeng/items/parts/PartType.java
+++ b/src/main/java/appeng/items/parts/PartType.java
@@ -49,14 +49,14 @@ public enum PartType {
         }
     },
 
-    CableSmart(40, EnumSet.of(AEFeature.Channels), EnumSet.noneOf(IntegrationType.class), PartCableSmart.class) {
+    CableSmart(40, EnumSet.of(AEFeature.Core), EnumSet.noneOf(IntegrationType.class), PartCableSmart.class) {
         @Override
         public boolean isCable() {
             return true;
         }
     },
 
-    CableDense(60, EnumSet.of(AEFeature.Channels), EnumSet.noneOf(IntegrationType.class), PartDenseCable.class) {
+    CableDense(60, EnumSet.of(AEFeature.Core), EnumSet.noneOf(IntegrationType.class), PartDenseCable.class) {
         @Override
         public boolean isCable() {
             return true;
@@ -64,7 +64,7 @@ public enum PartType {
     },
 
     CableDenseCovered(
-            520, EnumSet.of(AEFeature.Channels), EnumSet.noneOf(IntegrationType.class), PartDenseCableCovered.class) {
+            520, EnumSet.of(AEFeature.Core), EnumSet.noneOf(IntegrationType.class), PartDenseCableCovered.class) {
         @Override
         public boolean isCable() {
             return true;
@@ -72,20 +72,14 @@ public enum PartType {
     },
 
     CableUltraDenseCovered(
-            540,
-            EnumSet.of(AEFeature.Channels),
-            EnumSet.noneOf(IntegrationType.class),
-            PartUltraDenseCableCovered.class) {
+            540, EnumSet.of(AEFeature.Core), EnumSet.noneOf(IntegrationType.class), PartUltraDenseCableCovered.class) {
         @Override
         public boolean isCable() {
             return true;
         }
     },
     CableUltraDenseSmart(
-            560,
-            EnumSet.of(AEFeature.Channels),
-            EnumSet.noneOf(IntegrationType.class),
-            PartUltraDenseCableSmart.class) {
+            560, EnumSet.of(AEFeature.Core), EnumSet.noneOf(IntegrationType.class), PartUltraDenseCableSmart.class) {
         @Override
         public boolean isCable() {
             return true;

--- a/src/main/java/appeng/me/Grid.java
+++ b/src/main/java/appeng/me/Grid.java
@@ -25,6 +25,7 @@ import appeng.api.networking.events.MENetworkPostCacheConstruction;
 import appeng.api.util.IReadOnlyCollection;
 import appeng.core.worlddata.WorldData;
 import appeng.hooks.TickHandler;
+import appeng.me.cache.CraftingGridCache;
 import appeng.util.ReadOnlyCollection;
 import java.util.*;
 import java.util.Map.Entry;
@@ -182,7 +183,10 @@ public class Grid implements IGrid {
 
     @Override
     public MENetworkEvent postEvent(final MENetworkEvent ev) {
-        return this.eventBus.postEvent(this, ev);
+        CraftingGridCache.pauseRebuilds();
+        final MENetworkEvent ret = this.eventBus.postEvent(this, ev);
+        CraftingGridCache.unpauseRebuilds();
+        return ret;
     }
 
     @Override

--- a/src/main/java/appeng/me/GridNode.java
+++ b/src/main/java/appeng/me/GridNode.java
@@ -26,6 +26,8 @@ import appeng.api.networking.pathing.IPathingGrid;
 import appeng.api.util.AEColor;
 import appeng.api.util.DimensionalCoord;
 import appeng.api.util.IReadOnlyCollection;
+import appeng.core.AEConfig;
+import appeng.core.features.AEFeature;
 import appeng.core.worlddata.WorldData;
 import appeng.hooks.TickHandler;
 import appeng.me.pathfinding.IPathItem;
@@ -295,7 +297,12 @@ public class GridNode implements IGridNode, IPathItem {
 
     @Override
     public boolean meetsChannelRequirements() {
-        return (!this.gridProxy.getFlags().contains(GridFlags.REQUIRE_CHANNEL) || this.getUsedChannels() > 0);
+        if (this.gridProxy.getFlags().contains(GridFlags.REQUIRE_CHANNEL)) {
+            if (AEConfig.instance.isFeatureEnabled(AEFeature.Channels)) {
+                return this.getUsedChannels() > 0;
+            }
+        }
+        return true;
     }
 
     @Override

--- a/src/main/java/appeng/me/GridNode.java
+++ b/src/main/java/appeng/me/GridNode.java
@@ -30,6 +30,7 @@ import appeng.core.AEConfig;
 import appeng.core.features.AEFeature;
 import appeng.core.worlddata.WorldData;
 import appeng.hooks.TickHandler;
+import appeng.me.cache.CraftingGridCache;
 import appeng.me.pathfinding.IPathItem;
 import appeng.util.IWorldCallable;
 import appeng.util.ReadOnlyCollection;
@@ -126,6 +127,8 @@ public class GridNode implements IGridNode, IPathItem {
     public void beginVisit(final IGridVisitor g) {
         final Object tracker = new Object();
 
+        CraftingGridCache.pauseRebuilds();
+
         LinkedList<GridNode> nextRun = new LinkedList<GridNode>();
         nextRun.add(this);
 
@@ -157,6 +160,8 @@ public class GridNode implements IGridNode, IPathItem {
                 }
             }
         }
+
+        CraftingGridCache.unpauseRebuilds();
     }
 
     @Override

--- a/src/main/java/appeng/me/cache/CraftingGridCache.java
+++ b/src/main/java/appeng/me/cache/CraftingGridCache.java
@@ -96,6 +96,8 @@ public class CraftingGridCache
     private IStorageGrid storageGrid;
     private IEnergyGrid energyGrid;
     private boolean updateList = false;
+    private static int pauseRebuilds = 0;
+    private static Set<CraftingGridCache> rebuildNeeded = new HashSet<>();
 
     public CraftingGridCache(final IGrid grid) {
         this.grid = grid;
@@ -198,7 +200,28 @@ public class CraftingGridCache
         // nothing!
     }
 
+    public static void pauseRebuilds() {
+        pauseRebuilds++;
+    }
+
+    public static void unpauseRebuilds() {
+        pauseRebuilds--;
+        if (pauseRebuilds == 0 && rebuildNeeded.size() > 0) {
+            ImmutableSet<CraftingGridCache> needed = ImmutableSet.copyOf(rebuildNeeded);
+            rebuildNeeded.clear();
+            for (CraftingGridCache cache : needed) {
+                cache.updatePatterns();
+            }
+        }
+    }
+
     private void updatePatterns() {
+        // coalesce change events during a grid traversal to a single rebuild
+        if (pauseRebuilds != 0) {
+            rebuildNeeded.add(this);
+            return;
+        }
+
         final Map<IAEItemStack, ImmutableList<ICraftingPatternDetails>> oldItems = this.craftableItems;
 
         // erase list.

--- a/src/main/java/appeng/me/cache/PathGridCache.java
+++ b/src/main/java/appeng/me/cache/PathGridCache.java
@@ -77,19 +77,10 @@ public class PathGridCache implements IPathingGrid {
             this.updateNetwork = false;
             this.setChannelsInUse(0);
 
-            if (!AEConfig.instance.isFeatureEnabled(AEFeature.Channels)) {
-                final int used = this.calculateRequiredChannels();
-
-                final int nodes = this.myGrid.getNodes().size();
-                this.ticksUntilReady = 20 + Math.max(0, nodes / 100 - 20);
-                this.setChannelsByBlocks(nodes * used);
-                this.setChannelPowerUsage(this.getChannelsByBlocks() / 128.0);
-
-                this.myGrid.getPivot().beginVisit(new AdHocChannelUpdater(used));
-            } else if (this.controllerState == ControllerState.NO_CONTROLLER) {
+            if (this.controllerState == ControllerState.NO_CONTROLLER) {
                 final int requiredChannels = this.calculateRequiredChannels();
                 int used = requiredChannels;
-                if (requiredChannels > 8) {
+                if (AEConfig.instance.isFeatureEnabled(AEFeature.Channels) && requiredChannels > 8) {
                     used = 0;
                 }
 


### PR DESCRIPTION
This PR proposes changes that improve performance when the channel feature is disabled in the config.

This PR includes the following changes:
- enable various smart cables and ME controller when channel is disabled. Changes: [f29b19f](https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/commit/f29b19f0a8ee89563aa01b4fc1123e248143aa9a), [reference](https://github.com/AppliedEnergistics/Applied-Energistics-2/compare/rv6-1.12...talchas:Applied-Energistics-2:rv6-1.12)
- enable ME controller's functionality when channel is disabled. Changes: [b4cf9e4](https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/commit/b4cf9e490e18cbfd469b20fa3b1c5f1997356584), [reference 1](https://github.com/PrototypeTrousers/Applied-Energistics-2/commit/7996c44075af1521859196ddc2b02efcc62f497e#diff-d18c8cb705e28407a390ba8c707f7e9505f651376b046db2494c09a8a60424ee), [reference 2](https://github.com/PrototypeTrousers/Applied-Energistics-2/commit/b6955d42b6bb8e4bbed2b281dc362b10d84b897d)
- apply talchas's performance optimization for channel-less config, which could cut down up to 90% of calculation time when updating a huge channel-less network. Changes: [4264f92](https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/commit/4264f92e2531b437b60889db629760f0067a8e05), [reference](https://github.com/PrototypeTrousers/Applied-Energistics-2/commit/c8698fc2bfbab1d6c6f58c8b9bdfd8c177220227)

The enabling of ME controller allows the user to sever the network as they wish instead of imposing a hard limit of channels.