### PR TITLE
Allow "use substitutions" patterns to request crafting of substituted components

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1661114848
+//version: 1666118075
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -8,6 +8,10 @@
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import com.matthewprenger.cursegradle.CurseArtifact
+import com.matthewprenger.cursegradle.CurseRelation
+import com.modrinth.minotaur.dependencies.ModDependency
+import com.modrinth.minotaur.dependencies.VersionDependency
 import org.gradle.internal.logging.text.StyledTextOutput.Style
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 
@@ -59,6 +63,8 @@ plugins {
     id 'de.undercouch.download' version '5.0.1'
     id 'com.github.gmazzo.buildconfig' version '3.0.3' apply false
     id 'com.diffplug.spotless' version '6.7.2' apply false
+    id 'com.modrinth.minotaur' version '2.+' apply false
+    id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
 }
 boolean settingsupdated = verifySettingsGradle()
 settingsupdated = verifyGitAttributes() || settingsupdated
@@ -127,26 +133,35 @@ checkPropertyExists("containsMixinsAndOrCoreModOnly")
 checkPropertyExists("usesShadowedDependencies")
 checkPropertyExists("developmentEnvironmentUserName")
 
-boolean noPublishedSources = project.hasProperty("noPublishedSources") ? project.noPublishedSources.toBoolean() : false
-boolean usesMixinDebug = project.hasProperty('usesMixinDebug') ?: project.usesMixins.toBoolean()
-boolean forceEnableMixins = project.hasProperty('forceEnableMixins') ? project.forceEnableMixins.toBoolean() : false
-String channel = project.hasProperty('channel') ? project.channel : 'stable'
-String mappingsVersion = project.hasProperty('mappingsVersion') ? project.mappingsVersion : '12'
+propertyDefaultIfUnset("noPublishedSources", false)
+propertyDefaultIfUnset("usesMixinDebug", project.usesMixins)
+propertyDefaultIfUnset("forceEnableMixins", false)
+propertyDefaultIfUnset("channel", "stable")
+propertyDefaultIfUnset("mappingsVersion", "12")
+propertyDefaultIfUnset("modrinthProjectId", "")
+propertyDefaultIfUnset("modrinthRelations", "")
+propertyDefaultIfUnset("curseForgeProjectId", "")
+propertyDefaultIfUnset("curseForgeRelations", "")
+
 String javaSourceDir = "src/main/java/"
 String scalaSourceDir = "src/main/scala/"
 String kotlinSourceDir = "src/main/kotlin/"
 
