### PR TITLE
Trim arrays to size after mutations for memory savings

### DIFF
--- a/src/main/java/appeng/crafting/v2/resolvers/CraftableItemResolver.java
+++ b/src/main/java/appeng/crafting/v2/resolvers/CraftableItemResolver.java
@@ -53,8 +53,8 @@ public class CraftableItemResolver implements CraftingRequestResolver<IAEItemSta
         // With the recursive part subtracted
         protected final IAEItemStack[] patternOutputs;
         protected final IAEItemStack matchingOutput;
-        protected final List<RequestAndPerCraftAmount> childRequests = new ArrayList<>();
-        protected final List<CraftingRequest> complexRequestPerSlot = new ArrayList<>();
+        protected final ArrayList<RequestAndPerCraftAmount> childRequests = new ArrayList<>();
+        protected final ArrayList<CraftingRequest> complexRequestPerSlot = new ArrayList<>();
         protected final Map<IAEItemStack, CraftingRequest<IAEItemStack>> childRecursionRequests = new HashMap<>();
         // byproduct injected -> amount per craft
         protected final IdentityHashMap<IAEItemStack, Long> byproducts = new IdentityHashMap<>();
@@ -302,6 +302,8 @@ public class CraftableItemResolver implements CraftingRequestResolver<IAEItemSta
                         childRequests.add(new RequestAndPerCraftAmount(req, input.getStackSize()));
                     }
                 }
+                childRequests.trimToSize();
+                complexRequestPerSlot.trimToSize();
                 requestedInputs = true;
                 state = State.NEEDS_MORE_WORK;
                 return new StepOutput(Collections.unmodifiableList(newChildren));

--- a/src/main/java/appeng/crafting/v2/resolvers/ExtractItemResolver.java
+++ b/src/main/java/appeng/crafting/v2/resolvers/ExtractItemResolver.java
@@ -18,8 +18,8 @@ public class ExtractItemResolver implements CraftingRequestResolver<IAEItemStack
 
     public static class ExtractItemTask extends CraftingTask<IAEItemStack> {
 
-        public final List<IAEItemStack> removedFromSystem = new ArrayList<>();
-        public final List<IAEItemStack> removedFromByproducts = new ArrayList<>();
+        public final ArrayList<IAEItemStack> removedFromSystem = new ArrayList<>();
+        public final ArrayList<IAEItemStack> removedFromByproducts = new ArrayList<>();
 
         public ExtractItemTask(CraftingRequest<IAEItemStack> request) {
             super(request, CraftingTask.PRIORITY_EXTRACT); // always try to extract items first
@@ -42,6 +42,8 @@ public class ExtractItemResolver implements CraftingRequestResolver<IAEItemStack
                     extractFuzzy(context, context.itemModel, removedFromSystem);
                 }
             }
+            removedFromSystem.trimToSize();
+            removedFromByproducts.trimToSize();
             return new StepOutput(Collections.emptyList());
         }
 


### PR DESCRIPTION
Most of the arraylists keep 1 or 2 elements after each phase of the calculation, this will shrink them down to that size in memory instead of the default 10.