### PR TITLE
(#11628) Fix for crash when other mods create terminals

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
@@ -525,11 +525,19 @@ public class GuiCraftConfirm extends AEBaseGui implements ICraftingCPUTableHolde
     }
 
     public void switchToOriginalGUI() {
-        NetworkHandler.instance.sendToServer(new PacketSwitchGuis(this.OriginalGui));
+        // null if terminal is not a native AE2 terminal
+        if (this.OriginalGui != null) {
+            NetworkHandler.instance.sendToServer(new PacketSwitchGuis(this.OriginalGui));
+        }
     }
 
     public ItemStack getHoveredStack() {
         return hoveredStack;
+    }
+
+    // expose GUI buttons for mod integrations
+    public GuiButton getCancelButton() {
+        return cancel;
     }
 
     @Override


### PR DESCRIPTION
For mod interactions with AE2 (namely, Thaumic Energistics (ThE) ) the back button crashes since the OriginalGui is not explicitly listed in the constructor. This adds a null check so the implementing mod can handle the behavior instead.

This commit also adds an accessor for the cancel button so child mods can capture its behavior. This is not a functional change to AE2, but required to fix the crash in ThE and any other child mods

Tested and verified in local server.