### PR TITLE
Remove unnecessary SideOnly CLIENT annotations for getting item names

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1677142954
+//version: 1677938302
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -695,13 +695,13 @@ ext.java17PatchDependenciesCfg = configurations.create("java17PatchDependencies"
 }
 
 dependencies {
-    def lwjgl3ifyVersion = '1.1.28'
+    def lwjgl3ifyVersion = '1.1.35'
     def asmVersion = '9.4'
     if (modId != 'lwjgl3ify') {
         java17Dependencies("com.github.GTNewHorizons:lwjgl3ify:${lwjgl3ifyVersion}")
     }
     if (modId != 'hodgepodge') {
-        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.0.35')
+        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.0.40')
     }
 
     java17PatchDependencies('net.minecraft:launchwrapper:1.15') {transitive = false}
@@ -718,8 +718,8 @@ dependencies {
 ext.java17JvmArgs = [
     // Java 9+ support
     "--illegal-access=warn",
-    "-Dfile.encoding=UTF-8",
     "-Djava.security.manager=allow",
+    "-Dfile.encoding=UTF-8",
     "--add-opens", "java.base/jdk.internal.loader=ALL-UNNAMED",
     "--add-opens", "java.base/java.net=ALL-UNNAMED",
     "--add-opens", "java.base/java.nio=ALL-UNNAMED",
@@ -730,6 +730,7 @@ ext.java17JvmArgs = [
     "--add-opens", "java.base/java.util=ALL-UNNAMED",
     "--add-opens", "java.base/jdk.internal.reflect=ALL-UNNAMED",
     "--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED",
+    "--add-opens", "jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED,java.naming",
     "--add-opens", "java.desktop/sun.awt.image=ALL-UNNAMED",
     "--add-modules", "jdk.dynalink",
     "--add-opens", "jdk.dynalink/jdk.dynalink.beans=ALL-UNNAMED",

--- a/src/main/java/appeng/core/AELog.java
+++ b/src/main/java/appeng/core/AELog.java
@@ -60,6 +60,22 @@ public final class AELog {
     }
 
     /**
+     * Logs an unformatted message with a specific log level.
+     * <p>
+     * The output can be globally disabled via the configuration file.
+     *
+     * @param level   the intended level.
+     * @param message the message to be printed.
+     */
+    public static void logSimple(@Nonnull final Level level, @Nonnull final String message) {
+        if (AELog.isLogEnabled()) {
+            final Logger logger = getLogger();
+
+            logger.log(level, message);
+        }
+    }
+
+    /**
      * Logs a formatted message with a specific log level.
      * <p>
      * This uses {@link String#format(String, Object...)} as opposed to the {@link ParameterizedMessage} to allow a more

--- a/src/main/java/appeng/crafting/v2/CraftingJobV2.java
+++ b/src/main/java/appeng/crafting/v2/CraftingJobV2.java
@@ -110,11 +110,8 @@ public class CraftingJobV2 implements ICraftingJob, Future<ICraftingJob> {
             getByteTotal();
             this.state = State.FINISHED;
             if (AELog.isCraftingDebugLogEnabled()) {
-                AELog.log(
-                        Level.INFO,
-                        "Crafting job for %s finished with resolved steps: %s\n",
-                        originalRequest.toString(),
-                        context.toString());
+                AELog.log(Level.INFO, "Crafting job for %s finished with resolved steps:", originalRequest.toString());
+                AELog.logSimple(Level.INFO, context.toString());
             }
             if (callback != null) {
                 callback.calculationComplete(this);

--- a/src/main/java/appeng/util/item/AEItemDef.java
+++ b/src/main/java/appeng/util/item/AEItemDef.java
@@ -35,7 +35,6 @@ public class AEItemDef {
     private int maxDamage;
     private AESharedNBT tagCompound;
 
-    @SideOnly(Side.CLIENT)
     private String displayName;
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/appeng/util/item/AEItemStack.java
+++ b/src/main/java/appeng/util/item/AEItemStack.java
@@ -480,7 +480,6 @@ public final class AEItemStack extends AEStack<IAEItemStack> implements IAEItemS
         return this.getDefinition().setTooltip(Platform.getTooltip(this.getItemStack()));
     }
 
-    @SideOnly(Side.CLIENT)
     public String getDisplayName() {
         if (this.getDefinition().getDisplayName() == null) {
             this.getDefinition().setDisplayName(Platform.getItemDisplayName(this.getItemStack()));
@@ -489,7 +488,6 @@ public final class AEItemStack extends AEStack<IAEItemStack> implements IAEItemS
         return this.getDefinition().getDisplayName();
     }
 
-    @SideOnly(Side.CLIENT)
     public String getModID() {
         if (this.getDefinition().getUniqueID() != null) {
             return this.getModName(this.getDefinition().getUniqueID());


### PR DESCRIPTION
None of the methods these functions call are client-only, and being able to show display names of items in server logs is useful.
Also split off the crafting context printout to reduce string concatenations.