### PR TITLE
AE API: Add a method to blacklist items/provide filters based on item/fluid

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1683705740
+//version: 1684218858
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -69,7 +69,7 @@ plugins {
     id 'com.diffplug.spotless' version '6.13.0' apply false // 6.13.0 is the last jvm8 supporting version
     id 'com.modrinth.minotaur' version '2.+' apply false
     id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.11'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.14'
 }
 
 print("You might want to check out './gradlew :faq' if your build fails.\n")
@@ -730,7 +730,7 @@ dependencies {
         java17Dependencies("com.github.GTNewHorizons:lwjgl3ify:${lwjgl3ifyVersion}")
     }
     if (modId != 'hodgepodge') {
-        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.2.8')
+        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.2.13')
     }
 
     java17PatchDependencies('net.minecraft:launchwrapper:1.15') {transitive = false}

--- a/src/main/java/appeng/api/features/IRegistryContainer.java
+++ b/src/main/java/appeng/api/features/IRegistryContainer.java
@@ -17,6 +17,7 @@ import appeng.api.movable.IMovableRegistry;
 import appeng.api.networking.IGridCacheRegistry;
 import appeng.api.storage.ICellRegistry;
 import appeng.api.storage.IExternalStorageRegistry;
+import appeng.api.storage.IItemDisplayRegistry;
 
 /**
  * @author AlgorithmX2
@@ -56,6 +57,11 @@ public interface IRegistryContainer {
      * Allows you to register new cell types, these will function in drives
      */
     ICellRegistry cell();
+
+    /**
+     * Allows you to register items to be blacklisted from item terminals.
+     */
+    IItemDisplayRegistry itemDisplay();
 
     /**
      * Manage grinder recipes via API

--- a/src/main/java/appeng/api/storage/IItemDisplayRegistry.java
+++ b/src/main/java/appeng/api/storage/IItemDisplayRegistry.java
@@ -1,0 +1,37 @@
+package appeng.api.storage;
+
+import java.util.List;
+import java.util.function.BiPredicate;
+
+import net.minecraft.item.Item;
+
+import appeng.api.config.TypeFilter;
+import appeng.api.storage.data.IAEItemStack;
+
+/**
+ * API for item display repo.
+ */
+public interface IItemDisplayRegistry {
+
+    /**
+     * Blacklist the specified item from the item terminals from being displayed in item terminals.
+     */
+    void blacklistItemDisplay(Item item);
+
+    /**
+     * Blacklist the specified item class from being displayed in item terminals. Note that all instances of this class
+     * are blacklisted.
+     */
+    void blacklistItemDisplay(Class<? extends Item> item);
+
+    boolean isBlacklisted(Item item);
+
+    boolean isBlacklisted(Class<? extends Item> item);
+
+    /**
+     * Adds a filter option. This is primarily for ae2fc's item drops, but can be expanded.
+     */
+    void addItemFilter(BiPredicate<TypeFilter, IAEItemStack> filter);
+
+    List<BiPredicate<TypeFilter, IAEItemStack>> getItemFilters();
+}

--- a/src/main/java/appeng/api/storage/data/IDisplayRepo.java
+++ b/src/main/java/appeng/api/storage/data/IDisplayRepo.java
@@ -1,0 +1,35 @@
+package appeng.api.storage.data;
+
+import javax.annotation.Nonnull;
+
+import net.minecraft.item.ItemStack;
+
+/**
+ * Used to display and filter items shown.
+ */
+public interface IDisplayRepo {
+
+    void postUpdate(final IAEItemStack stack);
+
+    void setViewCell(final ItemStack[] filters);
+
+    ItemStack getItem(int idx);
+
+    void updateView();
+
+    int size();
+
+    void clear();
+
+    boolean hasPower();
+
+    void setPowered(final boolean hasPower);
+
+    int getRowSize();
+
+    void setRowSize(final int rowSize);
+
+    String getSearchString();
+
+    void setSearchString(@Nonnull final String searchString);
+}

--- a/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
@@ -22,6 +22,7 @@ import net.minecraft.item.ItemStack;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
 
+import appeng.api.AEApi;
 import appeng.api.config.*;
 import appeng.api.implementations.guiobjects.IPortableCell;
 import appeng.api.implementations.tiles.IMEChest;
@@ -265,7 +266,7 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
                             this.configSrc.getSetting(Settings.VIEW_MODE)));
             offset += 20;
         }
