### PR TITLE
Consistent, deterministic meteorite generation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1666827308
+//version: 1669411416
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -338,10 +338,10 @@ dependencies {
         annotationProcessor('org.ow2.asm:asm-debug-all:5.0.3')
         annotationProcessor('com.google.guava:guava:24.1.1-jre')
         annotationProcessor('com.google.code.gson:gson:2.8.6')
-        annotationProcessor('org.spongepowered:mixin:0.8.5-GTNH:processor')
+        annotationProcessor('com.gtnewhorizon:gtnhmixins:2.1.1:processor')
     }
     if (usesMixins.toBoolean() || forceEnableMixins.toBoolean()) {
-        compile('com.gtnewhorizon:gtnhmixins:2.0.1')
+        compile('com.gtnewhorizon:gtnhmixins:2.1.1')
     }
 }
 

--- a/src/main/java/appeng/debug/ToolMeteoritePlacer.java
+++ b/src/main/java/appeng/debug/ToolMeteoritePlacer.java
@@ -60,8 +60,8 @@ public class ToolMeteoritePlacer extends AEBaseItem {
             return false;
         }
 
-        final MeteoritePlacer mp = new MeteoritePlacer();
-        final boolean worked = mp.spawnMeteorite(new StandardWorld(world), x, y, z);
+        final MeteoritePlacer mp = new MeteoritePlacer(new StandardWorld(world), System.currentTimeMillis(), x, y, z);
+        final boolean worked = mp.spawnMeteoriteCenter();
 
         if (!worked) {
             player.addChatMessage(new ChatComponentText("Un-suitable Location."));

--- a/src/main/java/appeng/util/Platform.java
+++ b/src/main/java/appeng/util/Platform.java
@@ -138,6 +138,24 @@ public class Platform {
     }
 
     /**
+     * Seed a random number generator from a world seed and grid location.
+     * The grid can be any arbitrary set of coordinates, e.g. chunk position or block position.
+     * This method guarantees that for the same inputs (worldSeed, x, z) the same seed will be used.
+     *
+     * @param rng The generator to re-seed.
+     * @param worldSeed Global seed independent of the grid position
+     * @param x X location in the grid
+     * @param z Z location in the grid
+     */
+    public static void seedFromGrid(final Random rng, final long worldSeed, final long x, final long z) {
+        rng.setSeed(worldSeed);
+        final long xSeed = rng.nextLong() >> 2 + 1L;
+        final long zSeed = rng.nextLong() >> 2 + 1L;
+        final long gridSeed = (xSeed * x + zSeed * z) ^ worldSeed;
+        rng.setSeed(gridSeed);
+    }
+
+    /**
      * This displays the value for encoded longs ( double *100 )
      *
      * @param n      to be formatted long value

--- a/src/main/java/appeng/worldgen/MeteoriteWorldGen.java
+++ b/src/main/java/appeng/worldgen/MeteoriteWorldGen.java
@@ -35,65 +35,98 @@ import net.minecraft.world.chunk.IChunkProvider;
 public final class MeteoriteWorldGen implements IWorldGenerator {
     @Override
     public void generate(
-            final Random r,
+            final Random rng,
             final int chunkX,
             final int chunkZ,
-            final World w,
+            final World world,
             final IChunkProvider chunkGenerator,
             final IChunkProvider chunkProvider) {
-        if (WorldGenRegistry.INSTANCE.isWorldGenEnabled(WorldGenType.Meteorites, w)) {
+        if (WorldGenRegistry.INSTANCE.isWorldGenEnabled(WorldGenType.Meteorites, world)) {
             // Find the meteorite grid cell corresponding to this chunk
             final int gridCellSize = Math.max(8, AEConfig.instance.minMeteoriteDistance);
             final int gridCellMargin = Math.max(1, gridCellSize / 10);
             final int gridX = Math.floorDiv(chunkX << 4, gridCellSize);
             final int gridZ = Math.floorDiv(chunkZ << 4, gridCellSize);
             // Override chunk-based seed with grid-based seed, constructed in the same way as the FML-provided seed
-            final long worldSeed = w.getSeed();
-            r.setSeed(worldSeed);
-            final long xSeed = r.nextLong() >> 2 + 1L;
-            final long zSeed = r.nextLong() >> 2 + 1L;
-            final long gridSeed = (xSeed * gridX + zSeed * gridZ) ^ worldSeed;
-            r.setSeed(gridSeed);
+            Platform.seedFromGrid(rng, world.getSeed(), gridX, gridZ);
             // Calculate a deterministic position of the meteorite in the grid cell
-            final boolean spawnMeteor = r.nextDouble() < AEConfig.instance.meteoriteSpawnChance;
-            final int meteorX = (gridX * gridCellSize) + r.nextInt(gridCellSize - 2 * gridCellMargin) + gridCellMargin;
-            final int meteorZ = (gridZ * gridCellSize) + r.nextInt(gridCellSize - 2 * gridCellMargin) + gridCellMargin;
-            final int meteorDepth = 180 + r.nextInt(20);
+            final boolean spawnSurfaceMeteor = rng.nextDouble() < AEConfig.instance.meteoriteSpawnChance;
+            final int meteorX =
+                    (gridX * gridCellSize) + rng.nextInt(gridCellSize - 2 * gridCellMargin) + gridCellMargin;
+            final int meteorZ =
+                    (gridZ * gridCellSize) + rng.nextInt(gridCellSize - 2 * gridCellMargin) + gridCellMargin;
+            final int meteorDepth = 180 + rng.nextInt(20);
             final int meteorChunkX = meteorX >> 4;
             final int meteorChunkZ = meteorZ >> 4;
+            long meteorSeed = rng.nextLong();
+            while (meteorSeed == 0) {
+                meteorSeed = rng.nextLong();
+            }
             // add new meteorites?
-            if (spawnMeteor && (meteorChunkX == chunkX) && (meteorChunkZ == chunkZ)) {
-                TickHandler.INSTANCE.addCallable(w, new MeteoriteSpawn(meteorX, meteorDepth, meteorZ));
+            if ((meteorChunkX == chunkX) && (meteorChunkZ == chunkZ)) {
+                TickHandler.INSTANCE.addCallable(world, new ExistingMeteoriteSpawn(chunkX, chunkZ));
+                TickHandler.INSTANCE.addCallable(
+                        world,
+                        new MeteoriteSpawn(meteorX, spawnSurfaceMeteor ? meteorDepth : 128, meteorZ, meteorSeed));
             } else {
-                TickHandler.INSTANCE.addCallable(w, new MeteoriteSpawn(chunkX << 4, 128, chunkZ << 4));
+                TickHandler.INSTANCE.addCallable(world, new ExistingMeteoriteSpawn(chunkX, chunkZ));
             }
         } else {
-            WorldData.instance().compassData().service().updateArea(w, chunkX, chunkZ);
+            WorldData.instance().compassData().service().updateArea(world, chunkX, chunkZ);
         }
     }
 
-    private static class MeteoriteSpawn implements IWorldCallable<Object> {
+    /**
+     * Spawns blocks for meteorites that were previously generated in neighboring chunks
+     */
+    private static final class ExistingMeteoriteSpawn implements IWorldCallable<Object> {
+        private final int chunkX;
+        private final int chunkZ;
 
-        private final int x;
-        private final int z;
-        private final int depth;
-
-        public MeteoriteSpawn(final int x, final int depth, final int z) {
-            this.x = x;
-            this.z = z;
-            this.depth = depth;
+        public ExistingMeteoriteSpawn(int chunkX, int chunkZ) {
+            this.chunkX = chunkX;
+            this.chunkZ = chunkZ;
         }
 
         private Iterable<NBTTagCompound> getNearByMeteorites(final World w, final int chunkX, final int chunkZ) {
             return WorldData.instance().spawnData().getNearByMeteorites(w.provider.dimensionId, chunkX, chunkZ);
         }
 
+        @Override
+        public Object call(final World world) throws Exception {
+            // Generate blocks for nearby meteorites
+            for (final NBTTagCompound data : this.getNearByMeteorites(world, chunkX, chunkZ)) {
+                final MeteoritePlacer mp = new MeteoritePlacer(new ChunkOnly(world, chunkX, chunkZ), data);
+                mp.spawnMeteorite();
+            }
+
+            WorldData.instance().spawnData().setGenerated(world.provider.dimensionId, chunkX, chunkZ);
+            WorldData.instance().compassData().service().updateArea(world, chunkX, chunkZ);
+            return null;
+        }
+    }
+
+    private static final class MeteoriteSpawn implements IWorldCallable<Object> {
+
+        private final int x;
+        private final int z;
+        private final int depth;
+        private final long seed;
+
+        public MeteoriteSpawn(final int x, final int depth, final int z, final long seed) {
+            this.x = x;
+            this.z = z;
+            this.depth = depth;
+            this.seed = seed;
+        }
+
         private boolean tryMeteorite(final World w) {
             int depth = this.depth;
             for (int tries = 0; tries < 20; tries++) {
-                final MeteoritePlacer mp = new MeteoritePlacer();
+                final MeteoritePlacer mp =
+                        new MeteoritePlacer(new ChunkOnly(w, x >> 4, z >> 4), this.seed, x, depth, z);
 
-                if (mp.spawnMeteorite(new ChunkOnly(w, x >> 4, z >> 4), x, depth, z)) {
+                if (mp.spawnMeteoriteCenter()) {
                     final int px = x >> 4;
                     final int pz = z >> 4;
 
@@ -105,14 +138,14 @@ public final class MeteoriteWorldGen implements IWorldGenerator {
                                 }
 
                                 if (WorldData.instance().spawnData().hasGenerated(w.provider.dimensionId, cx, cz)) {
-                                    final MeteoritePlacer mp2 = new MeteoritePlacer();
-                                    mp2.spawnMeteorite(new ChunkOnly(w, cx, cz), mp.getSettings());
+                                    final MeteoritePlacer mp2 =
+                                            new MeteoritePlacer(new ChunkOnly(w, cx, cz), mp.getSettings());
+                                    mp2.spawnMeteorite();
                                 }
                             }
                         }
                     }
 
-                    System.err.printf("Meteorite spawned at %d, %d, %d\n", x, depth, z);
                     return true;
                 }
 
@@ -129,12 +162,6 @@ public final class MeteoriteWorldGen implements IWorldGenerator {
         public Object call(final World world) throws Exception {
             final int chunkX = this.x >> 4;
             final int chunkZ = this.z >> 4;
-
-            // Generate blocks for nearby meteorites
-            for (final NBTTagCompound data : this.getNearByMeteorites(world, chunkX, chunkZ)) {
-                final MeteoritePlacer mp = new MeteoritePlacer();
-                mp.spawnMeteorite(new ChunkOnly(world, chunkX, chunkZ), data);
-            }
 
             this.tryMeteorite(world);
 

--- a/src/main/java/appeng/worldgen/MeteoriteWorldGen.java
+++ b/src/main/java/appeng/worldgen/MeteoriteWorldGen.java
@@ -42,13 +42,28 @@ public final class MeteoriteWorldGen implements IWorldGenerator {
             final IChunkProvider chunkGenerator,
             final IChunkProvider chunkProvider) {
         if (WorldGenRegistry.INSTANCE.isWorldGenEnabled(WorldGenType.Meteorites, w)) {
+            // Find the meteorite grid cell corresponding to this chunk
+            final int gridCellSize = Math.max(8, AEConfig.instance.minMeteoriteDistance);
+            final int gridCellMargin = Math.max(1, gridCellSize / 10);
+            final int gridX = Math.floorDiv(chunkX << 4, gridCellSize);
+            final int gridZ = Math.floorDiv(chunkZ << 4, gridCellSize);
+            // Override chunk-based seed with grid-based seed, constructed in the same way as the FML-provided seed
+            final long worldSeed = w.getSeed();
+            r.setSeed(worldSeed);
+            final long xSeed = r.nextLong() >> 2 + 1L;
+            final long zSeed = r.nextLong() >> 2 + 1L;
+            final long gridSeed = (xSeed * gridX + zSeed * gridZ) ^ worldSeed;
+            r.setSeed(gridSeed);
+            // Calculate a deterministic position of the meteorite in the grid cell
+            final boolean spawnMeteor = r.nextDouble() < AEConfig.instance.meteoriteSpawnChance;
+            final int meteorX = (gridX * gridCellSize) + r.nextInt(gridCellSize - 2 * gridCellMargin) + gridCellMargin;
+            final int meteorZ = (gridZ * gridCellSize) + r.nextInt(gridCellSize - 2 * gridCellMargin) + gridCellMargin;
+            final int meteorDepth = 180 + r.nextInt(20);
+            final int meteorChunkX = meteorX >> 4;
+            final int meteorChunkZ = meteorZ >> 4;
             // add new meteorites?
-            if (r.nextFloat() < AEConfig.instance.meteoriteSpawnChance) {
-                final int x = r.nextInt(16) + (chunkX << 4);
-                final int z = r.nextInt(16) + (chunkZ << 4);
-
-                final int depth = 180 + r.nextInt(20);
-                TickHandler.INSTANCE.addCallable(w, new MeteoriteSpawn(x, depth, z));
+            if (spawnMeteor && (meteorChunkX == chunkX) && (meteorChunkZ == chunkZ)) {
+                TickHandler.INSTANCE.addCallable(w, new MeteoriteSpawn(meteorX, meteorDepth, meteorZ));
             } else {
                 TickHandler.INSTANCE.addCallable(w, new MeteoriteSpawn(chunkX << 4, 128, chunkZ << 4));
             }
@@ -57,46 +72,7 @@ public final class MeteoriteWorldGen implements IWorldGenerator {
         }
     }
 
-    private boolean tryMeteorite(final World w, int depth, final int x, final int z) {
-        for (int tries = 0; tries < 20; tries++) {
-            final MeteoritePlacer mp = new MeteoritePlacer();
-
-            if (mp.spawnMeteorite(new ChunkOnly(w, x >> 4, z >> 4), x, depth, z)) {
-                final int px = x >> 4;
-                final int pz = z >> 4;
-
-                for (int cx = px - 6; cx < px + 6; cx++) {
-                    for (int cz = pz - 6; cz < pz + 6; cz++) {
-                        if (w.getChunkProvider().chunkExists(cx, cz)) {
-                            if (px == cx && pz == cz) {
-                                continue;
-                            }
-
-                            if (WorldData.instance().spawnData().hasGenerated(w.provider.dimensionId, cx, cz)) {
-                                final MeteoritePlacer mp2 = new MeteoritePlacer();
-                                mp2.spawnMeteorite(new ChunkOnly(w, cx, cz), mp.getSettings());
-                            }
-                        }
-                    }
-                }
-
-                return true;
-            }
-
-            depth -= 15;
-            if (depth < 40) {
-                return false;
-            }
-        }
-
-        return false;
-    }
-
-    private Iterable<NBTTagCompound> getNearByMeteorites(final World w, final int chunkX, final int chunkZ) {
-        return WorldData.instance().spawnData().getNearByMeteorites(w.provider.dimensionId, chunkX, chunkZ);
-    }
-
-    private class MeteoriteSpawn implements IWorldCallable<Object> {
+    private static class MeteoriteSpawn implements IWorldCallable<Object> {
 
         private final int x;
         private final int z;
@@ -108,27 +84,59 @@ public final class MeteoriteWorldGen implements IWorldGenerator {
             this.depth = depth;
         }
 
+        private Iterable<NBTTagCompound> getNearByMeteorites(final World w, final int chunkX, final int chunkZ) {
+            return WorldData.instance().spawnData().getNearByMeteorites(w.provider.dimensionId, chunkX, chunkZ);
+        }
+
+        private boolean tryMeteorite(final World w) {
+            int depth = this.depth;
+            for (int tries = 0; tries < 20; tries++) {
+                final MeteoritePlacer mp = new MeteoritePlacer();
+
+                if (mp.spawnMeteorite(new ChunkOnly(w, x >> 4, z >> 4), x, depth, z)) {
+                    final int px = x >> 4;
+                    final int pz = z >> 4;
+
+                    for (int cx = px - 6; cx < px + 6; cx++) {
+                        for (int cz = pz - 6; cz < pz + 6; cz++) {
+                            if (w.getChunkProvider().chunkExists(cx, cz)) {
+                                if (px == cx && pz == cz) {
+                                    continue;
+                                }
+
+                                if (WorldData.instance().spawnData().hasGenerated(w.provider.dimensionId, cx, cz)) {
+                                    final MeteoritePlacer mp2 = new MeteoritePlacer();
+                                    mp2.spawnMeteorite(new ChunkOnly(w, cx, cz), mp.getSettings());
+                                }
+                            }
+                        }
+                    }
+
+                    System.err.printf("Meteorite spawned at %d, %d, %d\n", x, depth, z);
+                    return true;
+                }
+
+                depth -= 15;
+                if (depth < 40) {
+                    return false;
+                }
+            }
+
+            return false;
+        }
+
         @Override
         public Object call(final World world) throws Exception {
             final int chunkX = this.x >> 4;
             final int chunkZ = this.z >> 4;
 
-            double minSqDist = Double.MAX_VALUE;
-
-            // near by meteorites!
-            for (final NBTTagCompound data : MeteoriteWorldGen.this.getNearByMeteorites(world, chunkX, chunkZ)) {
+            // Generate blocks for nearby meteorites
+            for (final NBTTagCompound data : this.getNearByMeteorites(world, chunkX, chunkZ)) {
                 final MeteoritePlacer mp = new MeteoritePlacer();
                 mp.spawnMeteorite(new ChunkOnly(world, chunkX, chunkZ), data);
-
-                minSqDist = Math.min(minSqDist, mp.getSqDistance(this.x, this.z));
             }
 
-            final boolean isCluster =
-                    (minSqDist < 30 * 30) && Platform.getRandomFloat() < AEConfig.instance.meteoriteClusterChance;
-
-            if (minSqDist > AEConfig.instance.minMeteoriteDistanceSq || isCluster) {
-                MeteoriteWorldGen.this.tryMeteorite(world, this.depth, this.x, this.z);
-            }
+            this.tryMeteorite(world);
 
             WorldData.instance().spawnData().setGenerated(world.provider.dimensionId, chunkX, chunkZ);
             WorldData.instance().compassData().service().updateArea(world, chunkX, chunkZ);

--- a/src/main/java/appeng/worldgen/meteorite/Fallout.java
+++ b/src/main/java/appeng/worldgen/meteorite/Fallout.java
@@ -18,33 +18,31 @@ public class Fallout {
         return 0;
     }
 
-    public void getRandomFall(final IMeteoriteWorld w, final int x, final int y, final int z) {
-        final double a = Math.random();
-        if (a > 0.9) {
+    public void getRandomFall(final double random, final IMeteoriteWorld w, final int x, final int y, final int z) {
+        if (random > 0.9) {
             this.putter.put(w, x, y, z, Blocks.stone);
-        } else if (a > 0.8) {
+        } else if (random > 0.8) {
             this.putter.put(w, x, y, z, Blocks.cobblestone);
-        } else if (a > 0.7) {
+        } else if (random > 0.7) {
             this.putter.put(w, x, y, z, Blocks.dirt);
         } else {
             this.putter.put(w, x, y, z, Blocks.gravel);
         }
     }
 
-    public void getRandomInset(final IMeteoriteWorld w, final int x, final int y, final int z) {
-        final double a = Math.random();
-        if (a > 0.9) {
+    public void getRandomInset(final double random, final IMeteoriteWorld w, final int x, final int y, final int z) {
+        if (random > 0.9) {
             this.putter.put(w, x, y, z, Blocks.cobblestone);
-        } else if (a > 0.8) {
+        } else if (random > 0.8) {
             this.putter.put(w, x, y, z, Blocks.stone);
-        } else if (a > 0.7) {
+        } else if (random > 0.7) {
             this.putter.put(w, x, y, z, Blocks.grass);
-        } else if (a > 0.6) {
+        } else if (random > 0.6) {
             for (final Block skyStoneBlock :
                     this.skyStoneDefinition.maybeBlock().asSet()) {
                 this.putter.put(w, x, y, z, skyStoneBlock);
             }
-        } else if (a > 0.5) {
+        } else if (random > 0.5) {
             this.putter.put(w, x, y, z, Blocks.gravel);
         } else {
             this.putter.put(w, x, y, z, Platform.AIR_BLOCK);

--- a/src/main/java/appeng/worldgen/meteorite/FalloutCopy.java
+++ b/src/main/java/appeng/worldgen/meteorite/FalloutCopy.java
@@ -27,26 +27,24 @@ public class FalloutCopy extends Fallout {
     }
 
     @Override
-    public void getRandomFall(final IMeteoriteWorld w, final int x, final int y, final int z) {
-        final double a = Math.random();
-        if (a > SPECIFIED_BLOCK_THRESHOLD) {
+    public void getRandomFall(final double random, final IMeteoriteWorld w, final int x, final int y, final int z) {
+        if (random > SPECIFIED_BLOCK_THRESHOLD) {
             this.putter.put(w, x, y, z, this.block, this.meta);
         } else {
-            this.getOther(w, x, y, z, a);
+            this.getOther(w, x, y, z, random);
         }
     }
 
     public void getOther(final IMeteoriteWorld w, final int x, final int y, final int z, final double a) {}
 
     @Override
-    public void getRandomInset(final IMeteoriteWorld w, final int x, final int y, final int z) {
-        final double a = Math.random();
-        if (a > SPECIFIED_BLOCK_THRESHOLD) {
+    public void getRandomInset(final double random, final IMeteoriteWorld w, final int x, final int y, final int z) {
+        if (random > SPECIFIED_BLOCK_THRESHOLD) {
             this.putter.put(w, x, y, z, this.block, this.meta);
-        } else if (a > AIR_BLOCK_THRESHOLD) {
+        } else if (random > AIR_BLOCK_THRESHOLD) {
             this.putter.put(w, x, y, z, Platform.AIR_BLOCK);
         } else {
-            this.getOther(w, x, y, z, a - BLOCK_THRESHOLD_STEP);
+            this.getOther(w, x, y, z, random - BLOCK_THRESHOLD_STEP);
         }
     }
 }


### PR DESCRIPTION
A major refactor of meteorite generation to make them fully deterministic. Previously, they would generate in different locations depending on the chunk loading order because the generating code was checking against the list of previously generated meteors to prevent them from being too close to each other. I've replaced this with a grid-based system where in each grid cell (mindistance*mindistance from the config) a random location is picked for the meteor based on the world seed and grid cell position.

The sky stone loot is now also deterministic, previously it was using system's time-based RNG.

One downside is that meteorites no longer spawn in clusters (e.g. a meteor under another meteor), so a pack config change to the frequency of meteor spawning might be needed to make them more frequent for balance.