-String targetPackageJava = javaSourceDir + modGroup.toString().replaceAll("\\.", "/")
-String targetPackageScala = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/")
-String targetPackageKotlin = kotlinSourceDir + modGroup.toString().replaceAll("\\.", "/")
+
+final String modGroupPath = modGroup.toString().replaceAll("\\.", "/")
+final String apiPackagePath = apiPackage.toString().replaceAll("\\.", "/")
+
+String targetPackageJava = javaSourceDir + modGroupPath
+String targetPackageScala = scalaSourceDir + modGroupPath
+String targetPackageKotlin = kotlinSourceDir + modGroupPath
 if (!(getFile(targetPackageJava).exists() || getFile(targetPackageScala).exists() || getFile(targetPackageKotlin).exists())) {
     throw new GradleException("Could not resolve \"modGroup\"! Could not find " + targetPackageJava + " or " + targetPackageScala + " or " + targetPackageKotlin)
 }
 
 if (apiPackage) {
-    targetPackageJava = javaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + apiPackage.toString().replaceAll("\\.", "/")
-    targetPackageScala = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + apiPackage.toString().replaceAll("\\.", "/")
-    targetPackageKotlin = kotlinSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + apiPackage.toString().replaceAll("\\.", "/")
+    targetPackageJava = javaSourceDir + modGroupPath + "/" + apiPackagePath
+    targetPackageScala = scalaSourceDir + modGroupPath + "/" + apiPackagePath
+    targetPackageKotlin = kotlinSourceDir + modGroupPath + "/" + apiPackagePath
     if (!(getFile(targetPackageJava).exists() || getFile(targetPackageScala).exists() || getFile(targetPackageKotlin).exists())) {
         throw new GradleException("Could not resolve \"apiPackage\"! Could not find " + targetPackageJava + " or " + targetPackageScala + " or " + targetPackageKotlin)
     }
@@ -160,31 +175,36 @@ if (accessTransformersFile) {
 }
 
 if (usesMixins.toBoolean()) {
-    if (mixinsPackage.isEmpty() || mixinPlugin.isEmpty()) {
-        throw new GradleException("\"mixinPlugin\" requires \"mixinsPackage\" and \"mixinPlugin\" to be set!")
+    if (mixinsPackage.isEmpty()) {
+        throw new GradleException("\"usesMixins\" requires \"mixinsPackage\" to be set!")
     }
+    final String mixinPackagePath = mixinsPackage.toString().replaceAll("\\.", "/")
+    final String mixinPluginPath = mixinPlugin.toString().replaceAll("\\.", "/")
 
-    targetPackageJava = javaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinsPackage.toString().replaceAll("\\.", "/")
-    targetPackageScala = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinsPackage.toString().replaceAll("\\.", "/")
-    targetPackageKotlin = kotlinSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinsPackage.toString().replaceAll("\\.", "/")
+    targetPackageJava = javaSourceDir + modGroupPath + "/" + mixinPackagePath
+    targetPackageScala = scalaSourceDir + modGroupPath + "/" + mixinPackagePath
+    targetPackageKotlin = kotlinSourceDir + modGroupPath + "/" + mixinPackagePath
     if (!(getFile(targetPackageJava).exists() || getFile(targetPackageScala).exists() || getFile(targetPackageKotlin).exists())) {
         throw new GradleException("Could not resolve \"mixinsPackage\"! Could not find " + targetPackageJava + " or " + targetPackageScala + " or " + targetPackageKotlin)
     }
 
-    String targetFileJava = javaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinPlugin.toString().replaceAll("\\.", "/") + ".java"
-    String targetFileScala = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinPlugin.toString().replaceAll("\\.", "/") + ".scala"
-    String targetFileScalaJava = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinPlugin.toString().replaceAll("\\.", "/") + ".java"
-    String targetFileKotlin = kotlinSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinPlugin.toString().replaceAll("\\.", "/") + ".kt"
-    if (!(getFile(targetFileJava).exists() || getFile(targetFileScala).exists() || getFile(targetFileScalaJava).exists() || getFile(targetFileKotlin).exists())) {
-        throw new GradleException("Could not resolve \"mixinPlugin\"! Could not find " + targetFileJava + " or " + targetFileScala + " or " + targetFileScalaJava + " or " + targetFileKotlin)
+    if (!mixinPlugin.isEmpty()) {
+        String targetFileJava = javaSourceDir + modGroupPath + "/" + mixinPluginPath + ".java"
+        String targetFileScala = scalaSourceDir + modGroupPath + "/" + mixinPluginPath + ".scala"
+        String targetFileScalaJava = scalaSourceDir + modGroupPath + "/" + mixinPluginPath + ".java"
+        String targetFileKotlin = kotlinSourceDir + modGroupPath + "/" + mixinPluginPath + ".kt"
+        if (!(getFile(targetFileJava).exists() || getFile(targetFileScala).exists() || getFile(targetFileScalaJava).exists() || getFile(targetFileKotlin).exists())) {
+            throw new GradleException("Could not resolve \"mixinPlugin\"! Could not find " + targetFileJava + " or " + targetFileScala + " or " + targetFileScalaJava + " or " + targetFileKotlin)
+        }
     }
 }
 
 if (coreModClass) {
-    String targetFileJava = javaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + coreModClass.toString().replaceAll("\\.", "/") + ".java"
-    String targetFileScala = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + coreModClass.toString().replaceAll("\\.", "/") + ".scala"
-    String targetFileScalaJava = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + coreModClass.toString().replaceAll("\\.", "/") + ".java"
-    String targetFileKotlin = kotlinSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + coreModClass.toString().replaceAll("\\.", "/") + ".kt"
+    final String coreModPath = coreModClass.toString().replaceAll("\\.", "/")
+    String targetFileJava = javaSourceDir + modGroupPath + "/" + coreModPath + ".java"
+    String targetFileScala = scalaSourceDir + modGroupPath + "/" + coreModPath + ".scala"
+    String targetFileScalaJava = scalaSourceDir + modGroupPath + "/" + coreModPath + ".java"
+    String targetFileKotlin = kotlinSourceDir + modGroupPath + "/" + coreModPath + ".kt"
     if (!(getFile(targetFileJava).exists() || getFile(targetFileScala).exists() || getFile(targetFileScalaJava).exists() || getFile(targetFileKotlin).exists())) {
         throw new GradleException("Could not resolve \"coreModClass\"! Could not find " + targetFileJava + " or " + targetFileScala + " or " + targetFileScalaJava + " or " + targetFileKotlin)
     }
@@ -240,7 +260,7 @@ if (project.hasProperty("customArchiveBaseName") && customArchiveBaseName) {
 def arguments = []
 def jvmArguments = []
 
-if (usesMixins.toBoolean() || forceEnableMixins) {
+if (usesMixins.toBoolean() || forceEnableMixins.toBoolean()) {
     arguments += [
         "--tweakClass org.spongepowered.asm.launch.MixinTweaker"
     ]
@@ -305,13 +325,10 @@ repositories {
         name 'Overmind forge repo mirror'
         url 'https://gregtech.overminddl1.com/'
     }
-    if (usesMixins.toBoolean() || forceEnableMixins) {
+    if (usesMixins.toBoolean() || forceEnableMixins.toBoolean()) {
         maven {
-            name 'sponge'
-            url 'https://repo.spongepowered.org/repository/maven-public'
-        }
-        maven {
-            url 'https://jitpack.io'
+            name = "GTNH Maven"
+            url = "http://jenkins.usrv.eu:8081/nexus/content/groups/public/"
         }
     }
 }
@@ -321,19 +338,10 @@ dependencies {
         annotationProcessor('org.ow2.asm:asm-debug-all:5.0.3')
         annotationProcessor('com.google.guava:guava:24.1.1-jre')
         annotationProcessor('com.google.code.gson:gson:2.8.6')
-        annotationProcessor('org.spongepowered:mixin:0.8-SNAPSHOT')
+        annotationProcessor('org.spongepowered:mixin:0.8.5-GTNH:processor')
     }
-    if (usesMixins.toBoolean() || forceEnableMixins) {
-        // using 0.8 to workaround a issue in 0.7 which fails mixin application
-        compile('com.github.GTNewHorizons:SpongePoweredMixin:0.7.12-GTNH') {
-            // Mixin includes a lot of dependencies that are too up-to-date
-            exclude module: 'launchwrapper'
-            exclude module: 'guava'
-            exclude module: 'gson'
-            exclude module: 'commons-io'
-            exclude module: 'log4j-core'
-        }
-        compile('com.github.GTNewHorizons:SpongeMixins:1.5.0')
+    if (usesMixins.toBoolean() || forceEnableMixins.toBoolean()) {
+        compile('com.gtnewhorizon:gtnhmixins:2.0.1')
     }
 }
 
@@ -345,13 +353,18 @@ def mixinSrg = "${tasks.reobf.temporaryDir}" + File.separator + "mixins.srg"
 
 task generateAssets {
     if (usesMixins.toBoolean()) {
-        def mixinConfigFile = getFile("/src/main/resources/mixins." + modId + ".json");
+        def mixinConfigFile = getFile("/src/main/resources/mixins." + modId + ".json")
         if (!mixinConfigFile.exists()) {
+            def mixinPluginLine = ""
+            if(!mixinPlugin.isEmpty()) {
+                // We might not have a mixin plugin if we're using early/late mixins
+                mixinPluginLine +=   """\n  "plugin": "${modGroup}.${mixinPlugin}", """
+            }
+
             mixinConfigFile.text = """{
   "required": true,
-  "minVersion": "0.7.11",
-  "package": "${modGroup}.${mixinsPackage}",
-  "plugin": "${modGroup}.${mixinPlugin}",
+  "minVersion": "0.8.5-GTNH",
+  "package": "${modGroup}.${mixinsPackage}",${mixinPluginLine}
   "refmap": "${mixingConfigRefMap}",
   "target": "@env(DEFAULT)",
   "compatibilityLevel": "JAVA_8",
@@ -563,11 +576,11 @@ task devJar(type: Jar) {
 
 task apiJar(type: Jar) {
     from(sourceSets.main.allSource) {
-        include modGroup.toString().replaceAll("\\.", "/") + "/" + apiPackage.toString().replaceAll("\\.", "/") + '/**'
+        include modGroupPath + "/" + apiPackagePath + '/**'
     }
 
     from(sourceSets.main.output) {
-        include modGroup.toString().replaceAll("\\.", "/") + "/" + apiPackage.toString().replaceAll("\\.", "/") + '/**'
+        include modGroupPath + "/" + apiPackagePath + '/**'
     }
 
     from(sourceSets.main.resources.srcDirs) {
@@ -649,6 +662,113 @@ publishing {
             }
         }
     }
+}
+
+if (modrinthProjectId.size() != 0 && System.getenv("MODRINTH_TOKEN") != null) {
+    apply plugin: 'com.modrinth.minotaur'
+
+    File changelogFile = new File(System.getenv("CHANGELOG_FILE") ?: "CHANGELOG.md")
+
+    modrinth {
+        token = System.getenv("MODRINTH_TOKEN")
+        projectId = modrinthProjectId
+        versionNumber = identifiedVersion
+        versionType = identifiedVersion.endsWith("-pre") ? "beta" : "release"
+        changelog = changelogFile.exists() ? changelogFile.getText("UTF-8") : ""
+        uploadFile = jar
+        additionalFiles = getSecondaryArtifacts()
+        gameVersions = [minecraftVersion]
+        loaders = ["forge"]
+        debugMode = false
+    }
+
+    if (modrinthRelations.size() != 0) {
+        String[] deps = modrinthRelations.split(";")
+        deps.each { dep ->
+            if (dep.size() == 0) {
+                return
+            }
+            String[] parts = dep.split(":")
+            String[] qual = parts[0].split("-")
+            addModrinthDep(qual[0], qual[1], parts[1])
+        }
+    }
+    if (usesMixins.toBoolean()) {
+        addModrinthDep("required", "version", "gtnhmixins")
+    }
+    tasks.modrinth.dependsOn(build)
+    tasks.publish.dependsOn(tasks.modrinth)
+}
+
+if (curseForgeProjectId.size() != 0 && System.getenv("CURSEFORGE_TOKEN") != null) {
+    apply plugin: 'com.matthewprenger.cursegradle'
+
+    File changelogFile = new File(System.getenv("CHANGELOG_FILE") ?: "CHANGELOG.md")
+
+    curseforge {
+        apiKey = System.getenv("CURSEFORGE_TOKEN")
+        project {
+            id = curseForgeProjectId
+            if (changelogFile.exists()) {
+                changelogType = "markdown"
+                changelog = changelogFile
+            }
+            releaseType = identifiedVersion.endsWith("-pre") ? "beta" : "release"
+            addGameVersion minecraftVersion
+            addGameVersion "Forge"
+            mainArtifact jar
+            for (artifact in getSecondaryArtifacts()) addArtifact artifact
+        }
+
+        options {
+            javaIntegration = false
+            forgeGradleIntegration = false
+            debug = false
+        }
+    }
+
+    if (curseForgeRelations.size() != 0) {
+        String[] deps = curseForgeRelations.split(";")
+        deps.each { dep ->
+            if (dep.size() == 0) {
+                return
+            }
+            String[] parts = dep.split(":")
+            addCurseForgeRelation(parts[0], parts[1])
+        }
+    }
+    if (usesMixins.toBoolean()) {
+        addCurseForgeRelation("requiredDependency", "gtnhmixins")
+    }
+    tasks.curseforge.dependsOn(build)
+    tasks.publish.dependsOn(tasks.curseforge)
+}
+
+def addModrinthDep(scope, type, name) {
+    com.modrinth.minotaur.dependencies.Dependency dep;
+    if (!(scope in ["required", "optional", "incompatible", "embedded"])) {
+        throw new Exception("Invalid modrinth dependency scope: " + scope)
+    }
+    switch (type) {
+        case "project":
+            dep = new ModDependency(name, scope)
+            break
+        case "version":
+            dep = new VersionDependency(name, scope)
+            break
+        default:
+            throw new Exception("Invalid modrinth dependency type: " + type)
+    }
+    project.modrinth.dependencies.add(dep)
+}
+
+def addCurseForgeRelation(type, name) {
+    if (!(type in ["requiredDependency", "embeddedLibrary", "optionalDependency", "tool", "incompatible"])) {
+        throw new Exception("Invalid CurseForge relation type: " + type)
+    }
+    CurseArtifact artifact = project.curseforge.curseProjects[0].mainArtifact
+    CurseRelation rel = (artifact.curseRelations ?: (artifact.curseRelations = new CurseRelation()))
+    rel."$type"(name)
 }
 
 // Updating
@@ -963,6 +1083,21 @@ def checkPropertyExists(String propertyName) {
     }
 }
 
+def propertyDefaultIfUnset(String propertyName, defaultValue) {
+    if (!project.hasProperty(propertyName) || project.property(propertyName) == "") {
+        project.ext.setProperty(propertyName, defaultValue)
+    }
+}
+
 def getFile(String relativePath) {
     return new File(projectDir, relativePath)
+}
+
+def getSecondaryArtifacts() {
+    // Because noPublishedSources from the beginning of the script is somehow not visible here...
+    boolean noPublishedSources = project.hasProperty("noPublishedSources") ? project.noPublishedSources.toBoolean() : false
+    def secondaryArtifacts = [devJar]
+    if (!noPublishedSources) secondaryArtifacts += [sourcesJar]
+    if (apiPackage) secondaryArtifacts += [apiJar]
+    return secondaryArtifacts
 }

--- a/src/main/java/appeng/api/config/PatternBeSubstitution.java
+++ b/src/main/java/appeng/api/config/PatternBeSubstitution.java
@@ -1,0 +1,6 @@
+package appeng.api.config;
+
+public enum PatternBeSubstitution {
+    ENABLED,
+    DISABLED
+}

--- a/src/main/java/appeng/api/networking/crafting/ICraftingPatternDetails.java
+++ b/src/main/java/appeng/api/networking/crafting/ICraftingPatternDetails.java
@@ -80,6 +80,13 @@ public interface ICraftingPatternDetails {
     boolean canSubstitute();
 
     /**
+     * @return if this pattern can be used in autocrafting as a substitute for another item.
+     */
+    default boolean canBeSubstitute() {
+        return true;
+    }
+
+    /**
      * Allow using this INSTANCE of the pattern details to preform the crafting action with performance enhancements.
      *
      * @param craftingInv inventory

--- a/src/main/java/appeng/client/gui/implementations/GuiPatternTerm.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiPatternTerm.java
@@ -20,6 +20,7 @@ package appeng.client.gui.implementations;
 
 import appeng.api.config.ActionItems;
 import appeng.api.config.ItemSubstitution;
+import appeng.api.config.PatternBeSubstitution;
 import appeng.api.config.Settings;
 import appeng.api.storage.ITerminalHost;
 import appeng.client.gui.widgets.GuiImgButton;
@@ -51,6 +52,8 @@ public class GuiPatternTerm extends GuiMEMonitorable {
     private GuiTabButton tabProcessButton;
     private GuiImgButton substitutionsEnabledBtn;
     private GuiImgButton substitutionsDisabledBtn;
+    private GuiImgButton beSubstitutionsEnabledBtn;
+    private GuiImgButton beSubstitutionsDisabledBtn;
     private GuiImgButton encodeBtn;
     private GuiImgButton clearBtn;
     private GuiImgButton doubleBtn;
@@ -80,6 +83,10 @@ public class GuiPatternTerm extends GuiMEMonitorable {
                 NetworkHandler.instance.sendToServer(new PacketValueConfig(
                         "PatternTerminal.Substitute",
                         this.substitutionsEnabledBtn == btn ? SUBSITUTION_DISABLE : SUBSITUTION_ENABLE));
+            } else if (this.beSubstitutionsEnabledBtn == btn || this.beSubstitutionsDisabledBtn == btn) {
+                NetworkHandler.instance.sendToServer(new PacketValueConfig(
+                        "PatternTerminal.BeSubstitute",
+                        this.beSubstitutionsEnabledBtn == btn ? SUBSITUTION_DISABLE : SUBSITUTION_ENABLE));
             } else if (doubleBtn == btn) {
                 NetworkHandler.instance.sendToServer(new PacketValueConfig(
                         "PatternTerminal.Double", Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) ? "1" : "0"));
@@ -119,6 +126,16 @@ public class GuiPatternTerm extends GuiMEMonitorable {
         this.substitutionsDisabledBtn.setHalfSize(true);
         this.buttonList.add(this.substitutionsDisabledBtn);
 
+        this.beSubstitutionsEnabledBtn = new GuiImgButton(
+                this.guiLeft + 84, this.guiTop + this.ySize - 153, Settings.ACTIONS, PatternBeSubstitution.ENABLED);
+        this.beSubstitutionsEnabledBtn.setHalfSize(true);
+        this.buttonList.add(this.beSubstitutionsEnabledBtn);
+
+        this.beSubstitutionsDisabledBtn = new GuiImgButton(
+                this.guiLeft + 84, this.guiTop + this.ySize - 153, Settings.ACTIONS, PatternBeSubstitution.DISABLED);
+        this.beSubstitutionsDisabledBtn.setHalfSize(true);
+        this.buttonList.add(this.beSubstitutionsDisabledBtn);
+
         this.clearBtn = new GuiImgButton(
                 this.guiLeft + 74, this.guiTop + this.ySize - 163, Settings.ACTIONS, ActionItems.CLOSE);
         this.clearBtn.setHalfSize(true);
@@ -153,6 +170,9 @@ public class GuiPatternTerm extends GuiMEMonitorable {
             this.substitutionsEnabledBtn.visible = false;
             this.substitutionsDisabledBtn.visible = true;
         }
+
+        this.beSubstitutionsEnabledBtn.visible = this.container.beSubstitute;
+        this.beSubstitutionsDisabledBtn.visible = !this.container.beSubstitute;
 
         super.drawFG(offsetX, offsetY, mouseX, mouseY);
         this.fontRendererObj.drawString(

--- a/src/main/java/appeng/client/gui/implementations/GuiPatternTermEx.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiPatternTermEx.java
@@ -1,9 +1,6 @@
 package appeng.client.gui.implementations;
 
-import appeng.api.config.ActionItems;
-import appeng.api.config.ItemSubstitution;
-import appeng.api.config.PatternSlotConfig;
-import appeng.api.config.Settings;
+import appeng.api.config.*;
 import appeng.api.storage.ITerminalHost;
 import appeng.client.gui.widgets.GuiImgButton;
 import appeng.client.gui.widgets.GuiScrollbar;
@@ -28,6 +25,8 @@ public class GuiPatternTermEx extends GuiMEMonitorable {
 
     private GuiImgButton substitutionsEnabledBtn;
     private GuiImgButton substitutionsDisabledBtn;
+    private GuiImgButton beSubstitutionsEnabledBtn;
+    private GuiImgButton beSubstitutionsDisabledBtn;
     private GuiImgButton encodeBtn;
     private GuiImgButton clearBtn;
     private GuiImgButton invertBtn;
@@ -61,6 +60,10 @@ public class GuiPatternTermEx extends GuiMEMonitorable {
                 NetworkHandler.instance.sendToServer(new PacketValueConfig(
                         "PatternTerminalEx.Substitute",
                         this.substitutionsEnabledBtn == btn ? SUBSITUTION_DISABLE : SUBSITUTION_ENABLE));
+            } else if (this.beSubstitutionsEnabledBtn == btn || this.beSubstitutionsDisabledBtn == btn) {
+                NetworkHandler.instance.sendToServer(new PacketValueConfig(
+                        "PatternTerminalEx.BeSubstitute",
+                        this.beSubstitutionsEnabledBtn == btn ? SUBSITUTION_DISABLE : SUBSITUTION_ENABLE));
             } else if (doubleBtn == btn) {
                 NetworkHandler.instance.sendToServer(new PacketValueConfig(
                         "PatternTerminalEx.Double", Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) ? "1" : "0"));
@@ -84,6 +87,16 @@ public class GuiPatternTermEx extends GuiMEMonitorable {
                 this.guiLeft + 97, this.guiTop + this.ySize - 163, Settings.ACTIONS, ItemSubstitution.DISABLED);
         this.substitutionsDisabledBtn.setHalfSize(true);
         this.buttonList.add(this.substitutionsDisabledBtn);
+
+        this.beSubstitutionsEnabledBtn = new GuiImgButton(
+                this.guiLeft + 97, this.guiTop + this.ySize - 143, Settings.ACTIONS, PatternBeSubstitution.ENABLED);
+        this.beSubstitutionsEnabledBtn.setHalfSize(true);
+        this.buttonList.add(this.beSubstitutionsEnabledBtn);
+
+        this.beSubstitutionsDisabledBtn = new GuiImgButton(
+                this.guiLeft + 97, this.guiTop + this.ySize - 143, Settings.ACTIONS, PatternBeSubstitution.DISABLED);
+        this.beSubstitutionsDisabledBtn.setHalfSize(true);
+        this.buttonList.add(this.beSubstitutionsDisabledBtn);
 
         this.clearBtn = new GuiImgButton(
                 this.guiLeft + 87, this.guiTop + this.ySize - 163, Settings.ACTIONS, ActionItems.CLOSE);
@@ -145,6 +158,9 @@ public class GuiPatternTermEx extends GuiMEMonitorable {
             substitutionsEnabledBtn.visible = false;
             substitutionsDisabledBtn.visible = true;
         }
+
+        this.beSubstitutionsEnabledBtn.visible = this.container.beSubstitute;
+        this.beSubstitutionsDisabledBtn.visible = !this.container.beSubstitute;
 
         final int offset = container.inverted ? 18 * -3 : 0;
 

--- a/src/main/java/appeng/client/gui/widgets/GuiImgButton.java
+++ b/src/main/java/appeng/client/gui/widgets/GuiImgButton.java
@@ -289,6 +289,18 @@ public class GuiImgButton extends GuiButton implements ITooltip {
                     ItemSubstitution.DISABLED,
                     ButtonToolTips.Substitutions,
                     ButtonToolTips.SubstitutionsDescDisabled);
+            this.registerApp(
+                    2 + 1 * 16,
+                    Settings.ACTIONS,
+                    PatternBeSubstitution.ENABLED,
+                    ButtonToolTips.BeSubstitutions,
+                    ButtonToolTips.BeSubstitutionsDescEnabled);
+            this.registerApp(
+                    5 + 5 * 16,
+                    Settings.ACTIONS,
+                    PatternBeSubstitution.DISABLED,
+                    ButtonToolTips.BeSubstitutions,
+                    ButtonToolTips.BeSubstitutionsDescDisabled);
 
             this.registerApp(
                     8 + 16,

--- a/src/main/java/appeng/container/implementations/ContainerPatternTerm.java
+++ b/src/main/java/appeng/container/implementations/ContainerPatternTerm.java
@@ -75,6 +75,9 @@ public class ContainerPatternTerm extends ContainerMEMonitorable
     @GuiSync(96)
     public boolean substitute = false;
 
+    @GuiSync(95)
+    public boolean beSubstitute = true;
+
     public ContainerPatternTerm(final InventoryPlayer ip, final ITerminalHost monitorable) {
         super(ip, monitorable, false);
         this.patternTerminal = (PartPatternTerminal) monitorable;
@@ -261,6 +264,7 @@ public class ContainerPatternTerm extends ContainerMEMonitorable
         encodedValue.setTag("out", tagOut);
         encodedValue.setBoolean("crafting", this.isCraftingMode());
         encodedValue.setBoolean("substitute", this.isSubstitute());
+        encodedValue.setBoolean("beSubstitute", this.canBeSubstitute());
 
         output.setTagCompound(encodedValue);
     }
@@ -456,6 +460,7 @@ public class ContainerPatternTerm extends ContainerMEMonitorable
             }
 
             this.substitute = this.patternTerminal.isSubstitution();
+            this.beSubstitute = this.patternTerminal.canBeSubstitution();
         }
     }
 
@@ -536,8 +541,16 @@ public class ContainerPatternTerm extends ContainerMEMonitorable
         return this.substitute;
     }
 
+    private boolean canBeSubstitute() {
+        return this.beSubstitute;
+    }
+
     public void setSubstitute(final boolean substitute) {
         this.substitute = substitute;
+    }
+
+    public void setCanBeSubstitute(final boolean beSubstitute) {
+        this.beSubstitute = beSubstitute;
     }
 
     static boolean canDoubleStacks(SlotFake[] slots) {

--- a/src/main/java/appeng/container/implementations/ContainerPatternTermEx.java
+++ b/src/main/java/appeng/container/implementations/ContainerPatternTermEx.java
@@ -68,6 +68,9 @@ public class ContainerPatternTermEx extends ContainerMEMonitorable
     @GuiSync(96 + (17 - 9) + 12)
     public boolean substitute = false;
 
+    @GuiSync(96 + (17 - 9) + 13)
+    public boolean beSubstitute = false;
+
     @GuiSync(96 + (17 - 9) + 16)
     public boolean inverted;
 
@@ -211,6 +214,7 @@ public class ContainerPatternTermEx extends ContainerMEMonitorable
         encodedValue.setTag("out", tagOut);
         encodedValue.setBoolean("crafting", false);
         encodedValue.setBoolean("substitute", this.isSubstitute());
+        encodedValue.setBoolean("beSubstitute", this.canBeSubstitute());
 
         output.setTagCompound(encodedValue);
     }
@@ -294,6 +298,7 @@ public class ContainerPatternTermEx extends ContainerMEMonitorable
 
         if (Platform.isServer()) {
             substitute = patternTerminal.isSubstitution();
+            beSubstitute = patternTerminal.canBeSubstitution();
 
             if (inverted != patternTerminal.isInverted() || activePage != patternTerminal.getActivePage()) {
                 inverted = patternTerminal.isInverted();
@@ -380,8 +385,16 @@ public class ContainerPatternTermEx extends ContainerMEMonitorable
         return this.substitute;
     }
 
+    private boolean canBeSubstitute() {
+        return this.beSubstitute;
+    }
+
     public void setSubstitute(final boolean substitute) {
         this.substitute = substitute;
+    }
+
+    public void setCanBeSubstitute(final boolean beSubstitute) {
+        this.beSubstitute = beSubstitute;
     }
 
     public void setActivePage(final int activePage) {

--- a/src/main/java/appeng/core/localization/ButtonToolTips.java
+++ b/src/main/java/appeng/core/localization/ButtonToolTips.java
@@ -106,10 +106,13 @@ public enum ButtonToolTips {
     Encode,
     EncodeDescription,
     Substitutions,
+    BeSubstitutions,
     PatternSlotConfigTitle,
     PatternSlotConfigInfo,
     SubstitutionsDescEnabled,
     SubstitutionsDescDisabled,
+    BeSubstitutionsDescEnabled,
+    BeSubstitutionsDescDisabled,
     CraftOnly,
     CraftEither,
 

--- a/src/main/java/appeng/core/localization/GuiText.java
+++ b/src/main/java/appeng/core/localization/GuiText.java
@@ -104,6 +104,7 @@ public enum GuiText {
     And,
     With,
     Substitute,
+    BeSubstitute,
     Yes,
     No,
 

--- a/src/main/java/appeng/core/sync/packets/PacketValueConfig.java
+++ b/src/main/java/appeng/core/sync/packets/PacketValueConfig.java
@@ -121,6 +121,8 @@ public class PacketValueConfig extends AppEngPacket {
                 cpt.clear();
             } else if (this.Name.equals("PatternTerminal.Substitute")) {
                 cpt.getPatternTerminal().setSubstitution(this.Value.equals("1"));
+            } else if (this.Name.equals("PatternTerminal.BeSubstitute")) {
+                cpt.getPatternTerminal().setCanBeSubstitution(this.Value.equals("1"));
             } else if (this.Name.equals("PatternTerminal.Double")) {
                 cpt.doubleStacks(Value.equals("1"));
             }
@@ -134,6 +136,8 @@ public class PacketValueConfig extends AppEngPacket {
                 cpt.clear();
             } else if (this.Name.equals("PatternTerminalEx.Substitute")) {
                 cpt.getPatternTerminal().setSubstitution(this.Value.equals("1"));
+            } else if (this.Name.equals("PatternTerminalEx.BeSubstitute")) {
+                cpt.getPatternTerminal().setCanBeSubstitution(this.Value.equals("1"));
             } else if (this.Name.equals("PatternTerminalEx.Invert")) {
                 cpt.getPatternTerminal().setInverted(Value.equals("1"));
             } else if (this.Name.equals("PatternTerminalEx.Double")) {

--- a/src/main/java/appeng/crafting/CraftingTreeNode.java
+++ b/src/main/java/appeng/crafting/CraftingTreeNode.java
@@ -30,7 +30,6 @@ import appeng.me.cluster.implementations.CraftingCPUCluster;
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 import net.minecraft.world.World;
 
@@ -113,7 +112,7 @@ public class CraftingTreeNode {
             throws CraftBranchFailure, InterruptedException {
         this.job.handlePausing();
 
-        final List<IAEItemStack> thingsUsed = new LinkedList<IAEItemStack>();
+        final List<IAEItemStack> thingsUsed = new ArrayList<>();
 
         this.what.setStackSize(l);
         if (this.getSlot() >= 0 && this.parent != null && this.parent.details.isCraftable()) {

--- a/src/main/java/appeng/crafting/CraftingTreeProcess.java
+++ b/src/main/java/appeng/crafting/CraftingTreeProcess.java
@@ -20,6 +20,7 @@ package appeng.crafting;
 
 import appeng.api.AEApi;
 import appeng.api.config.Actionable;
+import appeng.api.config.FuzzyMode;
 import appeng.api.networking.crafting.ICraftingGrid;
 import appeng.api.networking.crafting.ICraftingPatternDetails;
 import appeng.api.networking.security.BaseActionSource;
@@ -237,8 +238,12 @@ public class CraftingTreeProcess {
 
         // more fuzzy!
         for (final IAEItemStack is : this.details.getCondensedOutputs()) {
-            if (is.getItem() == what2.getItem()
-                    && (is.getItem().isDamageable() || is.getItemDamage() == what2.getItemDamage())) {
+            final boolean perfectMatch = is.getItem() == what2.getItem()
+                    && (is.getItem().isDamageable() || is.getItemDamage() == what2.getItemDamage());
+            if (perfectMatch
+                    || ((this.details != null)
+                            && (this.details.canSubstitute())
+                            && is.fuzzyComparison(what2, FuzzyMode.IGNORE_ALL))) {
                 what2 = is.copy();
                 what2.setStackSize(is.getStackSize());
                 return what2;

--- a/src/main/java/appeng/helpers/PatternHelper.java
+++ b/src/main/java/appeng/helpers/PatternHelper.java
@@ -66,7 +66,7 @@ public class PatternHelper implements ICraftingPatternDetails, Comparable<Patter
         this.isCrafting = encodedValue.getBoolean("crafting");
 
         this.canSubstitute = encodedValue.getBoolean("substitute");
-        this.canBeSubstitute = encodedValue.getBoolean("be_substitute");
+        this.canBeSubstitute = encodedValue.getBoolean("beSubstitute");
         this.patternItem = is;
         this.pattern = AEItemStack.create(is);
 

--- a/src/main/java/appeng/helpers/PatternHelper.java
+++ b/src/main/java/appeng/helpers/PatternHelper.java
@@ -48,6 +48,7 @@ public class PatternHelper implements ICraftingPatternDetails, Comparable<Patter
     private final IAEItemStack[] outputs;
     private final boolean isCrafting;
     private final boolean canSubstitute;
+    private final boolean canBeSubstitute;
     private final Set<TestLookup> failCache = new HashSet<TestLookup>();
     private final Set<TestLookup> passCache = new HashSet<TestLookup>();
     private final IAEItemStack pattern;
@@ -65,6 +66,7 @@ public class PatternHelper implements ICraftingPatternDetails, Comparable<Patter
         this.isCrafting = encodedValue.getBoolean("crafting");
 
         this.canSubstitute = encodedValue.getBoolean("substitute");
+        this.canBeSubstitute = encodedValue.getBoolean("be_substitute");
         this.patternItem = is;
         this.pattern = AEItemStack.create(is);
 
@@ -218,6 +220,11 @@ public class PatternHelper implements ICraftingPatternDetails, Comparable<Patter
     @Override
     public boolean canSubstitute() {
         return this.canSubstitute;
+    }
+
+    @Override
+    public boolean canBeSubstitute() {
+        return this.canBeSubstitute;
     }
 
     @Override

--- a/src/main/java/appeng/items/misc/ItemEncodedPattern.java
+++ b/src/main/java/appeng/items/misc/ItemEncodedPattern.java
@@ -121,6 +121,7 @@ public class ItemEncodedPattern extends AEBaseItem implements ICraftingPatternIt
         final ICraftingPatternDetails details = this.getPatternForItem(stack, player.worldObj);
         final boolean isCrafting = encodedValue.getBoolean("crafting");
         final boolean substitute = encodedValue.getBoolean("substitute");
+        final boolean beSubstitute = encodedValue.getBoolean("beSubstitute");
         IAEItemStack[] inItems;
         IAEItemStack[] outItems;
 
@@ -142,7 +143,9 @@ public class ItemEncodedPattern extends AEBaseItem implements ICraftingPatternIt
         final List<String> out = new ArrayList<>();
 
         final String substitutionLabel = GuiText.Substitute.getLocal() + " ";
+        final String beSubstitutionLabel = GuiText.BeSubstitute.getLocal() + " ";
         final String canSubstitute = substitute ? GuiText.Yes.getLocal() : GuiText.No.getLocal();
+        final String canBeSubstitute = beSubstitute ? GuiText.Yes.getLocal() : GuiText.No.getLocal();
         final String label = (isCrafting ? GuiText.Crafts.getLocal() : GuiText.Creates.getLocal()) + ": ";
         final String and = " " + GuiText.And.getLocal() + " ";
         final String with = GuiText.With.getLocal() + ": ";
@@ -158,6 +161,7 @@ public class ItemEncodedPattern extends AEBaseItem implements ICraftingPatternIt
         lines.addAll(in);
 
         lines.add(substitutionLabel + canSubstitute);
+        lines.add(beSubstitutionLabel + canBeSubstitute);
     }
 
     @Override

--- a/src/main/java/appeng/parts/reporting/PartPatternTerminal.java
+++ b/src/main/java/appeng/parts/reporting/PartPatternTerminal.java
@@ -47,6 +47,7 @@ public class PartPatternTerminal extends AbstractPartTerminal {
 
     private boolean craftingMode = true;
     private boolean substitute = false;
+    private boolean beSubstitute = false;
 
     @Reflected
     public PartPatternTerminal(final ItemStack is) {
@@ -67,6 +68,7 @@ public class PartPatternTerminal extends AbstractPartTerminal {
         super.readFromNBT(data);
         this.setCraftingRecipe(data.getBoolean("craftingMode"));
         this.setSubstitution(data.getBoolean("substitute"));
+        this.setCanBeSubstitution(data.getBoolean("beSubstitute"));
         this.pattern.readFromNBT(data, "pattern");
         this.output.readFromNBT(data, "outputList");
         this.crafting.readFromNBT(data, "craftingGrid");
@@ -77,6 +79,7 @@ public class PartPatternTerminal extends AbstractPartTerminal {
         super.writeToNBT(data);
         data.setBoolean("craftingMode", this.craftingMode);
         data.setBoolean("substitute", this.substitute);
+        data.setBoolean("beSubstitute", this.beSubstitute);
         this.pattern.writeToNBT(data, "pattern");
         this.output.writeToNBT(data, "outputList");
         this.crafting.writeToNBT(data, "craftingGrid");
@@ -118,6 +121,7 @@ public class PartPatternTerminal extends AbstractPartTerminal {
                     final ICraftingPatternDetails details = pattern.getPatternForItem(
                             stack, this.getHost().getTile().getWorldObj());
                     final boolean substitute = encodedValue.getBoolean("substitute");
+                    final boolean beSubstitute = encodedValue.getBoolean("beSubstitute");
                     final boolean isCrafting = encodedValue.getBoolean("crafting");
                     final IAEItemStack[] inItems;
                     final IAEItemStack[] outItems;
@@ -133,6 +137,7 @@ public class PartPatternTerminal extends AbstractPartTerminal {
 
                     this.setCraftingRecipe(isCrafting);
                     this.setSubstitution(substitute);
+                    this.setCanBeSubstitution(beSubstitute);
 
                     for (int x = 0; x < this.crafting.getSizeInventory(); x++) {
                         this.crafting.setInventorySlotContents(x, null);
@@ -186,8 +191,16 @@ public class PartPatternTerminal extends AbstractPartTerminal {
         return this.substitute;
     }
 
+    public boolean canBeSubstitution() {
+        return this.beSubstitute;
+    }
+
     public void setSubstitution(boolean canSubstitute) {
         this.substitute = canSubstitute;
+    }
+
+    public void setCanBeSubstitution(boolean beSubstitute) {
+        this.beSubstitute = beSubstitute;
     }
 
     @Override

--- a/src/main/java/appeng/parts/reporting/PartPatternTerminalEx.java
+++ b/src/main/java/appeng/parts/reporting/PartPatternTerminalEx.java
@@ -26,6 +26,7 @@ public class PartPatternTerminalEx extends AbstractPartTerminal {
     private final AppEngInternalInventory pattern = new AppEngInternalInventory(this, 2);
 
     private boolean substitute = false;
+    private boolean beSubstitute = false;
     private boolean inverted = false;
     private int activePage = 0;
 
@@ -52,6 +53,7 @@ public class PartPatternTerminalEx extends AbstractPartTerminal {
         this.crafting.readFromNBT(data, "craftingGrid");
 
         this.setSubstitution(data.getBoolean("substitute"));
+        this.setCanBeSubstitution(data.getBoolean("beSubstitute"));
         this.setInverted(data.getBoolean("inverted"));
         this.setActivePage(data.getInteger("activePage"));
     }
@@ -65,6 +67,7 @@ public class PartPatternTerminalEx extends AbstractPartTerminal {
         this.crafting.writeToNBT(data, "craftingGrid");
 
         data.setBoolean("substitute", this.substitute);
+        data.setBoolean("beSubstitute", this.beSubstitute);
         data.setBoolean("inverted", this.inverted);
         data.setInteger("activePage", this.activePage);
     }
@@ -170,8 +173,16 @@ public class PartPatternTerminalEx extends AbstractPartTerminal {
         return this.substitute;
     }
 
+    public boolean canBeSubstitution() {
+        return this.beSubstitute;
+    }
+
     public void setSubstitution(boolean canSubstitute) {
         this.substitute = canSubstitute;
+    }
+
+    public void setCanBeSubstitution(boolean beSubstitute) {
+        this.beSubstitute = beSubstitute;
     }
 
     @Override

--- a/src/main/java/appeng/util/item/ItemList.java
+++ b/src/main/java/appeng/util/item/ItemList.java
@@ -183,6 +183,10 @@ public final class ItemList implements IItemList<IAEItemStack> {
         }
     }
 
+    public void clear() {
+        this.records.clear();
+    }
+
     private IAEItemStack putItemRecord(final IAEItemStack itemStack) {
         return this.records.put(itemStack, itemStack);
     }

--- a/src/main/resources/assets/appliedenergistics2/lang/en_US.lang
+++ b/src/main/resources/assets/appliedenergistics2/lang/en_US.lang
@@ -188,6 +188,7 @@ gui.appliedenergistics2.And=and
 gui.appliedenergistics2.Creates=Creates
 gui.appliedenergistics2.With=with
 gui.appliedenergistics2.Substitute=Using Substitutions:
+gui.appliedenergistics2.BeSubstitute=Can be a substitution:
 gui.appliedenergistics2.Yes=Yes
 gui.appliedenergistics2.No=No
 gui.appliedenergistics2.InWorldCrafting=AE2 In World Crafting
@@ -268,6 +269,9 @@ gui.tooltips.appliedenergistics2.StashDesc=Return items on the crafting grid to 
 gui.tooltips.appliedenergistics2.Substitutions=Ore-Dict Substitutions
 gui.tooltips.appliedenergistics2.SubstitutionsDescEnabled=Allow substitutions of input components.
 gui.tooltips.appliedenergistics2.SubstitutionsDescDisabled=Prevent substitutions of input components.
+gui.tooltips.appliedenergistics2.BeSubstitutions=Use as substitution
+gui.tooltips.appliedenergistics2.BeSubstitutionsDescEnabled=Allow crafting as substitutions of input components.
+gui.tooltips.appliedenergistics2.BeSubstitutionsDescDisabled=Prevent crafting as substitutions of input components.
 
 gui.tooltips.appliedenergistics2.PatternSlotConfigTitle=Switch Terminal Mode
 gui.tooltips.appliedenergistics2.PatternSlotConfigInfo=Switch slot pattern mode beween (16 -> 4) and (4 -> 16)


### PR DESCRIPTION
Previously only existing substitution items would be used, but crafting new ones wouldn't be requested.
This may not be 100% reliable when multiple alternative patterns exist and only some are craftable, as not all possible crafting permutations are explored.


![Dark oak -> dark oak planks recipe encoded](https://i.ibb.co/5MGyfNQ/2022-10-21-16-38-10.png)
![8 oak planks -> 1 chest recipe encoded](https://i.ibb.co/6RyVT4H/2022-10-21-16-38-12.png)
![Successful craft of the chest with dark oak plank substitution](https://i.ibb.co/vw6R1fx/2022-10-21-16-38-19.png)