### PR TITLE
More calculator fixes

### DIFF
--- a/src/functionalTest/java/appeng/test/CraftingV2Tests.java
+++ b/src/functionalTest/java/appeng/test/CraftingV2Tests.java
@@ -218,4 +218,23 @@ public class CraftingV2Tests {
                 AEItemStack.create(new ItemStack(Blocks.planks, 0, 1)).setCountRequestable(4),
                 AEItemStack.create(new ItemStack(Blocks.chest, 0)).setCountRequestable(1));
     }
+
+    @Test
+    void canHandleCyclicalPatterns() {
+        MockAESystem aeSystem = new MockAESystem(dummyWorld);
+        aeSystem.addStoredItem(new ItemStack(Blocks.log, 4, 0));
+        aeSystem.newProcessingPattern()
+                .addInput(new ItemStack(Blocks.log, 1))
+                .addOutput(new ItemStack(Blocks.planks, 4))
+                .buildAndAdd();
+        aeSystem.newProcessingPattern()
+                .addInput(new ItemStack(Blocks.planks, 4))
+                .addOutput(new ItemStack(Blocks.log, 1))
+                .buildAndAdd();
+        for (int plankAmount = 1; plankAmount < 64; plankAmount++) {
+            final CraftingJobV2 job = aeSystem.makeCraftingJob(new ItemStack(Blocks.planks, plankAmount));
+            simulateJobAndCheck(job, SIMPLE_SIMULATION_TIMEOUT_MS);
+            assertEquals(job.isSimulation(), plankAmount > 16);
+        }
+    }
 }

--- a/src/functionalTest/java/appeng/test/CraftingV2Tests.java
+++ b/src/functionalTest/java/appeng/test/CraftingV2Tests.java
@@ -237,4 +237,19 @@ public class CraftingV2Tests {
             assertEquals(job.isSimulation(), plankAmount > 16);
         }
     }
+
+    @Test
+    void strictNamedItems() {
+        MockAESystem aeSystem = new MockAESystem(dummyWorld);
+        aeSystem.addStoredItem(new ItemStack(Blocks.log, 4, 0).setStackDisplayName("Named Log"));
+        aeSystem.newProcessingPattern()
+                .addInput(new ItemStack(Blocks.log, 1))
+                .addOutput(new ItemStack(Blocks.planks, 4))
+                .allowBeingASubstitute()
+                .buildAndAdd();
+
+        final CraftingJobV2 job = aeSystem.makeCraftingJob(new ItemStack(Blocks.planks, 1));
+        simulateJobAndCheck(job, SIMPLE_SIMULATION_TIMEOUT_MS);
+        assertEquals(true, job.isSimulation()); // Don't use renamed items
+    }
 }

--- a/src/functionalTest/java/appeng/test/mockme/MockAESystem.java
+++ b/src/functionalTest/java/appeng/test/mockme/MockAESystem.java
@@ -82,8 +82,18 @@ public class MockAESystem implements ICellProvider {
             return this;
         }
 
+        public PatternBuilder allowUsingSubstitutes(boolean allow) {
+            this.canUseSubstitutes = allow;
+            return this;
+        }
+
         public PatternBuilder allowBeingASubstitute() {
             this.canBeSubstitute = true;
+            return this;
+        }
+
+        public PatternBuilder allowBeingASubstitute(boolean allow) {
+            this.canBeSubstitute = allow;
             return this;
         }
 

--- a/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
@@ -62,7 +62,7 @@ public class GuiCraftConfirm extends AEBaseGui implements ICraftingCPUTableHolde
     private final IItemList<IAEItemStack> pending = AEApi.instance().storage().createItemList();
     private final IItemList<IAEItemStack> missing = AEApi.instance().storage().createItemList();
 
-    private final List<IAEItemStack> visual = new ArrayList<IAEItemStack>();
+    private final List<IAEItemStack> visual = new ArrayList<>();
 
     private GuiBridge OriginalGui;
     private GuiButton cancel;

--- a/src/main/java/appeng/crafting/v2/CraftingContext.java
+++ b/src/main/java/appeng/crafting/v2/CraftingContext.java
@@ -8,18 +8,26 @@ import appeng.api.networking.storage.IStorageGrid;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IAEStack;
 import appeng.api.storage.data.IItemList;
