### PR TITLE
Revert commit 84574778291f54e4bf32e545fd8d49c2e8d8f624

### DIFF
--- a/src/main/java/appeng/me/GridNode.java
+++ b/src/main/java/appeng/me/GridNode.java
@@ -52,7 +52,6 @@ public class GridNode implements IGridNode, IPathItem {
     private int compressedData = 0;
     private int usedChannels = 0;
     private int lastUsedChannels = 0;
-    private boolean isAlive = true;
 
     public GridNode(final IGridBlock what) {
         this.gridProxy = what;
@@ -104,7 +103,7 @@ public class GridNode implements IGridNode, IPathItem {
     void validateGrid() {
         final GridSplitDetector gsd = new GridSplitDetector(this.getInternalGrid().getPivot());
         this.beginVisit(gsd);
-        if (!gsd.isPivotFound() && isAlive) {
+        if (!gsd.isPivotFound()) {
             final IGridVisitor gp = new GridPropagator(new Grid(this));
             this.beginVisit(gp);
         }
@@ -213,7 +212,6 @@ public class GridNode implements IGridNode, IPathItem {
 
     @Override
     public void destroy() {
-        isAlive = false;
 
         while (!this.connections.isEmpty()) {
             // not part of this network for real anymore.


### PR DESCRIPTION
(aka PR #289)

Connections in AE2 are so complicated, but here's a rundown of what happens, at least my running theory:

Some definitions:

* Grid - a ME network.
* Node - any ME network cable, controller, etc. Must belong to its Grid.
* Connection (GridConnection) - a graph edge that connects two Nodes. For a connection A - B, there is a commutative connection B - A. That is, this graph is undirected.

Let's look at a very simple scenario: nodes A - B - C are connected in a line.

When we destroy B, it removes itself from its Grid. It then has its connections traverse the Grid to find a "pivot" - in this context, the closest controller. If we cannot find a pivot, we create new Grid.

For the connection A - B, A checks to see if it can find a pivot. If it can, it is somewhere in A's Grid. If not, then it creates a new Grid for itself.

For the connection B - A, B checks to see if it can find a pivot. It can't, because it just removed itself from its Grid!

The same happens for the connection B - C. C finds a pivot, or it doesn't. B still cannot find a Grid.

The problem with "isAlive" is that in the situation A - B, if A can find a pivot, it does not create a new Grid, even if it should. In that situation, B should create a new Grid for A. Notice, though, that "isAlive" is false here, so no new Grid is created! Thus, we end up with a single Grid that contains both A and C. If A and C both have different pivots, the Grid thus thinks its invalid.

And that's why we see "wireless AE".