### PR TITLE
Fixes interfaces not pushing big stacks to ME chests

### DIFF
--- a/src/main/java/appeng/util/InventoryAdaptor.java
+++ b/src/main/java/appeng/util/InventoryAdaptor.java
@@ -98,6 +98,7 @@ public abstract class InventoryAdaptor implements Iterable<ItemSlot> {
 
     /**
      * @param insertionMode advice implementation on how ItemStacks should be inserted. Might not has an effect whatsoever!
+     * @return The leftover itemstack, or null if everything could be inserted
      */
     public ItemStack simulateAdd(ItemStack toBeSimulated, InsertionMode insertionMode) {
         return simulateAdd(toBeSimulated);


### PR DESCRIPTION
(and potentially other inventories that limit per-operation stack size). Also because of the possibility of pushing that may need multiple ticks to complete, take that into account when requesting quicker ticking, otherwise pushing e.g. 512 wool to a ME chest takes a minute instead of seconds.