### PR TITLE
Add some infrastructure for part deprecation.

### DIFF
--- a/src/main/java/appeng/api/parts/IPartDeprecated.java
+++ b/src/main/java/appeng/api/parts/IPartDeprecated.java
@@ -1,0 +1,25 @@
+package appeng.api.parts;
+
+import net.minecraft.nbt.NBTTagCompound;
+
+/**
+ * Mark a part with this interface to seamlessly transition it from a deprecated part to a supported part.
+ */
+public interface IPartDeprecated {
+
+    /**
+     * transformPart
+     * 
+     * @param def the def data for the part
+     * @return the transformed def data for the replacement part
+     */
+    NBTTagCompound transformPart(NBTTagCompound def);
+
+    /**
+     * transformNBT
+     * 
+     * @param extra the extra data for the part
+     * @return the transformed extra data for the replacement part
+     */
+    NBTTagCompound transformNBT(NBTTagCompound extra);
+}

--- a/src/main/java/appeng/parts/CableBusContainer.java
+++ b/src/main/java/appeng/parts/CableBusContainer.java
@@ -891,6 +891,10 @@ public class CableBusContainer extends CableBusStorage implements AEMultiTile, I
             extra = covert[1];
             if (def != null && extra != null) {
                 IPart p = this.getPart(side);
+                if (p instanceof IPartDeprecated) {
+                    def = ((IPartDeprecated) p).transformPart(def);
+                    extra = ((IPartDeprecated) p).transformNBT(extra);
+                }
                 final ItemStack iss = ItemStack.loadItemStackFromNBT(def);
                 if (iss == null) {
                     continue;


### PR DESCRIPTION
I would like to implement transformers for parts to help in the EC2 -> AE2FC transition. Commit adds an interface that can be attached to any part. Plan is to use this interface to automatically convert any part by marking it deprecated and implementing the appropriate transformer methods - basically an extension of what Glod is doing.

@GlodBlock I think this will make it easier to convert parts. This way we don't have to write separate methods in the cable bus container class, but instead move that code to EC2.

post 2.3