-        if (ItemRepo.getFilter().containsKey(TypeFilter.FLUIDS)) {
+        if (!AEApi.instance().registries().itemDisplay().getItemFilters().isEmpty()) {
             this.buttonList.add(
                     this.typeFilter = new GuiImgButton(
                             this.guiLeft - 18,
@@ -512,7 +513,7 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
 
     @Override
     public void updateScreen() {
-        this.repo.setPower(this.monitorableContainer.isPowered());
+        this.repo.setPowered(this.monitorableContainer.isPowered());
         super.updateScreen();
     }
 

--- a/src/main/java/appeng/core/features/registries/ItemDisplayRegistry.java
+++ b/src/main/java/appeng/core/features/registries/ItemDisplayRegistry.java
@@ -1,0 +1,56 @@
+package appeng.core.features.registries;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.BiPredicate;
+
+import net.minecraft.item.Item;
+
+import appeng.api.config.TypeFilter;
+import appeng.api.storage.IItemDisplayRegistry;
+import appeng.api.storage.data.IAEItemStack;
+
+public final class ItemDisplayRegistry implements IItemDisplayRegistry {
+
+    private final Set<Class<? extends Item>> blacklistedItemClasses;
+    private final Set<Item> blacklistedItems;
+    private final List<BiPredicate<TypeFilter, IAEItemStack>> itemFilters;
+
+    public ItemDisplayRegistry() {
+        this.blacklistedItemClasses = new HashSet<>();
+        this.blacklistedItems = new HashSet<>();
+        this.itemFilters = new ArrayList<>();
+    }
+
+    @Override
+    public void blacklistItemDisplay(Item item) {
+        this.blacklistedItems.add(item);
+    }
+
+    @Override
+    public void blacklistItemDisplay(Class<? extends Item> item) {
+        this.blacklistedItemClasses.add(item);
+    }
+
+    @Override
+    public boolean isBlacklisted(Item item) {
+        return blacklistedItems.contains(item);
+    }
+
+    @Override
+    public boolean isBlacklisted(Class<? extends Item> item) {
+        return blacklistedItemClasses.contains(item);
+    }
+
+    @Override
+    public void addItemFilter(BiPredicate<TypeFilter, IAEItemStack> filter) {
+        this.itemFilters.add(filter);
+    }
+
+    @Override
+    public List<BiPredicate<TypeFilter, IAEItemStack>> getItemFilters() {
+        return itemFilters;
+    }
+}

--- a/src/main/java/appeng/core/features/registries/RegistryContainer.java
+++ b/src/main/java/appeng/core/features/registries/RegistryContainer.java
@@ -15,6 +15,7 @@ import appeng.api.movable.IMovableRegistry;
 import appeng.api.networking.IGridCacheRegistry;
 import appeng.api.storage.ICellRegistry;
 import appeng.api.storage.IExternalStorageRegistry;
+import appeng.api.storage.IItemDisplayRegistry;
 
 /**
  * represents all registries
@@ -30,6 +31,7 @@ public class RegistryContainer implements IRegistryContainer {
     private final IInscriberRegistry inscriber = new InscriberRegistry();
     private final IExternalStorageRegistry storage = new ExternalStorageRegistry();
     private final ICellRegistry cell = new CellRegistry();
+    private final IItemDisplayRegistry itemDisplay = new ItemDisplayRegistry();
     private final ILocatableRegistry locatable = new LocatableRegistry();
     private final ISpecialComparisonRegistry comparison = new SpecialComparisonRegistry();
     private final IWirelessTermRegistry wireless = new WirelessRegistry();
@@ -68,6 +70,11 @@ public class RegistryContainer implements IRegistryContainer {
     @Override
     public ICellRegistry cell() {
         return this.cell;
+    }
+
+    @Override
+    public IItemDisplayRegistry itemDisplay() {
+        return itemDisplay;
     }
 
     @Override


### PR DESCRIPTION
AE API additions.

Items can now be added to the blacklist to prevent them from being shown. This does NOT blacklist them from being stored in storage cells (for the time being), but is provided as a way for mods with special implementations to prevent their items from being shown. (Looking at you, Thaumic Energistics)

While the type filters were previously implemented directly in ItemRepo by asdfjk, this commit adds them to the API, as it feels more appropriate to have them accessible there.

ItemRepo is now extracted as an interface, primarily for AE2FC and other add-ons.

Sure, it makes some of the accessors kind of ugly (API access), but I think API calls are preferred over bytecode tweaking.