### PR TITLE
Deprecation updates

### DIFF
--- a/src/main/java/appeng/parts/CableBusContainer.java
+++ b/src/main/java/appeng/parts/CableBusContainer.java
@@ -913,13 +913,15 @@ public class CableBusContainer extends CableBusStorage implements AEMultiTile, I
             extra = covert[1];
             if (def != null && extra != null) {
                 IPart p = this.getPart(side);
-                if (p instanceof IPartDeprecated) {
-                    def = ((IPartDeprecated) p).transformPart(def);
-                    extra = ((IPartDeprecated) p).transformNBT(extra);
-                }
-                final ItemStack iss = ItemStack.loadItemStackFromNBT(def);
-                if (iss == null) {
-                    continue;
+                ItemStack iss = ItemStack.loadItemStackFromNBT(def);
+                if (iss == null) continue;
+                if (iss.getItem() instanceof IPartItem) {
+                    IPart part = ((IPartItem) iss.getItem()).createPartFromItemStack(iss);
+                    if (part instanceof IPartDeprecated) {
+                        def = ((IPartDeprecated) part).transformPart(def);
+                        extra = ((IPartDeprecated) part).transformNBT(extra);
+                    }
+                    iss = ItemStack.loadItemStackFromNBT(def);
                 }
 
                 final ItemStack current = p == null ? null : p.getItemStack(PartItemStack.World);


### PR DESCRIPTION
Deprecation will now work as follows:

1. Load IPart from ItemStack.

2. If IPart is IPartDeprecated, run transformers on the def/extra nbt.

3. Reload the ItemStack and continue as normal. It's assumed that IPartDeprecated will **NEVER** return null, and the ItemStack that comes out post-transformation will always be valid (i.e. non null).

Sorry I didn't really pay attention to how the calls worked when parts were placed previously. Now they should work.

After this, I have several EC2 parts that have been tested and will make those PRs. I've already tested them together with this patch in the full pack (2.3.0 RC3).