### PR TITLE
Split crafting tree data packets into 1MB chunks and only limit max crafting steps on dedicated servers

### DIFF
--- a/src/main/java/appeng/container/implementations/ContainerCraftConfirm.java
+++ b/src/main/java/appeng/container/implementations/ContainerCraftConfirm.java
@@ -11,6 +11,7 @@
 package appeng.container.implementations;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.concurrent.Future;
 
 import javax.annotation.Nonnull;
@@ -186,11 +187,11 @@ public class ContainerCraftConfirm extends AEBaseContainer implements ICraftingC
                         }
                     }
 
-                    final PacketCraftingTreeData treeUpdate;
+                    final List<PacketCraftingTreeData> treeUpdates;
                     if (this.result instanceof CraftingJobV2) {
-                        treeUpdate = new PacketCraftingTreeData((CraftingJobV2) this.result);
+                        treeUpdates = PacketCraftingTreeData.createChunks((CraftingJobV2) this.result);
                     } else {
-                        treeUpdate = null;
+                        treeUpdates = null;
                     }
                     for (final Object player : this.crafters) {
                         if (player instanceof EntityPlayerMP playerMP) {
@@ -199,8 +200,10 @@ public class ContainerCraftConfirm extends AEBaseContainer implements ICraftingC
                             if (missingUpdate != null) {
                                 NetworkHandler.instance.sendTo(missingUpdate, playerMP);
                             }
-                            if (treeUpdate != null) {
-                                NetworkHandler.instance.sendTo(treeUpdate, playerMP);
+                            if (treeUpdates != null) {
+                                for (PacketCraftingTreeData pkt : treeUpdates) {
+                                    NetworkHandler.instance.sendTo(pkt, playerMP);
+                                }
                             }
                         }
                     }

--- a/src/main/java/appeng/core/sync/AppEngPacket.java
+++ b/src/main/java/appeng/core/sync/AppEngPacket.java
@@ -49,7 +49,7 @@ public abstract class AppEngPacket {
     }
 
     public FMLProxyPacket getProxy() {
-        if (this.p.array().length > 2 * 1024 * 1024) // 2k walking room :)
+        if (this.p.array().length > 0x1FFF90) // Use the maximum MC S3FPacketCustomPayload size with space for FML
         {
             throw new IllegalArgumentException(
                     "Sorry AE2 made a " + this.p.array().length + " byte packet by accident!");

--- a/src/main/java/appeng/core/sync/packets/PacketCraftingTreeData.java
+++ b/src/main/java/appeng/core/sync/packets/PacketCraftingTreeData.java
@@ -98,8 +98,8 @@ public class PacketCraftingTreeData extends AppEngPacket {
             AELog.warn("Invalid chunked crafting tree packet received from server: Chunk %d/%d", chunkId, totalChunks);
             return;
         }
-        if (totalChunks == -1) {
-            onFullClientData(receivedData.slice(), player);
+        if (totalChunks == 1) {
+            onFullClientData(receivedData.slice().order(ByteOrder.LITTLE_ENDIAN), player);
         } else {
             boolean packetComplete = false;
             ByteBuf[] storage;

--- a/src/main/java/appeng/core/sync/packets/PacketCraftingTreeData.java
+++ b/src/main/java/appeng/core/sync/packets/PacketCraftingTreeData.java
@@ -2,6 +2,7 @@ package appeng.core.sync.packets;
 
 import java.io.IOException;
 import java.nio.ByteOrder;
+import java.util.*;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
@@ -18,6 +19,7 @@ import appeng.core.features.AEFeature;
 import appeng.core.sync.AppEngPacket;
 import appeng.core.sync.network.INetworkInfo;
 import appeng.crafting.v2.CraftingJobV2;
+import appeng.util.Platform;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -28,6 +30,8 @@ import io.netty.buffer.Unpooled;
 
 public class PacketCraftingTreeData extends AppEngPacket {
 
+    private static final int CHUNK_SIZE = 1024 * 1024; // Send data in 1MiB chunks
+
     // Store data for later deserialization when we get access to the World object
     private ByteBuf receivedData = null;
 
@@ -36,13 +40,22 @@ public class PacketCraftingTreeData extends AppEngPacket {
         if (FMLCommonHandler.instance().getSide() != Side.CLIENT) {
             throw new UnsupportedOperationException("A client tried to use a client-only packet on the server.");
         }
-        receivedData = stream.order(ByteOrder.LITTLE_ENDIAN).slice();
+        receivedData = stream.slice();
     }
 
-    public PacketCraftingTreeData(final CraftingJobV2 job) {
-        final ByteBuf jobData = job.serialize();
-        final ByteBuf output = Unpooled.buffer(jobData.readableBytes() + 4);
+    private PacketCraftingTreeData(final ByteBuf chunkData, int chunkId, int totalChunks) {
+        final ByteBuf output = Unpooled.buffer(12 + chunkData.readableBytes());
         output.writeInt(this.getPacketID());
+        output.writeInt(chunkId);
+        output.writeInt(totalChunks);
+        output.writeBytes(chunkData);
+        this.configureWrite(output);
+    }
+
+    public static List<PacketCraftingTreeData> createChunks(final CraftingJobV2 job) {
+        final ByteBuf jobData = job.serialize();
+        // Compress with GZIP
+        final ByteBuf output = Unpooled.buffer(jobData.readableBytes() + 4);
         try (final ByteBufOutputStream bbos = new ByteBufOutputStream(output);
                 final GZIPOutputStream gzos = new GZIPOutputStream(bbos);
                 final ByteBufInputStream bbis = new ByteBufInputStream(jobData)) {
@@ -51,14 +64,27 @@ public class PacketCraftingTreeData extends AppEngPacket {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+        // Split into chunks
+        final int chunkCount = (int) Platform.ceilDiv(output.readableBytes(), CHUNK_SIZE);
+        final ArrayList<PacketCraftingTreeData> chunks = new ArrayList<>(chunkCount);
+        for (int chunk = 0; chunk < chunkCount; chunk++) {
+            final int start = CHUNK_SIZE * chunk;
+            final int end = Math.min(start + CHUNK_SIZE, output.readableBytes());
+            final int len = end - start;
+            chunks.add(new PacketCraftingTreeData(output.slice(start, len), chunk, chunkCount));
+        }
         if (AEConfig.instance.isFeatureEnabled(AEFeature.DebugLogging)) {
             AELog.info(
-                    "Crafting tree packet raw size %d, compressed %d",
+                    "Crafting tree packet raw size %d, compressed %d, chunk count %d",
                     jobData.writerIndex(),
-                    output.readableBytes());
+                    output.readableBytes(),
+                    chunks.size());
         }
-        this.configureWrite(output);
+        return chunks;
     }
+
+    // Store partially received packets client-side
+    private static final WeakHashMap<EntityPlayer, ByteBuf[]> chunkStorage = new WeakHashMap<>();
 
     @Override
     @SideOnly(Side.CLIENT)
@@ -66,9 +92,40 @@ public class PacketCraftingTreeData extends AppEngPacket {
         if (receivedData == null) {
             return;
         }
+        final int chunkId = receivedData.readInt();
+        final int totalChunks = receivedData.readInt();
+        if (totalChunks <= 0 || chunkId < 0 || chunkId >= totalChunks) {
+            AELog.warn("Invalid chunked crafting tree packet received from server: Chunk %d/%d", chunkId, totalChunks);
+            return;
+        }
+        if (totalChunks == -1) {
+            onFullClientData(receivedData.slice(), player);
+        } else {
+            boolean packetComplete = false;
+            ByteBuf[] storage;
+            synchronized (chunkStorage) {
+                storage = chunkStorage.get(player);
+                if (storage == null || storage.length != totalChunks) {
+                    storage = new ByteBuf[totalChunks];
+                    chunkStorage.put(player, storage);
+                }
+                storage[chunkId] = receivedData.slice().order(ByteOrder.LITTLE_ENDIAN);
+                if (Arrays.stream(storage).noneMatch(Objects::isNull)) {
+                    chunkStorage.remove(player);
+                    packetComplete = true;
+                }
+            }
+            if (packetComplete) {
+                ByteBuf combined = Unpooled.wrappedBuffer(storage).order(ByteOrder.LITTLE_ENDIAN);
+                onFullClientData(combined, player);
+            }
+        }
+    }
+
+    private static void onFullClientData(ByteBuf data, EntityPlayer player) {
         final ByteBuf decompressedData = Unpooled.buffer().order(ByteOrder.LITTLE_ENDIAN);
         try (final ByteBufOutputStream bbos = new ByteBufOutputStream(decompressedData);
-                final ByteBufInputStream bbis = new ByteBufInputStream(receivedData);
+                final ByteBufInputStream bbis = new ByteBufInputStream(data);
                 final GZIPInputStream gzis = new GZIPInputStream(bbis)) {
             IOUtils.copy(gzis, bbos);
             bbos.flush();

--- a/src/main/java/appeng/crafting/v2/CraftingContext.java
+++ b/src/main/java/appeng/crafting/v2/CraftingContext.java
@@ -38,6 +38,7 @@ import appeng.util.Platform;
 import appeng.util.item.AEItemStack;
 import appeng.util.item.OreListMultiMap;
 import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.relauncher.Side;
 
 /**
  * A bundle of state for the crafting operation like the ME grid, who requested crafting, etc.
@@ -259,7 +260,10 @@ public final class CraftingContext {
         if (tasksToProcess.isEmpty()) {
             return finishedState;
         }
-        if (resolvedTasks.size() > AEConfig.instance.maxCraftingSteps) {
+        // Limit number of crafting steps on dedicated servers to prevent abuse, in singleplayer the lag only affects
+        // the player.
+        if (FMLCommonHandler.instance().getSide() == Side.SERVER
+                && resolvedTasks.size() > AEConfig.instance.maxCraftingSteps) {
             this.finishedState = State.FAILURE;
             for (CraftingTask task : tasksToProcess) {
                 if (task.request != null) {


### PR DESCRIPTION
The MC packet limit size is just under 2MB (inherent due to length encoding), the crafting tree packets can be bigger than that so I split them into 1MB chunks. The code has been tested with single and multiple chunk packets.
I also disabled the crafting step limit on singleplayer, because the only reason for it is to prevent lag from breaking other players' experience - in SP this is not a concern.