### PR TITLE
Hotfix: Pattern Refiller

### DIFF
--- a/src/main/java/appeng/container/implementations/ContainerMEMonitorable.java
+++ b/src/main/java/appeng/container/implementations/ContainerMEMonitorable.java
@@ -383,20 +383,22 @@ public class ContainerMEMonitorable extends AEBaseContainer
 
     // to avoid duplicating this method in 2 pattern terminals
     protected void refillBlankPatterns(Slot slot) {
-        ItemStack blanks = slot.getStack();
-        int blanksToRefill = 64;
-        if (blanks != null) blanksToRefill -= blanks.stackSize;
-        if (blanksToRefill <= 0) return;
-        final AEItemStack request = AEItemStack
-                .create(AEApi.instance().definitions().materials().blankPattern().maybeStack(blanksToRefill).get());
-        final IAEItemStack extracted = Platform
-                .poweredExtraction(this.getPowerSource(), this.getCellInventory(), request, this.getActionSource());
-        if (extracted != null) {
-            if (blanks != null) blanks.stackSize += extracted.getStackSize();
-            else {
-                blanks = extracted.getItemStack();
+        if (Platform.isServer()) {
+            ItemStack blanks = slot.getStack();
+            int blanksToRefill = 64;
+            if (blanks != null) blanksToRefill -= blanks.stackSize;
+            if (blanksToRefill <= 0) return;
+            final AEItemStack request = AEItemStack
+                    .create(AEApi.instance().definitions().materials().blankPattern().maybeStack(blanksToRefill).get());
+            final IAEItemStack extracted = Platform
+                    .poweredExtraction(this.getPowerSource(), this.getCellInventory(), request, this.getActionSource());
+            if (extracted != null) {
+                if (blanks != null) blanks.stackSize += extracted.getStackSize();
+                else {
+                    blanks = extracted.getItemStack();
+                }
+                slot.putStack(blanks);
             }
-            slot.putStack(blanks);
         }
     }
 }


### PR DESCRIPTION
@repo-alt Please check if adding a check for whether the server is appropriate here.

The client currently crashes to title after the second GUI open with the refiller card because `this.getCellInventory() == null` on the client side of `ContainerMEMonitorable`.