### PR TITLE
Revert "Enable "Use as substitution" by default (#204)"

### DIFF
--- a/src/main/java/appeng/container/implementations/ContainerPatternTermEx.java
+++ b/src/main/java/appeng/container/implementations/ContainerPatternTermEx.java
@@ -69,7 +69,7 @@ public class ContainerPatternTermEx extends ContainerMEMonitorable
     public boolean substitute = false;
 
     @GuiSync(96 + (17 - 9) + 13)
-    public boolean beSubstitute = true;
+    public boolean beSubstitute = false;
 
     @GuiSync(96 + (17 - 9) + 16)
     public boolean inverted;

--- a/src/main/java/appeng/helpers/PatternHelper.java
+++ b/src/main/java/appeng/helpers/PatternHelper.java
@@ -66,11 +66,7 @@ public class PatternHelper implements ICraftingPatternDetails, Comparable<Patter
         this.isCrafting = encodedValue.getBoolean("crafting");
 
         this.canSubstitute = encodedValue.getBoolean("substitute");
-        if (encodedValue.hasKey("beSubstitute")) {
-            this.canBeSubstitute = encodedValue.getBoolean("beSubstitute");
-        } else {
-            this.canBeSubstitute = true;
-        }
+        this.canBeSubstitute = encodedValue.getBoolean("beSubstitute");
         this.patternItem = is;
         this.pattern = AEItemStack.create(is);
 

--- a/src/main/java/appeng/items/misc/ItemEncodedPattern.java
+++ b/src/main/java/appeng/items/misc/ItemEncodedPattern.java
@@ -121,12 +121,7 @@ public class ItemEncodedPattern extends AEBaseItem implements ICraftingPatternIt
         final ICraftingPatternDetails details = this.getPatternForItem(stack, player.worldObj);
         final boolean isCrafting = encodedValue.getBoolean("crafting");
         final boolean substitute = encodedValue.getBoolean("substitute");
-        final boolean beSubstitute;
-        if (encodedValue.hasKey("beSubstitute")) {
-            beSubstitute = encodedValue.getBoolean("beSubstitute");
-        } else {
-            beSubstitute = true;
-        }
+        final boolean beSubstitute = encodedValue.getBoolean("beSubstitute");
         IAEItemStack[] inItems;
         IAEItemStack[] outItems;
 

--- a/src/main/java/appeng/parts/reporting/PartPatternTerminal.java
+++ b/src/main/java/appeng/parts/reporting/PartPatternTerminal.java
@@ -47,7 +47,7 @@ public class PartPatternTerminal extends AbstractPartTerminal {
 
     private boolean craftingMode = true;
     private boolean substitute = false;
-    private boolean beSubstitute = true;
+    private boolean beSubstitute = false;
 
     @Reflected
     public PartPatternTerminal(final ItemStack is) {
@@ -68,11 +68,7 @@ public class PartPatternTerminal extends AbstractPartTerminal {
         super.readFromNBT(data);
         this.setCraftingRecipe(data.getBoolean("craftingMode"));
         this.setSubstitution(data.getBoolean("substitute"));
-        if (data.hasKey("beSubstitute")) {
-            this.setCanBeSubstitution(data.getBoolean("beSubstitute"));
-        } else {
-            this.setCanBeSubstitution(true);
-        }
+        this.setCanBeSubstitution(data.getBoolean("beSubstitute"));
         this.pattern.readFromNBT(data, "pattern");
         this.output.readFromNBT(data, "outputList");
         this.crafting.readFromNBT(data, "craftingGrid");

--- a/src/main/java/appeng/parts/reporting/PartPatternTerminalEx.java
+++ b/src/main/java/appeng/parts/reporting/PartPatternTerminalEx.java
@@ -26,7 +26,7 @@ public class PartPatternTerminalEx extends AbstractPartTerminal {
     private final AppEngInternalInventory pattern = new AppEngInternalInventory(this, 2);
 
     private boolean substitute = false;
-    private boolean beSubstitute = true;
+    private boolean beSubstitute = false;
     private boolean inverted = false;
     private int activePage = 0;
 
@@ -53,11 +53,7 @@ public class PartPatternTerminalEx extends AbstractPartTerminal {
         this.crafting.readFromNBT(data, "craftingGrid");
 
         this.setSubstitution(data.getBoolean("substitute"));
-        if (data.hasKey("beSubstitute")) {
-            this.setCanBeSubstitution(data.getBoolean("beSubstitute"));
-        } else {
-            this.setCanBeSubstitution(true);
-        }
+        this.setCanBeSubstitution(data.getBoolean("beSubstitute"));
         this.setInverted(data.getBoolean("inverted"));
         this.setActivePage(data.getInteger("activePage"));
     }

--- a/src/main/resources/assets/appliedenergistics2/lang/en_US.lang
+++ b/src/main/resources/assets/appliedenergistics2/lang/en_US.lang
@@ -271,7 +271,7 @@ gui.tooltips.appliedenergistics2.SubstitutionsDescEnabled=Allow substitutions of
 gui.tooltips.appliedenergistics2.SubstitutionsDescDisabled=Prevent substitutions of input components.
 gui.tooltips.appliedenergistics2.BeSubstitutions=Use as substitution
 gui.tooltips.appliedenergistics2.BeSubstitutionsDescEnabled=Allow crafting as substitutions of input components.
-gui.tooltips.appliedenergistics2.BeSubstitutionsDescDisabled=Prevent crafting as substitutions of input components.
+gui.tooltips.appliedenergistics2.BeSubstitutionsDescDisabled=Prevent crafting as substitutions of input components. If all patterns available for a ingredient are disabled to be substitutions, crafting simulator will treat them as if they're enabled to be substitutions.
 
 gui.tooltips.appliedenergistics2.PatternSlotConfigTitle=Switch Terminal Mode
 gui.tooltips.appliedenergistics2.PatternSlotConfigInfo=Switch slot pattern mode beween (16 -> 4) and (4 -> 16)


### PR DESCRIPTION
See https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11991

Also add tooltip to clarify current behavior with beSubstitution disabled, but I'm not good at English