### PR TITLE
Add crafting debug logging to the v2 calculator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1675110695
+//version: 1675624371
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -66,7 +66,7 @@ plugins {
     id 'com.diffplug.spotless' version '6.7.2' apply false
     id 'com.modrinth.minotaur' version '2.+' apply false
     id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.1.2'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.1.4'
 }
 boolean settingsupdated = verifySettingsGradle()
 settingsupdated = verifyGitAttributes() || settingsupdated
@@ -520,20 +520,20 @@ dependencies {
         annotationProcessor('org.ow2.asm:asm-debug-all:5.0.3')
         annotationProcessor('com.google.guava:guava:24.1.1-jre')
         annotationProcessor('com.google.code.gson:gson:2.8.6')
-        annotationProcessor('com.gtnewhorizon:gtnhmixins:2.1.10:processor')
+        annotationProcessor('com.gtnewhorizon:gtnhmixins:2.1.12:processor')
         if (usesMixinDebug.toBoolean()) {
             runtimeOnlyNonPublishable('org.jetbrains:intellij-fernflower:1.2.1.16')
         }
     }
     if (usesMixins.toBoolean() || forceEnableMixins.toBoolean()) {
-        implementation('com.gtnewhorizon:gtnhmixins:2.1.10')
+        implementation('com.gtnewhorizon:gtnhmixins:2.1.12')
     }
 }
 
 pluginManager.withPlugin('org.jetbrains.kotlin.kapt') {
     if (usesMixins.toBoolean()) {
         dependencies {
-            kapt('com.gtnewhorizon:gtnhmixins:2.1.10:processor')
+            kapt('com.gtnewhorizon:gtnhmixins:2.1.12:processor')
         }
     }
 }
@@ -633,6 +633,7 @@ tasks.named("processResources", ProcessResources).configure {
 
     if (usesMixins.toBoolean()) {
         from refMap
+        dependsOn("compileJava", "compileScala")
     }
 }
 
@@ -743,6 +744,7 @@ idea {
     module {
         downloadJavadoc = true
         downloadSources = true
+        inheritOutputDirs = true
     }
     project {
         settings {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,10 +1,9 @@
 // Add your dependencies here
 
 dependencies {
-    compile('com.github.GTNewHorizons:CodeChickenLib:1.1.5.6:dev')
-    compile('com.github.GTNewHorizons:NotEnoughItems:2.3.21-GTNH:dev')
-    compile('curse.maven:cofh-core-69162:2388751')
-    compile('com.github.GTNewHorizons:BuildCraft:7.1.28:dev') {transitive = false}
+    implementation('com.github.GTNewHorizons:NotEnoughItems:2.3.27-GTNH:dev')
+    implementation('curse.maven:cofh-core-69162:2388751')
+    implementation('com.github.GTNewHorizons:BuildCraft:7.1.28:dev') {transitive = false}
     compileOnly('com.github.GTNewHorizons:ForgeMultipart:1.2.8:dev') {transitive = false}
     compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.41.254:dev') {transitive = false}
     compileOnly('com.github.GTNewHorizons:Jabba:1.2.21:dev') {transitive = false}
@@ -19,7 +18,7 @@ dependencies {
     compileOnly('curse.maven:better-storage-232919:2731636')
     compileOnly('api:immibis:1')
 
-    testCompile('junit:junit:4.12')
+    testImplementation('junit:junit:4.12')
     functionalTestImplementation(platform('org.junit:junit-bom:5.9.2'))
     functionalTestImplementation('org.junit.jupiter:junit-jupiter')
     functionalTestImplementation('org.junit.platform:junit-platform-engine')

--- a/gradle.properties
+++ b/gradle.properties
@@ -58,3 +58,6 @@ containsMixinsAndOrCoreModOnly = false
 # If enabled, you may use 'shadowImplementation' for dependencies. They will be integrated in your jar. It is your
 # responsibility check the licence and request permission for distribution, if required.
 usesShadowedDependencies = false
+
+# Adds the GTNH maven, CurseMaven, IC2/Player maven, and some more well-known 1.7.10 repositories
+includeWellKnownRepositories = true

--- a/repositories.gradle
+++ b/repositories.gradle
@@ -2,20 +2,6 @@
 
 repositories {
     maven {
-        name 'GTNH Maven'
-        url 'http://jenkins.usrv.eu:8081/nexus/content/groups/public/'
-        allowInsecureProtocol
-    }
-    maven {
-        name 'ic2'
-        url 'https://maven.ic2.player.to/'
-        url 'https://maven2.ic2.player.to/'
-        metadataSources {
-            mavenPom()
-            artifact()
-        }
-    }
-    maven {
         name 'MM repo'
         url 'https://maven.k-4u.nl/'
     }
@@ -26,14 +12,5 @@ repositories {
             mavenPom()
             artifact()
         }
-    }
-    maven {
-        url 'https://cursemaven.com'
-        content {
-            includeGroup 'curse.maven'
-        }
-    }
-    maven {
-        url 'https://jitpack.io'
     }
 }

--- a/src/main/java/appeng/crafting/v2/CraftingContext.java
+++ b/src/main/java/appeng/crafting/v2/CraftingContext.java
@@ -2,6 +2,7 @@ package appeng.crafting.v2;
 
 import java.util.*;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 
@@ -284,6 +285,11 @@ public final class CraftingContext {
      */
     public List<RequestInProcessing<?>> getLiveRequests() {
         return Collections.unmodifiableList(liveRequests);
+    }
+
+    @Override
+    public String toString() {
+        return getResolvedTasks().stream().map(rt -> "  " + rt.toString()).collect(Collectors.joining("\n"));
     }
 
     /**

--- a/src/main/java/appeng/crafting/v2/CraftingJobV2.java
+++ b/src/main/java/appeng/crafting/v2/CraftingJobV2.java
@@ -8,6 +8,8 @@ import java.util.concurrent.TimeoutException;
 
 import net.minecraft.world.World;
 
+import org.apache.logging.log4j.Level;
+
 import appeng.api.networking.IGrid;
 import appeng.api.networking.crafting.ICraftingCPU;
 import appeng.api.networking.crafting.ICraftingCallback;
@@ -15,6 +17,7 @@ import appeng.api.networking.crafting.ICraftingJob;
 import appeng.api.networking.security.BaseActionSource;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IItemList;
+import appeng.core.AELog;
 import appeng.crafting.MECraftingInventory;
 import appeng.crafting.v2.CraftingContext.RequestInProcessing;
 import appeng.crafting.v2.CraftingRequest.SubstitutionMode;
@@ -97,6 +100,13 @@ public class CraftingJobV2 implements ICraftingJob, Future<ICraftingJob> {
         if (!taskState.needsMoreWork) {
             getByteTotal();
             this.state = State.FINISHED;
+            if (AELog.isCraftingDebugLogEnabled()) {
+                AELog.log(
+                        Level.DEBUG,
+                        "Crafting job for %s finished with resolved steps: %s\n",
+                        originalRequest.toString(),
+                        context.toString());
+            }
             if (callback != null) {
                 callback.calculationComplete(this);
             }


### PR DESCRIPTION
When debug logging and crafting logging are enabled in the config this prints the list of resolvers that were attempted to be used to resolve a given crafting request with their internal state.