### PR TITLE
missing items always in the top

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
@@ -44,10 +44,7 @@ import appeng.util.Platform;
 import appeng.util.ReadableNumberConverter;
 import com.google.common.base.Joiner;
 import java.text.NumberFormat;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
@@ -424,8 +421,25 @@ public class GuiCraftConfirm extends AEBaseGui implements ICraftingCPUTableHolde
                 is.setStackSize(amt);
             }
         }
-
+        this.sortItems();
         this.setScrollBar();
+    }
+
+    Comparator<IAEItemStack> comparator = (i1, i2) -> {
+        if (missing.findPrecise(i1) != null) {
+            if (missing.findPrecise(i2) != null) return 0;
+            return -1;
+        } else if (missing.findPrecise(i2) != null) {
+            return 1;
+        } else {
+            return 0;
+        }
+    };
+
+    private void sortItems() {
+        if (!this.missing.isEmpty()) {
+            this.visual.sort(comparator);
+        }
     }
 
     private void handleInput(final IItemList<IAEItemStack> s, final IAEItemStack l) {


### PR DESCRIPTION
crafting preview screen missing items always in the top
| Before | After|
| ------- | ------- |
|![image](https://user-images.githubusercontent.com/33802162/213635595-d5028a7d-4d91-45e7-b43b-01d41a6f1196.png)|![image](https://user-images.githubusercontent.com/33802162/213635641-ce090f55-8858-49e5-b9e0-deb42df499b4.png)|

link https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/66