### PR TITLE
Forge direction backwards compat

### DIFF
--- a/src/main/java/appeng/parts/layers/LayerIEnergyConnected.java
+++ b/src/main/java/appeng/parts/layers/LayerIEnergyConnected.java
@@ -16,6 +16,11 @@ public class LayerIEnergyConnected extends LayerBase implements IEnergyConnected
 
     public LayerIEnergyConnected() {}
 
+    @Deprecated
+    public long injectEnergyUnits(byte side, long voltage, long amperage) {
+        return injectEnergyUnits(ForgeDirection.getOrientation(side), voltage, amperage);
+    }
+
     public long injectEnergyUnits(ForgeDirection side, long voltage, long amperage) {
         IPart part = this.getPart(side);
         if (part instanceof IPartGT5Power) {
@@ -37,6 +42,11 @@ public class LayerIEnergyConnected extends LayerBase implements IEnergyConnected
         }
     }
 
+    @Deprecated
+    public boolean inputEnergyFrom(byte side) {
+        return inputEnergyFrom(ForgeDirection.getOrientation(side));
+    }
+
     @Override
     public boolean inputEnergyFrom(ForgeDirection side) {
         IPart part = this.getPart(side);
@@ -48,6 +58,11 @@ public class LayerIEnergyConnected extends LayerBase implements IEnergyConnected
             TileEntity source = this.getTileEntityAtSide(side);
             return source != null && ((IEnergySink) part).acceptsEnergyFrom(source, side);
         }
+    }
+
+    @Deprecated
+    public boolean inputEnergyFrom(byte side, boolean waitForActive) {
+        return inputEnergyFrom(ForgeDirection.getOrientation(side), waitForActive);
     }
 
     @Override
@@ -63,10 +78,20 @@ public class LayerIEnergyConnected extends LayerBase implements IEnergyConnected
         }
     }
 
+    @Deprecated
+    public boolean outputsEnergyTo(byte side) {
+        return outputsEnergyTo(ForgeDirection.getOrientation(side));
+    }
+
     @Override
     public boolean outputsEnergyTo(ForgeDirection side) {
         IPart part = this.getPart(side);
         return part instanceof IPartGT5Power && ((IPartGT5Power) part).outputsEnergy();
+    }
+
+    @Deprecated
+    public boolean outputsEnergyTo(byte side, boolean waitForActive) {
+        return outputsEnergyTo(ForgeDirection.getOrientation(side), waitForActive);
     }
 
     @Override

--- a/src/main/java/appeng/parts/p2p/PartP2PGT5Power.java
+++ b/src/main/java/appeng/parts/p2p/PartP2PGT5Power.java
@@ -136,6 +136,20 @@ public class PartP2PGT5Power extends PartP2PTunnel<PartP2PGT5Power> implements I
                 .getTileEntity(te.xCoord + side.offsetX, te.yCoord + side.offsetY, te.zCoord + side.offsetZ);
     }
 
