### PR TITLE
Uncap ME chest stack size

### DIFF
--- a/src/main/java/appeng/tile/inventory/AppEngInternalInventory.java
+++ b/src/main/java/appeng/tile/inventory/AppEngInternalInventory.java
@@ -30,6 +30,7 @@ public class AppEngInternalInventory implements IInventory, Iterable<ItemStack> 
     private boolean enableClientEvents = false;
     private IAEAppEngInventory te;
     private int maxStack;
+    private boolean ignoreStackLimit = false;
 
     public AppEngInternalInventory(final IAEAppEngInventory inventory, final int size) {
         this(inventory, size, 64);
@@ -40,6 +41,12 @@ public class AppEngInternalInventory implements IInventory, Iterable<ItemStack> 
         this.size = size;
         this.maxStack = maxstack;
         this.inv = new ItemStack[size];
+    }
+
+    public AppEngInternalInventory(final IAEAppEngInventory inventory, final int size, final int maxstack,
+            final boolean ignoreStackLimit) {
+        this(inventory, size, maxstack);
+        this.ignoreStackLimit = ignoreStackLimit;
     }
 
     public IMEInventory getMEInventory() {
@@ -139,7 +146,7 @@ public class AppEngInternalInventory implements IInventory, Iterable<ItemStack> 
 
     @Override
     public int getInventoryStackLimit() {
-        return this.maxStack > 64 ? 64 : this.maxStack;
+        return this.ignoreStackLimit ? this.maxStack : Math.min(this.maxStack, 64);
     }
 
     @Override

--- a/src/main/java/appeng/tile/storage/TileChest.java
+++ b/src/main/java/appeng/tile/storage/TileChest.java
@@ -65,7 +65,7 @@ public class TileChest extends AENetworkPowerTile
     private static final int[] SIDES = { 0 };
     private static final int[] FRONT = { 1 };
     private static final int[] NO_SLOTS = {};
-    private final AppEngInternalInventory inv = new AppEngInternalInventory(this, 2);
+    private final AppEngInternalInventory inv = new AppEngInternalInventory(this, 2, Integer.MAX_VALUE, true);
     private final BaseActionSource mySrc = new MachineSource(this);
     private final IConfigManager config = new ConfigManager(this);
     private ItemStack storageType;

--- a/src/main/java/appeng/util/InventoryAdaptor.java
+++ b/src/main/java/appeng/util/InventoryAdaptor.java
@@ -24,6 +24,7 @@ import appeng.api.config.InsertionMode;
 import appeng.integration.IntegrationRegistry;
 import appeng.integration.IntegrationType;
 import appeng.integration.abstraction.IBetterStorage;
+import appeng.tile.AEBaseInvTile;
 import appeng.util.inv.*;
 
 public abstract class InventoryAdaptor implements Iterable<ItemSlot> {
@@ -52,7 +53,14 @@ public abstract class InventoryAdaptor implements Iterable<ItemSlot> {
         } else if (te instanceof ISidedInventory) {
             final ISidedInventory si = (ISidedInventory) te;
             final int[] slots = si.getAccessibleSlotsFromSide(d.ordinal());
+            int stackLimit = 0;
+            if (te instanceof AEBaseInvTile) {
+                stackLimit = ((AEBaseInvTile) te).getInternalInventory().getInventoryStackLimit();
+            }
             if (si.getSizeInventory() > 0 && slots != null && slots.length > 0) {
+                if (stackLimit > 0) {
+                    return new AdaptorIInventory(new WrapperMCISidedInventory(si, d), stackLimit);
+                }
                 return new AdaptorIInventory(new WrapperMCISidedInventory(si, d));
             }
         } else if (te instanceof IInventory) {

--- a/src/main/java/appeng/util/inv/AdaptorIInventory.java
+++ b/src/main/java/appeng/util/inv/AdaptorIInventory.java
@@ -24,13 +24,18 @@ public class AdaptorIInventory extends InventoryAdaptor {
 
     private final IInventory i;
     private final boolean wrapperEnabled;
-    private final boolean skipStackSizeCheck;
+    private boolean skipStackSizeCheck;
 
     public AdaptorIInventory(final IInventory s) {
         this.i = s;
         skipStackSizeCheck = i.getClass().toString()
                 .equals("class wanion.avaritiaddons.block.chest.infinity.TileEntityInfinityChest");
         this.wrapperEnabled = s instanceof IInventoryWrapper;
+    }
+
+    public AdaptorIInventory(final IInventory s, final int maxStack) {
+        this(s);
+        skipStackSizeCheck = skipStackSizeCheck || maxStack == Integer.MAX_VALUE;
     }
 
     @Override
@@ -230,8 +235,15 @@ public class AdaptorIInventory extends InventoryAdaptor {
         }
 
         final ItemStack left = itemsToAdd.copy();
-        final int perOperationLimit = this.skipStackSizeCheck ? this.i.getInventoryStackLimit()
-                : Math.min(this.i.getInventoryStackLimit(), itemsToAdd.getMaxStackSize());
+
+        int internalLimit = 0;
+        if (this.i instanceof WrapperInventoryRange) {
+            internalLimit = ((WrapperInventoryRange) this.i).getInternalInventoryStackLimit();
+        }
+        int invLimit = internalLimit > 0 ? internalLimit : this.i.getInventoryStackLimit();
+
+        final int perOperationLimit = this.skipStackSizeCheck ? invLimit
+                : Math.min(invLimit, itemsToAdd.getMaxStackSize());
         final int inventorySize = this.i.getSizeInventory();
 
         // go over empty slots first if needed

--- a/src/main/java/appeng/util/inv/WrapperInventoryRange.java
+++ b/src/main/java/appeng/util/inv/WrapperInventoryRange.java
@@ -14,6 +14,8 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 
+import appeng.tile.AEBaseInvTile;
+
 public class WrapperInventoryRange implements IInventory {
 
     private final IInventory src;
@@ -92,6 +94,15 @@ public class WrapperInventoryRange implements IInventory {
     @Override
     public int getInventoryStackLimit() {
         return this.src.getInventoryStackLimit();
+    }
+
+    public int getInternalInventoryStackLimit() {
+        if (this.src instanceof AEBaseInvTile) {
+            IInventory internalInv = ((AEBaseInvTile) this.src).getInternalInventory();
+            return internalInv.getInventoryStackLimit();
+        }
+
+        return 0;
     }
 
     @Override


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12842

Allows for stack sizes larger than 64 to be directly inserted into an ME chest at once. Allows for interface -> ME chest with large stack size patterns instead of requiring interface -> infinity chest to do the same.