### PR TITLE
Set Parent of CoreMod

### DIFF
--- a/src/main/java/appeng/transformer/AppEngCore.java
+++ b/src/main/java/appeng/transformer/AppEngCore.java
@@ -46,6 +46,7 @@ public final class AppEngCore extends DummyModContainer implements IFMLLoadingPl
         this.metadata.url = "http://ae2.ae-mod.info";
         this.metadata.logoFile = "assets/appliedenergistics2/meta/logo.png";
         this.metadata.description = "Embedded Coremod for Applied Energistics 2";
+        this.metadata.parent = "appliedenergistics2";
     }
 
     @EventHandler


### PR DESCRIPTION
The coremod won't be listed as a sepperate jar anymore but as a child mod. Example from Aroma1997Core:
![grafik](https://user-images.githubusercontent.com/35727266/212753499-25aa236d-7ca3-4e4f-9534-a2e586ae686a.png)