### PR TITLE
Make PartP2PTunnel#getTypeTexture() public

### DIFF
--- a/src/main/java/appeng/parts/p2p/PartP2PGT5Power.java
+++ b/src/main/java/appeng/parts/p2p/PartP2PGT5Power.java
@@ -53,8 +53,9 @@ public class PartP2PGT5Power extends PartP2PTunnel<PartP2PGT5Power> implements I
         this.cachedTarget = null;
     }
 
+    @Override
     @SideOnly(Side.CLIENT)
-    protected IIcon getTypeTexture() {
+    public IIcon getTypeTexture() {
         return Blocks.obsidian.getIcon(0, 0);
     }
 

--- a/src/main/java/appeng/parts/p2p/PartP2PInterface.java
+++ b/src/main/java/appeng/parts/p2p/PartP2PInterface.java
@@ -112,7 +112,7 @@ public class PartP2PInterface extends PartP2PTunnel<PartP2PInterface>
 
     @Override
     @SideOnly(Side.CLIENT)
-    protected IIcon getTypeTexture() {
+    public IIcon getTypeTexture() {
         return AEApi.instance().definitions().blocks().iface().maybeBlock().get().getBlockTextureFromSide(0);
     }
 

--- a/src/main/java/appeng/parts/p2p/PartP2PPressure.java
+++ b/src/main/java/appeng/parts/p2p/PartP2PPressure.java
@@ -58,7 +58,7 @@ public final class PartP2PPressure extends PartP2PTunnel<PartP2PPressure>
     }
 
     @Override
-    protected IIcon getTypeTexture() {
+    public IIcon getTypeTexture() {
         return BlockSupplier.getBlock(PRESSURE_TYPE_ICON_NAME).getIcon(0, 0);
     }
 

--- a/src/main/java/appeng/parts/p2p/PartP2PTunnel.java
+++ b/src/main/java/appeng/parts/p2p/PartP2PTunnel.java
@@ -125,7 +125,7 @@ public abstract class PartP2PTunnel<T extends PartP2PTunnel> extends PartBasicSt
     /**
      * @return If enabled it returns the icon of an AE quartz block, else vanilla quartz block icon
      */
-    protected IIcon getTypeTexture() {
+    public IIcon getTypeTexture() {
         final Optional<Block> maybeBlock = AEApi.instance().definitions().blocks().quartz().maybeBlock();
         if (maybeBlock.isPresent()) {
             return maybeBlock.get().getIcon(0, 0);


### PR DESCRIPTION
Use case - BetterP2P to display P2P icons in Advanced Memory Card GUI. Alternative is to mirror P2P icons in BetterP2P itself which is doable but not as clean as calling this method.