### PR TITLE
make substitution pattern fallback to normal pattern if no substitutable pattern matches

### DIFF
--- a/src/main/java/appeng/me/cache/CraftingGridCache.java
+++ b/src/main/java/appeng/me/cache/CraftingGridCache.java
@@ -418,11 +418,15 @@ public class CraftingGridCache
         if (details != null && details.canSubstitute()) {
             final Collection<IAEItemStack> substitutions =
                     this.craftableItemSubstitutes.findFuzzy(whatToCraft, FuzzyMode.IGNORE_ALL);
-            ImmutableList.Builder<ICraftingPatternDetails> allPatterns = ImmutableList.builder();
-            for (IAEItemStack alternative : substitutions) {
-                allPatterns.addAll(this.craftableItems.get(alternative));
+            if (substitutions.isEmpty()) {
+                res = this.craftableItems.get(whatToCraft);
+            } else {
+                ImmutableList.Builder<ICraftingPatternDetails> allPatterns = ImmutableList.builder();
+                for (IAEItemStack alternative : substitutions) {
+                    allPatterns.addAll(this.craftableItems.get(alternative));
+                }
+                res = allPatterns.build();
             }
-            res = allPatterns.build();
         } else {
             res = this.craftableItems.get(whatToCraft);
         }


### PR DESCRIPTION
fix the old save pattern and ae2fc pattern doesn't work
it conflicts what `substitution: true` actually means, since it fallback to normal patterns if no substitutable pattern matches, but currently it is the relatively proper fix