+    private long injectEnergy(IEnergyConnected te, ForgeDirection oppositeSide, long aVoltage, long aAmperage) {
+        try {
+            return te.injectEnergyUnits(oppositeSide, aVoltage, aAmperage);
+        } catch (Throwable e) { // NoSuchMethodException on old GT versions
+            Class<?> iEConn = te.getClass();
+            try {
+                Method injectEU = iEConn.getMethod("injectEnergyUnits", byte.class, long.class, long.class);
+                return (long) injectEU.invoke(te, (byte) oppositeSide.ordinal(), aVoltage, aAmperage);
+            } catch (Throwable error) {
+                return 0L;
+            }
+        }
+    }
+
     private long doOutput(long aVoltage, long aAmperage) {
         if (!this.isOutput()) {
             return 0L;
@@ -146,17 +160,7 @@ public class PartP2PGT5Power extends PartP2PTunnel<PartP2PGT5Power> implements I
             } else {
                 ForgeDirection oppositeSide = this.getSide().getOpposite();
                 if (te instanceof IEnergyConnected) {
-                    try {
-                        return ((IEnergyConnected) te).injectEnergyUnits(oppositeSide, aVoltage, aAmperage);
-                    } catch (Throwable e) { // NoSuchMethodException on old GT versions
-                        Class<?> iEConn = ((IEnergyConnected) te).getClass();
-                        try {
-                            Method injectEU = iEConn.getMethod("injectEnergyUnits", byte.class, long.class, long.class);
-                            return (long) injectEU.invoke(te, (byte) oppositeSide.ordinal(), aVoltage, aAmperage);
-                        } catch (Throwable error) {
-                            return 0L;
-                        }
-                    }
+                    return injectEnergy((IEnergyConnected) te, oppositeSide, aVoltage, aAmperage);
                 } else {
                     if (te instanceof IEnergySink) {
                         if (((IEnergySink) te).acceptsEnergyFrom(this.getTile(), oppositeSide)) {

--- a/src/main/java/appeng/parts/p2p/PartP2PGT5Power.java
+++ b/src/main/java/appeng/parts/p2p/PartP2PGT5Power.java
@@ -1,5 +1,7 @@
 package appeng.parts.p2p;
 
+import java.lang.reflect.Method;
+
 import javax.annotation.Nullable;
 
 import net.minecraft.entity.player.EntityPlayer;
@@ -144,7 +146,17 @@ public class PartP2PGT5Power extends PartP2PTunnel<PartP2PGT5Power> implements I
             } else {
                 ForgeDirection oppositeSide = this.getSide().getOpposite();
                 if (te instanceof IEnergyConnected) {
-                    return ((IEnergyConnected) te).injectEnergyUnits(oppositeSide, aVoltage, aAmperage);
+                    try {
+                        return ((IEnergyConnected) te).injectEnergyUnits(oppositeSide, aVoltage, aAmperage);
+                    } catch (Throwable e) { // NoSuchMethodException on old GT versions
+                        Class<?> iEConn = ((IEnergyConnected) te).getClass();
+                        try {
+                            Method injectEU = iEConn.getMethod("injectEnergyUnits", byte.class, long.class, long.class);
+                            return (long) injectEU.invoke(te, (byte) oppositeSide.ordinal(), aVoltage, aAmperage);
+                        } catch (Throwable error) {
+                            return 0L;
+                        }
+                    }
                 } else {
                     if (te instanceof IEnergySink) {
                         if (((IEnergySink) te).acceptsEnergyFrom(this.getTile(), oppositeSide)) {

--- a/src/main/java/appeng/tile/powersink/GTPowerSink.java
+++ b/src/main/java/appeng/tile/powersink/GTPowerSink.java
@@ -11,6 +11,11 @@ import gregtech.api.interfaces.tileentity.IEnergyConnected;
 @Integration.Interface(iname = IntegrationType.GT, iface = "gregtech.api.interfaces.tileentity.IEnergyConnected")
 public abstract class GTPowerSink extends AERootPoweredTile implements IEnergyConnected {
 
+    @Deprecated
+    public long injectEnergyUnits(byte side, long voltage, long amperage) {
+        return injectEnergyUnits(ForgeDirection.getOrientation(side), voltage, amperage);
+    }
+
     @Override
     public long injectEnergyUnits(ForgeDirection side, long voltage, long amperage) {
         double e = PowerUnits.EU.convertTo(PowerUnits.AE, voltage * amperage);
@@ -28,9 +33,19 @@ public abstract class GTPowerSink extends AERootPoweredTile implements IEnergyCo
         return used;
     }
 
+    @Deprecated
+    public boolean inputEnergyFrom(byte b) {
+        return true;
+    }
+
     @Override
     public boolean inputEnergyFrom(ForgeDirection side) {
         return true;
+    }
+
+    @Deprecated
+    public boolean outputsEnergyTo(byte b) {
+        return false;
     }
 
     @Override


### PR DESCRIPTION
After https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/315 updating AE without updating GT results in many errors. Doing so is pretty common since historically AE has been updatable standalone, so this readds (deprecated) support for old forge direction handling. Probably relevant for keeping compatibility in other GT packs too, but I am less sure on use cases for that.

Relevant error log/conversation https://discord.com/channels/181078474394566657/234936569360809996/1107091276664406097

The reflection feels bad, but I don't know a better way.