### PR TITLE
Fullscreen crafting tree and tall crafting list

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1682616243
+//version: 1683373797
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -71,6 +71,9 @@ plugins {
     id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
     id 'com.gtnewhorizons.retrofuturagradle' version '1.3.7'
 }
+
+print("You might want to check out './gradlew :faq' if your build fails.\n")
+
 boolean settingsupdated = verifySettingsGradle()
 settingsupdated = verifyGitAttributes() || settingsupdated
 if (settingsupdated)
@@ -219,6 +222,8 @@ if (enableModernJavaSyntax.toBoolean()) {
 
     dependencies {
         annotationProcessor 'com.github.bsideup.jabel:jabel-javac-plugin:1.0.0'
+        // workaround for https://github.com/bsideup/jabel/issues/174
+        annotationProcessor 'net.java.dev.jna:jna-platform:5.13.0'
         compileOnly('com.github.bsideup.jabel:jabel-javac-plugin:1.0.0') {
             transitive = false // We only care about the 1 annotation class
         }
@@ -1249,6 +1254,19 @@ if (!project.getGradle().startParameter.isOffline() && !Boolean.getBoolean('DISA
         if (gradle.gradleVersion != buildscriptGradleVersion) {
             out.style(Style.SuccessHeader).println("updateBuildScript can update gradle from ${gradle.gradleVersion} to ${buildscriptGradleVersion}\n")
         }
+    }
+}
+
+// If you want to add more cases to this task, implement them as arguments if total amount to print gets too large
+tasks.register('faq') {
+    group = 'GTNH Buildscript'
+    description = 'Prints frequently asked questions about building a project'
+
+    doLast {
+        print("If your build fails to fetch dependencies, they might have been deleted and replaced by newer " +
+            "versions.\nCheck if the versions you try to fetch are still on the distributing sites.\n" +
+            "The links can be found in repositories.gradle and build.gradle:repositories, " +
+            "not build.gradle:buildscript.repositories - this one is for gradle plugin metadata.")
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -26,3 +26,5 @@ blowdryerSetup {
     github('GTNewHorizons/ExampleMod1.7.10', 'tag', '0.2.0')
     //devLocal '.' // Use this when testing config updates locally
 }
+
+rootProject.name = "Applied-Energistics-2-Unofficial"

--- a/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
@@ -115,7 +115,7 @@ public class GuiCraftConfirm extends AEBaseGui implements ICraftingCPUTableHolde
     private final List<IAEItemStack> visual = new ArrayList<>();
 
     private DisplayMode displayMode = DisplayMode.LIST;
-    private boolean tallMode = false;
+    private boolean tallMode = true;
 
     private GuiBridge OriginalGui;
     private GuiButton cancel;

--- a/src/main/java/appeng/client/gui/widgets/GuiCraftingTree.java
+++ b/src/main/java/appeng/client/gui/widgets/GuiCraftingTree.java
@@ -24,7 +24,7 @@ import appeng.util.ReadableNumberConverter;
 public class GuiCraftingTree {
 
     private final AEBaseGui parent;
-    private final int widgetX, widgetY, widgetW, widgetH;
+    public int widgetX, widgetY, widgetW, widgetH;
 
     public float scrollX = -8, scrollY = -8;
     private CraftingRequest<?> request;


### PR DESCRIPTION
Implements a toggleable fullscreen view for the crafting tree view and a tall mode for the crafting list view in the crafting plan display (this does not affect the crafting cpu status, as that is a separate gui implementation).
![image](https://user-images.githubusercontent.com/1017004/236646267-352e7e1d-1847-459a-a14c-0dc01832eead.png)
![image](https://user-images.githubusercontent.com/1017004/236646274-86320227-7367-4c19-b172-f950bf6262cd.png)
The extra items in the list view screenshot are added by some debug code that's not commited here, it's not a bug.