+import appeng.container.ContainerNull;
 import appeng.crafting.MECraftingInventory;
 import appeng.crafting.v2.resolvers.CraftingTask;
 import appeng.me.cluster.implementations.CraftingCPUCluster;
+import appeng.util.Platform;
+import appeng.util.item.AEItemStack;
 import appeng.util.item.OreListMultiMap;
 import com.google.common.collect.ClassToInstanceMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.MutableClassToInstanceMap;
+import cpw.mods.fml.common.FMLCommonHandler;
 import java.util.*;
 import java.util.function.Supplier;
 import javax.annotation.Nonnull;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
+import net.minecraft.world.WorldServer;
 
 /**
  * A bundle of state for the crafting operation like the ME grid, who requested crafting, etc.
@@ -74,6 +82,7 @@ public final class CraftingContext {
     private final ImmutableMap<IAEItemStack, ImmutableList<ICraftingPatternDetails>> availablePatterns;
     private final Map<IAEItemStack, List<ICraftingPatternDetails>> precisePatternCache = new HashMap<>();
     private final OreListMultiMap<ICraftingPatternDetails> fuzzyPatternCache = new OreListMultiMap<>();
+    private final IdentityHashMap<ICraftingPatternDetails, Boolean> isPatternComplexCache = new IdentityHashMap<>();
     private final ClassToInstanceMap<Object> userCaches = MutableClassToInstanceMap.create();
 
     public CraftingContext(@Nonnull World world, @Nonnull IGrid meGrid, @Nonnull BaseActionSource actionSource) {
@@ -139,6 +148,73 @@ public final class CraftingContext {
             fuzzyPatternCache.freeze();
         }
         return fuzzyPatternCache.get(stack);
+    }
+
+    /**
+     * @return Whether the pattern has complex behavior leaving items in the crafting grid, requiring 1-by-1 simulation using a fake player
+     */
+    public boolean isPatternComplex(@Nonnull ICraftingPatternDetails pattern) {
+        if (!pattern.isCraftable()) {
+            return false;
+        }
+        final Boolean cached = isPatternComplexCache.get(pattern);
+        if (cached != null) {
+            return cached;
+        }
+
+        final IAEItemStack[] inputs = pattern.getInputs();
+        final IAEItemStack[] mcOutputs = simulateComplexCrafting(inputs, pattern);
+
+        final boolean isComplex = Arrays.stream(mcOutputs).anyMatch(Objects::nonNull);
+        isPatternComplexCache.put(pattern, isComplex);
+        return isComplex;
+    }
+
+    /**
+     * Simulates doing 1 craft with a crafting table.
+     * @param inputSlots 3x3 crafting matrix contents
+     * @return What remains in the 3x3 crafting matrix
+     */
+    public IAEItemStack[] simulateComplexCrafting(IAEItemStack[] inputSlots, ICraftingPatternDetails pattern) {
+        if (inputSlots.length > 9) {
+            throw new IllegalArgumentException(inputSlots.length + " slots supplied to a simulated crafting task");
+        }
+        final InventoryCrafting simulatedWorkbench = new InventoryCrafting(new ContainerNull(), 3, 3);
+        for (int i = 0; i < inputSlots.length; i++) {
+            simulatedWorkbench.setInventorySlotContents(i, inputSlots[i] == null ? null : inputSlots[i].getItemStack());
+        }
+        if (world instanceof WorldServer) {
+            FMLCommonHandler.instance()
+                    .firePlayerCraftingEvent(
+                            Platform.getPlayer((WorldServer) world),
+                            pattern.getOutput(simulatedWorkbench, world),
+                            simulatedWorkbench);
+        }
+        IAEItemStack[] output = new IAEItemStack[9];
+        for (int i = 0; i < output.length; i++) {
+            ItemStack mcOut = simulatedWorkbench.getStackInSlot(i);
+            if (mcOut == null || mcOut.getItem() == null || mcOut.stackSize <= 0) {
+                output[i] = null;
+                continue;
+            }
+            Item item = mcOut.getItem();
+            if (item.hasContainerItem(mcOut)) {
+                ItemStack container = item.getContainerItem(mcOut);
+                if (container == null || container.stackSize <= 0) {
+                    output[i] = null;
+                } else {
+                    output[i] = AEItemStack.create(container);
+                }
+            } else {
+                mcOut.stackSize -= 1;
+                if (mcOut.stackSize <= 0) {
+                    output[i] = null;
+                } else {
+                    output[i] = AEItemStack.create(mcOut);
+                }
+            }
+        }
+        return output;
     }
 
     /**

--- a/src/main/java/appeng/crafting/v2/CraftingRequest.java
+++ b/src/main/java/appeng/crafting/v2/CraftingRequest.java
@@ -1,11 +1,14 @@
 package appeng.crafting.v2;
 
+import appeng.api.networking.crafting.ICraftingPatternDetails;
 import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IAEStack;
 import appeng.crafting.v2.resolvers.CraftingTask;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 import org.apache.commons.lang3.tuple.MutablePair;
 
@@ -55,6 +58,11 @@ public class CraftingRequest<StackType extends IAEStack<StackType>> {
      * If the item had to be simulated (there was not enough ingredients in the system to fulfill this request in any way)
      */
     public volatile boolean wasSimulated = false;
