### PR TITLE
Hotfix: Make the interface part work with adv. blocking card

### DIFF
--- a/src/main/java/appeng/util/InventoryAdaptor.java
+++ b/src/main/java/appeng/util/InventoryAdaptor.java
@@ -21,11 +21,14 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import appeng.api.config.FuzzyMode;
 import appeng.api.config.InsertionMode;
+import appeng.api.parts.IPart;
+import appeng.helpers.IInterfaceHost;
 import appeng.integration.IntegrationRegistry;
 import appeng.integration.IntegrationType;
 import appeng.integration.abstraction.IBetterStorage;
 import appeng.tile.AEBaseInvTile;
 import appeng.tile.misc.TileInterface;
+import appeng.tile.networking.TileCableBus;
 import appeng.util.inv.*;
 
 public abstract class InventoryAdaptor implements Iterable<ItemSlot> {
@@ -54,7 +57,12 @@ public abstract class InventoryAdaptor implements Iterable<ItemSlot> {
         } else if (te instanceof ISidedInventory si) {
             final int[] slots = si.getAccessibleSlotsFromSide(d.ordinal());
             if (te instanceof TileInterface) {
-                return new AdaptorDualityInterface(new WrapperMCISidedInventory(si, d), (TileInterface) te);
+                return new AdaptorDualityInterface(new WrapperMCISidedInventory(si, d), (IInterfaceHost) te);
+            } else if (te instanceof TileCableBus) {
+                IPart part = ((TileCableBus) te).getPart(d);
+                if (part instanceof IInterfaceHost host) {
+                    return new AdaptorDualityInterface(new WrapperMCISidedInventory(si, d), host);
+                }
             }
             int stackLimit = 0;
             if (te instanceof AEBaseInvTile) {

--- a/src/main/java/appeng/util/inv/AdaptorDualityInterface.java
+++ b/src/main/java/appeng/util/inv/AdaptorDualityInterface.java
@@ -8,20 +8,20 @@ import appeng.api.config.Upgrades;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IItemList;
 import appeng.helpers.DualityInterface;
-import appeng.tile.misc.TileInterface;
+import appeng.helpers.IInterfaceHost;
 
 public class AdaptorDualityInterface extends AdaptorIInventory {
 
-    private final TileInterface tileInterface;
+    public final IInterfaceHost interfaceHost;
 
-    public AdaptorDualityInterface(IInventory s, TileInterface tileInterface) {
+    public AdaptorDualityInterface(IInventory s, IInterfaceHost interfaceHost) {
         super(s);
-        this.tileInterface = tileInterface;
+        this.interfaceHost = interfaceHost;
     }
 
     @Override
     public boolean containsItems() {
-        DualityInterface dual = tileInterface.getInterfaceDuality();
+        DualityInterface dual = interfaceHost.getInterfaceDuality();
         boolean hasMEItems = false;
         if (dual.getInstalledUpgrades(Upgrades.ADVANCED_BLOCKING) > 0) {
             if (dual.getConfigManager().getSetting(Settings.ADVANCED_BLOCKING_MODE) == AdvancedBlockingMode.DEFAULT) {


### PR DESCRIPTION
Found this while I was porting this to ae2fc.

Used TileInterface for the adaptor when I should also consider parts. I skipped testing parts because of laziness (and I wanted to put it out asap). Patch uses IInterfaceHost instead, which is the proper Java interface for both parts and tiles. Also it's public so I can reuse it in ae2fc.