### PR TITLE
Fall back to the default icon provider if null is returned from ICraftingIconProvider, handle renamed interfaces in the crafting tree view

### DIFF
--- a/src/main/java/appeng/helpers/DualityInterface.java
+++ b/src/main/java/appeng/helpers/DualityInterface.java
@@ -1050,7 +1050,10 @@ public class DualityInterface implements IGridTickable, IStorageMonitorable, IIn
             }
 
             if (directedTile instanceof ICraftingIconProvider) {
-                return ((ICraftingIconProvider) directedTile).getMachineCraftingIcon();
+                final ItemStack icon = ((ICraftingIconProvider) directedTile).getMachineCraftingIcon();
+                if (icon != null) {
+                    return icon;
+                }
             }
 
             final InventoryAdaptor adaptor = InventoryAdaptor.getAdaptor(directedTile, direction.getOpposite());

--- a/src/main/java/appeng/helpers/DualityInterface.java
+++ b/src/main/java/appeng/helpers/DualityInterface.java
@@ -1052,6 +1052,9 @@ public class DualityInterface implements IGridTickable, IStorageMonitorable, IIn
             if (directedTile instanceof ICraftingIconProvider) {
                 final ItemStack icon = ((ICraftingIconProvider) directedTile).getMachineCraftingIcon();
                 if (icon != null) {
+                    if (customName != null) {
+                        icon.setStackDisplayName(customName);
+                    }
                     return icon;
                 }
             }
@@ -1111,7 +1114,11 @@ public class DualityInterface implements IGridTickable, IStorageMonitorable, IIn
 
                 final Item item = Item.getItemFromBlock(directedBlock);
                 if (item != null) {
-                    return new ItemStack(item);
+                    final ItemStack icon = new ItemStack(item);
+                    if (customName != null) {
+                        icon.setStackDisplayName(customName);
+                    }
+                    return icon;
                 }
             }
         }


### PR DESCRIPTION
This will make the gt5 mte implementation easier. There are currently no users of this API at all, it's been introduced in my crafting tree view PR.