### PR TITLE
Fix ME Chest storage bus integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1683563728
+//version: 1683705740
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -69,7 +69,7 @@ plugins {
     id 'com.diffplug.spotless' version '6.13.0' apply false // 6.13.0 is the last jvm8 supporting version
     id 'com.modrinth.minotaur' version '2.+' apply false
     id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.7'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.11'
 }
 
 print("You might want to check out './gradlew :faq' if your build fails.\n")
@@ -569,9 +569,10 @@ repositories {
 
 def mixinProviderGroup = "io.github.legacymoddingmc"
 def mixinProviderModule = "unimixins"
-def mixinProviderVersion = "0.1.6"
+def mixinProviderVersion = "0.1.7.1"
 def mixinProviderSpecNoClassifer = "${mixinProviderGroup}:${mixinProviderModule}:${mixinProviderVersion}"
 def mixinProviderSpec = "${mixinProviderSpecNoClassifer}:dev"
+ext.mixinProviderSpec = mixinProviderSpec
 
 dependencies {
     if (usesMixins.toBoolean()) {
@@ -821,6 +822,18 @@ public abstract class RunHotswappableMinecraftTask extends RunMinecraftTask {
             !file.path.contains("2.9.4-nightly-20150209") // Remove lwjgl2
         }
         this.classpath(project.java17DependenciesCfg)
+    }
+
+    public void setup(Project project) {
+        super.setup(project)
+        if (project.usesMixins.toBoolean()) {
+            this.extraJvmArgs.addAll(project.provider(() -> {
+                def mixinCfg = project.configurations.detachedConfiguration(project.dependencies.create(project.mixinProviderSpec))
+                mixinCfg.canBeConsumed = false
+                mixinCfg.transitive = false
+                enableHotswap ? ["-javaagent:" + mixinCfg.singleFile.absolutePath] : []
+            }))
+        }
     }
 }
 

--- a/src/main/java/appeng/tile/storage/TileChest.java
+++ b/src/main/java/appeng/tile/storage/TileChest.java
@@ -693,16 +693,13 @@ public class TileChest extends AENetworkPowerTile
 
         @Override
         public void postChange(final IBaseMonitor<T> monitor, final Iterable<T> change, final BaseActionSource source) {
-            if (source == TileChest.this.mySrc
-                    || (source instanceof PlayerSource && ((PlayerSource) source).via == TileChest.this)) {
-                try {
-                    if (TileChest.this.getProxy().isActive()) {
-                        TileChest.this.getProxy().getStorage()
-                                .postAlterationOfStoredItems(this.chan, change, TileChest.this.mySrc);
-                    }
-                } catch (final GridAccessException e) {
-                    // :(
+            try {
+                if (TileChest.this.getProxy().isActive()) {
+                    TileChest.this.getProxy().getStorage()
+                            .postAlterationOfStoredItems(this.chan, change, TileChest.this.mySrc);
                 }
+            } catch (final GridAccessException e) {
+                // :(
             }
 
             TileChest.this.blinkCell(0);


### PR DESCRIPTION
Limiting ME Chest `postChange` to only care about itself as a source is too restrictive and ignores when contents are changed via direct integration through storage bus for example. Now ME chest will update its own net whenever contents are changed instead of only when they are changed by itself.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13486