+
+    /**
+     * A set of all patterns used to resolve this request and its parents, used for avoiding infinite recursion.
+     */
+    public final Set<ICraftingPatternDetails> patternParents = new HashSet<>();
 
     /**
      * @param stack                  The item/fluid and stack to request

--- a/src/main/java/appeng/crafting/v2/CraftingRequest.java
+++ b/src/main/java/appeng/crafting/v2/CraftingRequest.java
@@ -10,7 +10,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
-import org.apache.commons.lang3.tuple.MutablePair;
 
 /**
  * A single requested stack (item or fluid) to craft, e.g. 32x Torches
@@ -33,6 +32,16 @@ public class CraftingRequest<StackType extends IAEStack<StackType>> {
         ACCEPT_FUZZY
     }
 
+    public static class UsedResolverEntry {
+        public final CraftingTask task;
+        public final IAEStack<?> resolvedStack;
+
+        public UsedResolverEntry(CraftingTask task, IAEStack<?> resolvedStack) {
+            this.task = task;
+            this.resolvedStack = resolvedStack;
+        }
+    }
+
     public final Class<StackType> stackTypeClass;
     /**
      * An item/fluid + count representing how many need to be crafted
@@ -42,7 +51,7 @@ public class CraftingRequest<StackType extends IAEStack<StackType>> {
     public final SubstitutionMode substitutionMode;
     public final Predicate<StackType> acceptableSubstituteFn;
     // (task, amount fulfilled by task)
-    public final List<MutablePair<CraftingTask, Long>> usedResolvers = new ArrayList<>();
+    public final List<UsedResolverEntry> usedResolvers = new ArrayList<>();
     /**
      * Whether this request and its children can be fulfilled by simulations
      */
