### PR TITLE
Use interface instead of class for generalization

### DIFF
--- a/src/main/java/appeng/api/storage/data/IDisplayRepo.java
+++ b/src/main/java/appeng/api/storage/data/IDisplayRepo.java
@@ -13,6 +13,8 @@ public interface IDisplayRepo {
 
     void setViewCell(final ItemStack[] filters);
 
+    IAEItemStack getReferenceItem(int idx);
+
     ItemStack getItem(int idx);
 
     void updateView();

--- a/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
@@ -29,6 +29,7 @@ import appeng.api.implementations.tiles.IMEChest;
 import appeng.api.implementations.tiles.IViewCellStorage;
 import appeng.api.storage.ITerminalHost;
 import appeng.api.storage.data.IAEItemStack;
+import appeng.api.storage.data.IDisplayRepo;
 import appeng.api.util.IConfigManager;
 import appeng.api.util.IConfigurableObject;
 import appeng.client.ActionKey;
@@ -67,7 +68,7 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
     public static int craftingGridOffsetY;
 
     private static String memoryText = "";
-    private final ItemRepo repo;
+    private final IDisplayRepo repo;
     private final int offsetX = 9;
     private final int MAGIC_HEIGHT_NUMBER = 114 + 1;
     private final int lowerTextureOffset = 0;

--- a/src/main/java/appeng/client/me/InternalSlotME.java
+++ b/src/main/java/appeng/client/me/InternalSlotME.java
@@ -13,15 +13,16 @@ package appeng.client.me;
 import net.minecraft.item.ItemStack;
 
 import appeng.api.storage.data.IAEItemStack;
+import appeng.api.storage.data.IDisplayRepo;
 
 public class InternalSlotME {
 
     private final int offset;
     private final int xPos;
     private final int yPos;
-    private final ItemRepo repo;
+    private final IDisplayRepo repo;
 
-    public InternalSlotME(final ItemRepo def, final int offset, final int displayX, final int displayY) {
+    public InternalSlotME(final IDisplayRepo def, final int offset, final int displayX, final int displayY) {
         this.repo = def;
         this.offset = offset;
         this.xPos = displayX;

--- a/src/main/java/appeng/client/me/ItemRepo.java
+++ b/src/main/java/appeng/client/me/ItemRepo.java
@@ -58,6 +58,7 @@ public class ItemRepo implements IDisplayRepo {
         this.sortSrc = sortSrc;
     }
 
+    @Override
     public IAEItemStack getReferenceItem(int idx) {
         idx += this.src.getCurrentScroll() * this.rowSize;
 


### PR DESCRIPTION
Let's just say I forgot a method.

Was missing getReferenceItem, which is used for displaying slots. This way we can swap in implementations and not create our own slot handlers in addons.