@@ -135,7 +144,7 @@ public class CraftingRequest<StackType extends IAEStack<StackType>> {
         this.untransformedByteCost += input.getStackSize();
         this.byteCost = CraftingCalculations.adjustByteCost(this, untransformedByteCost);
         this.remainingToProcess -= input.getStackSize();
-        this.usedResolvers.add(MutablePair.of(origin, input.getStackSize()));
+        this.usedResolvers.add(new UsedResolverEntry(origin, input.copy()));
     }
 
     /**
@@ -143,17 +152,17 @@ public class CraftingRequest<StackType extends IAEStack<StackType>> {
      */
     public void partialRefund(CraftingContext context, long amount) {
         long remainingTaskAmount = amount;
-        for (MutablePair<CraftingTask, Long> task : usedResolvers) {
+        for (UsedResolverEntry resolver : usedResolvers) {
             if (remainingTaskAmount <= 0) {
                 break;
             }
-            if (task.getRight() <= 0) {
+            if (resolver.resolvedStack.getStackSize() <= 0) {
                 continue;
             }
-            final long taskRefunded =
-                    task.getLeft().partialRefund(context, Math.min(remainingTaskAmount, task.getRight()));
+            final long taskRefunded = resolver.task.partialRefund(
+                    context, Math.min(remainingTaskAmount, resolver.resolvedStack.getStackSize()));
             remainingTaskAmount -= taskRefunded;
-            task.setRight(task.getRight() - taskRefunded);
+            resolver.resolvedStack.setStackSize(resolver.resolvedStack.getStackSize() - taskRefunded);
         }
         if (remainingTaskAmount < 0) {
             throw new IllegalStateException("Refunds resulted in a negative amount of an item for request " + this);
@@ -172,13 +181,35 @@ public class CraftingRequest<StackType extends IAEStack<StackType>> {
     }
 
     public void fullRefund(CraftingContext context) {
-        for (MutablePair<CraftingTask, Long> task : usedResolvers) {
-            task.getLeft().fullRefund(context);
+        for (UsedResolverEntry resolver : usedResolvers) {
+            resolver.task.fullRefund(context);
         }
         this.remainingToProcess = 0;
         this.untransformedByteCost = 0;
         this.byteCost = CraftingCalculations.adjustByteCost(this, untransformedByteCost);
         this.stack.setStackSize(0);
         this.usedResolvers.clear();
+    }
+
+    /**
+     * Gets the resolved item stack.
+     * @throws IllegalStateException if multiple item types were used to resolve the request
+     */
+    public IAEStack<?> getOneResolvedType() {
+        IAEStack<?> found = null;
+        for (UsedResolverEntry resolver : usedResolvers) {
+            if (resolver.resolvedStack.getStackSize() <= 0) {
+                continue;
+            }
+            if (found == null) {
+                found = resolver.resolvedStack.copy();
+            } else {
+                throw new IllegalStateException("Found multiple item types resolving " + this);
+            }
+        }
+        if (found == null) {
+            throw new IllegalStateException("Found no resolution for " + this);
+        }
+        return found;
     }
 }

--- a/src/main/java/appeng/crafting/v2/resolvers/CraftableItemResolver.java
+++ b/src/main/java/appeng/crafting/v2/resolvers/CraftableItemResolver.java
@@ -32,6 +32,7 @@ public class CraftableItemResolver implements CraftingRequestResolver<IAEItemSta
     public static class CraftFromPatternTask extends CraftingTask<IAEItemStack> {
         public final ICraftingPatternDetails pattern;
         public final boolean allowSimulation;
+        public final boolean isComplex;
         // Inputs needed to kickstart recursive crafting
         protected final IAEItemStack[] patternRecursionInputs;
         // With the recursive part subtracted
@@ -40,6 +41,7 @@ public class CraftableItemResolver implements CraftingRequestResolver<IAEItemSta
         protected final IAEItemStack[] patternOutputs;
         protected final IAEItemStack matchingOutput;
         protected final Map<IAEItemStack, RequestAndPerCraftAmount> childRequests = new HashMap<>();
+        protected final List<CraftingRequest> complexRequestPerSlot = new ArrayList<>();
         protected final Map<IAEItemStack, CraftingRequest<IAEItemStack>> childRecursionRequests = new HashMap<>();
         // byproduct injected -> amount per craft
         protected final IdentityHashMap<IAEItemStack, Long> byproducts = new IdentityHashMap<>();
@@ -54,10 +56,12 @@ public class CraftableItemResolver implements CraftingRequestResolver<IAEItemSta
                 CraftingRequest<IAEItemStack> request,
                 ICraftingPatternDetails pattern,
                 int priority,
-                boolean allowSimulation) {
+                boolean allowSimulation,
+                boolean isComplex) {
             super(request, priority);
             this.pattern = pattern;
             this.allowSimulation = allowSimulation;
+            this.isComplex = isComplex;
 
             HashBasedItemList pInputs = new HashBasedItemList();
             HashBasedItemList pOutputs = new HashBasedItemList();
@@ -118,6 +122,14 @@ public class CraftableItemResolver implements CraftingRequestResolver<IAEItemSta
             return true;
         }
 
+        public boolean isValidSubstitute(IAEItemStack reference, IAEItemStack stack, World world, int slot) {
+            if (!pattern.isCraftable()) {
+                return true;
+            }
+            IAEItemStack[] rawInputs = pattern.getInputs();
+            return pattern.isValidItemForSlot(slot, stack.getItemStack(), world);
+        }
+
         @Override
         public StepOutput calculateOneStep(CraftingContext context) {
             if (request.remainingToProcess <= 0) {
@@ -127,7 +139,8 @@ public class CraftableItemResolver implements CraftingRequestResolver<IAEItemSta
             final boolean canUseSubstitutes = pattern.canSubstitute();
             final SubstitutionMode childMode =
                     canUseSubstitutes ? SubstitutionMode.ACCEPT_FUZZY : SubstitutionMode.PRECISE;
-            final long toCraft = Platform.ceilDiv(request.remainingToProcess, matchingOutput.getStackSize());
+            final long toCraft =
+                    Platform.ceilDiv(isComplex ? 1 : request.remainingToProcess, matchingOutput.getStackSize());
 
             if (requestedInputs) {
                 // Calculate how many full recipes we could fulfill
@@ -158,6 +171,30 @@ public class CraftableItemResolver implements CraftingRequestResolver<IAEItemSta
                             matchingOutput.copy().setStackSize(matchingOutputRemainderItems),
                             Actionable.MODULATE,
                             context.actionSource);
+                }
+                // Add byproducts of complex recipes
+                if (isComplex && fulfilledAmount > 0) {
+                    if (maxCraftable > 1) {
+                        throw new IllegalStateException(
+                                "Complex recipe got calculated with more than 1 set of inputs at a time");
+                    }
+                    final IAEItemStack[] inputs = new IAEItemStack[9];
+                    for (int slot = 0; slot < complexRequestPerSlot.size(); slot++) {
+                        final CraftingRequest<IAEItemStack> slotRequest = complexRequestPerSlot.get(slot);
+                        if (slotRequest != null) {
+                            final IAEItemStack resolvedItem = (IAEItemStack) slotRequest.getOneResolvedType();
+                            inputs[slot] = resolvedItem;
+                        }
+                    }
+                    final IAEItemStack[] leftovers = context.simulateComplexCrafting(inputs, pattern);
+
+                    for (IAEItemStack leftover : leftovers) {
+                        if (leftover == null || leftover.getStackSize() <= 0) {
+                            continue;
+                        }
+                        context.byproductsInventory.injectItems(leftover, Actionable.MODULATE, context.actionSource);
+                        this.byproducts.put(leftover.copy(), leftover.getStackSize());
+                    }
                 }
                 for (IAEItemStack output : patternOutputs) {
                     // add byproducts to the system
@@ -196,29 +233,54 @@ public class CraftableItemResolver implements CraftingRequestResolver<IAEItemSta
             } else {
                 request.patternParents.add(this.pattern);
                 ArrayList<CraftingRequest<IAEItemStack>> newChildren = new ArrayList<>(patternInputs.length);
-                if (patternRecursionInputs.length > 0) {
-                    for (IAEItemStack recInput : patternRecursionInputs) {
+                if (isComplex) {
+                    if (toCraft > 1) {
+                        throw new IllegalStateException();
+                    }
+                    final IAEItemStack[] slotInputs = pattern.getInputs();
+                    for (int slot = 0; slot < slotInputs.length; slot++) {
+                        final IAEItemStack input = slotInputs[slot];
+                        if (input == null) {
+                            complexRequestPerSlot.add(null);
+                            continue;
+                        }
+                        final long amount = Math.multiplyExact(input.getStackSize(), toCraft);
+                        final int finalSlot = slot; // for lambda capture
                         CraftingRequest<IAEItemStack> req = new CraftingRequest<>(
-                                recInput.copy(),
+                                input.copy().setStackSize(amount),
                                 childMode,
                                 IAEItemStack.class,
                                 allowSimulation,
-                                stack -> this.isValidSubstitute(recInput, stack, context.world));
+                                stack -> this.isValidSubstitute(input, stack, context.world, finalSlot));
+                        complexRequestPerSlot.add(req);
                         newChildren.add(req);
-                        childRecursionRequests.put(recInput, req);
+                        childRequests.put(input, new RequestAndPerCraftAmount(req, input.getStackSize()));
                     }
-                    state = State.NEEDS_MORE_WORK;
-                }
-                for (IAEItemStack input : patternInputs) {
-                    final long amount = Math.multiplyExact(input.getStackSize(), toCraft);
-                    CraftingRequest<IAEItemStack> req = new CraftingRequest<>(
-                            input.copy().setStackSize(amount),
-                            childMode,
-                            IAEItemStack.class,
-                            allowSimulation,
-                            stack -> this.isValidSubstitute(input, stack, context.world));
-                    newChildren.add(req);
-                    childRequests.put(input, new RequestAndPerCraftAmount(req, input.getStackSize()));
+                } else {
+                    if (patternRecursionInputs.length > 0) {
+                        for (IAEItemStack recInput : patternRecursionInputs) {
+                            CraftingRequest<IAEItemStack> req = new CraftingRequest<>(
+                                    recInput.copy(),
+                                    childMode,
+                                    IAEItemStack.class,
+                                    allowSimulation,
+                                    stack -> this.isValidSubstitute(recInput, stack, context.world));
+                            newChildren.add(req);
+                            childRecursionRequests.put(recInput, req);
+                        }
+                        state = State.NEEDS_MORE_WORK;
+                    }
+                    for (IAEItemStack input : patternInputs) {
+                        final long amount = Math.multiplyExact(input.getStackSize(), toCraft);
+                        CraftingRequest<IAEItemStack> req = new CraftingRequest<>(
+                                input.copy().setStackSize(amount),
+                                childMode,
+                                IAEItemStack.class,
+                                allowSimulation,
+                                stack -> this.isValidSubstitute(input, stack, context.world));
+                        newChildren.add(req);
+                        childRequests.put(input, new RequestAndPerCraftAmount(req, input.getStackSize()));
+                    }
                 }
                 requestedInputs = true;
                 state = State.NEEDS_MORE_WORK;
@@ -355,12 +417,26 @@ public class CraftableItemResolver implements CraftingRequestResolver<IAEItemSta
         }
         int priority = CraftingTask.PRIORITY_CRAFT_OFFSET + patterns.size() - 1;
         for (ICraftingPatternDetails pattern : patterns) {
-            tasks.add(new CraftFromPatternTask(request, pattern, priority, false));
+            if (context.isPatternComplex(pattern)) {
+                for (int i = 0; i < request.remainingToProcess; i++) {
+                    tasks.add(new CraftFromPatternTask(request, pattern, priority, false, true));
+                }
+            } else {
+                tasks.add(new CraftFromPatternTask(request, pattern, priority, false, false));
+            }
             priority--;
         }
         // Fallback: use highest priority pattern to simulate if nothing else works
         if (!patterns.isEmpty()) {
-            tasks.add(new CraftFromPatternTask(request, patterns.get(0), CraftingTask.PRIORITY_SIMULATE_CRAFT, true));
+            ICraftingPatternDetails pattern = patterns.get(0);
+            if (context.isPatternComplex(pattern)) {
+                for (int i = 0; i < request.remainingToProcess; i++) {
+                    tasks.add(new CraftFromPatternTask(request, pattern, priority, false, true));
+                }
+            } else {
+                tasks.add(
+                        new CraftFromPatternTask(request, pattern, CraftingTask.PRIORITY_SIMULATE_CRAFT, true, false));
+            }
         }
         return tasks.build();
     }

--- a/src/main/java/appeng/crafting/v2/resolvers/CraftingTask.java
+++ b/src/main/java/appeng/crafting/v2/resolvers/CraftingTask.java
@@ -1,6 +1,7 @@
 package appeng.crafting.v2.resolvers;
 
 import appeng.api.storage.data.IAEItemStack;
+import appeng.api.storage.data.IAEStack;
 import appeng.api.storage.data.IItemList;
 import appeng.crafting.MECraftingInventory;
 import appeng.crafting.v2.CraftingContext;
@@ -15,7 +16,7 @@ import javax.annotation.Nonnull;
  * A single action that can be performed to solve a {@link CraftingRequest}.
  * Can have multiple inputs and outputs, resolved at runtime during crafting resolution (e.g. for handling substitutions).
  */
-public abstract class CraftingTask {
+public abstract class CraftingTask<RequestStackType extends IAEStack<RequestStackType>> {
     public enum State {
         NEEDS_MORE_WORK(true),
         SUCCESS(false),
@@ -51,6 +52,7 @@ public abstract class CraftingTask {
     public static final int PRIORITY_SIMULATE_CRAFT = Integer.MIN_VALUE + 200;
     public static final int PRIORITY_SIMULATE = Integer.MIN_VALUE + 100;
 
+    public final CraftingRequest<RequestStackType> request;
     public final int priority;
     protected State state;
 
@@ -74,7 +76,8 @@ public abstract class CraftingTask {
     public abstract void startOnCpu(
             CraftingContext context, CraftingCPUCluster cpuCluster, MECraftingInventory craftingInv);
 
-    protected CraftingTask(int priority) {
+    protected CraftingTask(CraftingRequest<RequestStackType> request, int priority) {
+        this.request = request;
         this.priority = priority;
         this.state = State.NEEDS_MORE_WORK;
     }

--- a/src/main/java/appeng/crafting/v2/resolvers/EmitableItemResolver.java
+++ b/src/main/java/appeng/crafting/v2/resolvers/EmitableItemResolver.java
@@ -11,13 +11,12 @@ import java.util.List;
 import javax.annotation.Nonnull;
 
 public class EmitableItemResolver implements CraftingRequestResolver<IAEItemStack> {
-    public static class EmitItemTask extends CraftingTask {
-        public final CraftingRequest<IAEItemStack> request;
+    public static class EmitItemTask extends CraftingTask<IAEItemStack> {
 
         public EmitItemTask(CraftingRequest<IAEItemStack> request) {
-            super(CraftingTask.PRIORITY_CRAFTING_EMITTER); // conjure items for calculations out of thin air as a last
-            // resort
-            this.request = request;
+            super(
+                    request,
+                    CraftingTask.PRIORITY_CRAFTING_EMITTER); // conjure items for calculations out of thin air as a last
         }
 
         @Override

--- a/src/main/java/appeng/crafting/v2/resolvers/ExtractItemResolver.java
+++ b/src/main/java/appeng/crafting/v2/resolvers/ExtractItemResolver.java
@@ -120,9 +120,6 @@ public class ExtractItemResolver implements CraftingRequestResolver<IAEItemStack
 
         @Override
         public void populatePlan(IItemList<IAEItemStack> targetPlan) {
-            for (IAEItemStack removed : removedFromByproducts) {
-                targetPlan.addRequestable(removed.copy().setCountRequestable(removed.getStackSize()));
-            }
             for (IAEItemStack removed : removedFromSystem) {
                 targetPlan.add(removed.copy());
             }

--- a/src/main/java/appeng/crafting/v2/resolvers/ExtractItemResolver.java
+++ b/src/main/java/appeng/crafting/v2/resolvers/ExtractItemResolver.java
@@ -13,14 +13,12 @@ import java.util.*;
 import javax.annotation.Nonnull;
 
 public class ExtractItemResolver implements CraftingRequestResolver<IAEItemStack> {
-    public static class ExtractItemTask extends CraftingTask {
-        public final CraftingRequest<IAEItemStack> request;
+    public static class ExtractItemTask extends CraftingTask<IAEItemStack> {
         public final List<IAEItemStack> removedFromSystem = new ArrayList<>();
         public final List<IAEItemStack> removedFromByproducts = new ArrayList<>();
 
         public ExtractItemTask(CraftingRequest<IAEItemStack> request) {
-            super(CraftingTask.PRIORITY_EXTRACT); // always try to extract items first
-            this.request = request;
+            super(request, CraftingTask.PRIORITY_EXTRACT); // always try to extract items first
         }
 
         @Override

--- a/src/main/java/appeng/crafting/v2/resolvers/SimulateMissingItemResolver.java
+++ b/src/main/java/appeng/crafting/v2/resolvers/SimulateMissingItemResolver.java
@@ -13,12 +13,11 @@ import javax.annotation.Nonnull;
 
 public class SimulateMissingItemResolver<StackType extends IAEStack<StackType>>
         implements CraftingRequestResolver<StackType> {
-    public static class ConjureItemTask<StackType extends IAEStack<StackType>> extends CraftingTask {
-        public final CraftingRequest<StackType> request;
-
+    public static class ConjureItemTask<StackType extends IAEStack<StackType>> extends CraftingTask<StackType> {
         public ConjureItemTask(CraftingRequest<StackType> request) {
-            super(CraftingTask.PRIORITY_SIMULATE); // conjure items for calculations out of thin air as a last resort
-            this.request = request;
+            super(
+                    request,
+                    CraftingTask.PRIORITY_SIMULATE); // conjure items for calculations out of thin air as a last resort
         }
 
         @Override
@@ -69,7 +68,7 @@ public class SimulateMissingItemResolver<StackType extends IAEStack<StackType>>
     public List<CraftingTask> provideCraftingRequestResolvers(
             @Nonnull CraftingRequest<StackType> request, @Nonnull CraftingContext context) {
         if (request.allowSimulation) {
-            return Collections.singletonList(new ConjureItemTask<StackType>(request));
+            return Collections.singletonList(new ConjureItemTask<>(request));
         } else {
             return Collections.emptyList();
         }


### PR DESCRIPTION
Fixes the calculator getting stuck when there's a pattern cycle (a->b->c->a).
Adds a test for renamed items, but it seems to be working fine, both in unit tests and in-world, so I'm not sure what's going on with <https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12207>.

Fixes <https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12333> - tested locally with gt5u.