### PR TITLE
Crafting tree zoom and screenshot

### DIFF
--- a/src/main/java/appeng/client/gui/AEBaseGui.java
+++ b/src/main/java/appeng/client/gui/AEBaseGui.java
@@ -713,20 +713,29 @@ public abstract class AEBaseGui extends GuiContainer {
             return;
         }
 
-        if (isShiftKeyDown()) {
-            this.mouseWheelEvent(x, y, wheel);
-        } else if (this.getScrollBar() != null) {
-            final GuiScrollbar scrollBar = this.getScrollBar();
+        if (!this.mouseWheelEvent(x, y, wheel)) {
+            if (this.getScrollBar() != null) {
+                final GuiScrollbar scrollBar = this.getScrollBar();
 
-            if (x > this.guiLeft && y - this.guiTop > scrollBar.getTop()
-                    && x <= this.guiLeft + this.xSize
-                    && y - this.guiTop <= scrollBar.getTop() + scrollBar.getHeight()) {
-                this.getScrollBar().wheel(wheel);
+                if (x > this.guiLeft && y - this.guiTop > scrollBar.getTop()
+                        && x <= this.guiLeft + this.xSize
+                        && y - this.guiTop <= scrollBar.getTop() + scrollBar.getHeight()) {
+                    this.getScrollBar().wheel(wheel);
+                }
             }
         }
     }
 
-    private void mouseWheelEvent(final int x, final int y, final int wheel) {
+    /**
+     * @param x     Current mouse X coordinate
+     * @param y     Current mouse Y coordinate
+     * @param wheel Wheel movement normalized to units of 1
+     * @return If the event was handled
+     */
+    protected boolean mouseWheelEvent(final int x, final int y, final int wheel) {
+        if (!isShiftKeyDown()) {
+            return false;
+        }
         final Slot slot = this.getSlot(x, y);
         if (slot instanceof SlotME) {
             final IAEItemStack item = ((SlotME) slot).getAEStack();
@@ -741,6 +750,7 @@ public abstract class AEBaseGui extends GuiContainer {
                 }
             }
         }
+        return true;
     }
 
     protected boolean enableSpaceClicking() {

--- a/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
@@ -34,6 +34,7 @@ import appeng.client.gui.widgets.*;
 import appeng.container.implementations.ContainerCraftConfirm;
 import appeng.container.implementations.CraftingCPUStatus;
 import appeng.core.AELog;
+import appeng.core.localization.ButtonToolTips;
 import appeng.core.localization.GuiColors;
 import appeng.core.localization.GuiText;
 import appeng.core.sync.GuiBridge;
@@ -122,6 +123,7 @@ public class GuiCraftConfirm extends AEBaseGui implements ICraftingCPUTableHolde
     private GuiButton start;
     private GuiButton selectCPU;
     private GuiImgButton switchTallMode;
+    private GuiSimpleImgButton takeScreenshot;
     private GuiTabButton switchDisplayMode;
     private int tooltip = -1;
     private ItemStack hoveredStack;
@@ -213,6 +215,13 @@ public class GuiCraftConfirm extends AEBaseGui implements ICraftingCPUTableHolde
                 tallMode ? TerminalStyle.TALL : TerminalStyle.SMALL);
         this.buttonList.add(switchTallMode);
 
+        this.takeScreenshot = new GuiSimpleImgButton(
+                this.guiLeft - 18,
+                this.guiTop + 184,
+                16 * 9,
+                ButtonToolTips.SaveAsImage.getLocal());
+        this.buttonList.add(takeScreenshot);
+
         this.switchDisplayMode = new GuiTabButton(
                 this.guiLeft + this.xSize - 25,
                 this.guiTop - 4,
@@ -239,6 +248,7 @@ public class GuiCraftConfirm extends AEBaseGui implements ICraftingCPUTableHolde
 
         this.selectCPU.enabled = (displayMode == DisplayMode.LIST) && !this.isSimulation();
         this.selectCPU.visible = (displayMode == DisplayMode.LIST);
+        this.takeScreenshot.visible = (displayMode == DisplayMode.TREE);
 
         super.drawScreen(mouseX, mouseY, btn);
 
@@ -733,6 +743,10 @@ public class GuiCraftConfirm extends AEBaseGui implements ICraftingCPUTableHolde
             switchTallMode.set(tallMode ? TerminalStyle.TALL : TerminalStyle.SMALL);
             recalculateScreenSize();
             this.setWorldAndResolution(mc, width, height);
+        } else if (btn == this.takeScreenshot) {
+            if (craftingTree != null) {
+                craftingTree.saveScreenshot();
+            }
         } else if (btn == this.start) {
             try {
                 NetworkHandler.instance.sendToServer(new PacketValueConfig("Terminal.Start", "Start"));

--- a/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
@@ -648,6 +648,16 @@ public class GuiCraftConfirm extends AEBaseGui implements ICraftingCPUTableHolde
         }
     }
 
+    @Override
+    protected boolean mouseWheelEvent(int x, int y, int wheel) {
+        if (displayMode == DisplayMode.TREE && craftingTree != null
+                && craftingTree.isPointInWidget(x - guiLeft, y - guiTop)) {
+            craftingTree.onMouseWheel(x - guiLeft, y - guiTop, wheel);
+            return true;
+        }
+        return super.mouseWheelEvent(x, y, wheel);
+    }
+
     private long getTotal(final IAEItemStack is) {
         final IAEItemStack a = this.storage.findPrecise(is);
         final IAEItemStack c = this.pending.findPrecise(is);

--- a/src/main/java/appeng/client/gui/widgets/GuiCraftingTree.java
+++ b/src/main/java/appeng/client/gui/widgets/GuiCraftingTree.java
@@ -535,17 +535,12 @@ public class GuiCraftingTree {
             final String date = SCREENSHOT_DATE_FORMAT.format(LocalDateTime.now());
             String filename = String.format("%s-ae2.png", date);
             File outFile = new File(screenshotsDir, filename);
+            for (int i = 1; outFile.exists() && i < 99; i++) {
+                filename = String.format("%s-ae2-%d.png", date, i);
+                outFile = new File(screenshotsDir, filename);
+            }
             if (outFile.exists()) {
-                for (int i = 1; i < 99; i++) {
-                    filename = String.format("%s-ae2-%d.png", date, i);
-                    outFile = new File(screenshotsDir, filename);
-                    if (!outFile.exists()) {
-                        break;
-                    }
-                }
-                if (outFile.exists()) {
-                    throw new FileAlreadyExistsException(filename);
-                }
+                throw new FileAlreadyExistsException(filename);
             }
             ImageIO.write(outputImg, "png", outFile);
 

--- a/src/main/java/appeng/client/gui/widgets/GuiCraftingTree.java
+++ b/src/main/java/appeng/client/gui/widgets/GuiCraftingTree.java
@@ -1,17 +1,35 @@
 package appeng.client.gui.widgets;
 
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.nio.IntBuffer;
+import java.nio.file.FileAlreadyExistsException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.Map.Entry;
 
+import javax.imageio.ImageIO;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.OpenGlHelper;
+import net.minecraft.client.shader.Framebuffer;
+import net.minecraft.event.ClickEvent;
+import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.MathHelper;
 
+import org.apache.commons.io.FileUtils;
+import org.lwjgl.BufferUtils;
 import org.lwjgl.input.Mouse;
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
 
 import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IAEStack;
 import appeng.client.gui.AEBaseGui;
+import appeng.core.AELog;
 import appeng.core.localization.GuiColors;
 import appeng.crafting.v2.CraftingRequest;
 import appeng.crafting.v2.CraftingRequest.UsedResolverEntry;
@@ -19,6 +37,7 @@ import appeng.crafting.v2.resolvers.CraftableItemResolver.CraftFromPatternTask;
 import appeng.crafting.v2.resolvers.EmitableItemResolver.EmitItemTask;
 import appeng.crafting.v2.resolvers.ExtractItemResolver.ExtractItemTask;
 import appeng.crafting.v2.resolvers.SimulateMissingItemResolver;
+import appeng.util.Platform;
 import appeng.util.ReadableNumberConverter;
 
 public class GuiCraftingTree {
@@ -308,6 +327,10 @@ public class GuiCraftingTree {
     }
 
     public void draw(int guiMouseX, int guiMouseY) {
+        draw(guiMouseX, guiMouseY, false);
+    }
+
+    public void draw(int guiMouseX, int guiMouseY, boolean inScreenshotMode) {
         if (request == null) {
             return;
         }
@@ -339,7 +362,10 @@ public class GuiCraftingTree {
 
         GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS);
 
-        float guiScaleFactor = (float) parent.mc.displayWidth / (float) parent.width;
+        final float guiScaleFactor = inScreenshotMode ? 1.0f : ((float) parent.mc.displayWidth / (float) parent.width);
+        final float zoomLevel = inScreenshotMode ? 1.0f : this.zoomLevel;
+        final float scrollX = inScreenshotMode ? -8.0f : this.scrollX;
+        final float scrollY = inScreenshotMode ? -8.0f : this.scrollY;
         final int widgetBottomY = parent.getYSize() - widgetY - widgetH;
 
         final float zScrollX = scrollX * zoomLevel;
@@ -350,27 +376,31 @@ public class GuiCraftingTree {
         final int cropXMax = (int) ((zScrollX + 32) / zoomLevel) + (int) (widgetW / zoomLevel);
 
         // Scissor rect 0,0 is in the bottom left corner of the screen
-        GL11.glScissor(
-                (int) ((parent.getGuiLeft() + widgetX) * guiScaleFactor),
-                (int) ((parent.getGuiTop() + widgetBottomY) * guiScaleFactor),
-                (int) (widgetW * guiScaleFactor),
-                (int) (widgetH * guiScaleFactor));
-        GL11.glEnable(GL11.GL_SCISSOR_TEST);
+        if (!inScreenshotMode) {
+            GL11.glScissor(
+                    (int) ((parent.getGuiLeft() + widgetX) * guiScaleFactor),
+                    (int) ((parent.getGuiTop() + widgetBottomY) * guiScaleFactor),
+                    (int) (widgetW * guiScaleFactor),
+                    (int) (widgetH * guiScaleFactor));
+            GL11.glEnable(GL11.GL_SCISSOR_TEST);
+        }
         GL11.glPushMatrix();
 
         // Round to the nearest real pixel
-        GL11.glTranslatef(widgetX - zScrollX, widgetY - zScrollY, 0.0f);
-        GL11.glScalef(zoomLevel, zoomLevel, 1.0f);
+        if (!inScreenshotMode) {
+            GL11.glTranslatef(widgetX - zScrollX, widgetY - zScrollY, 0.0f);
+            GL11.glScalef(zoomLevel, zoomLevel, 1.0f);
+        }
 
-        SortedMap<Integer, ArrayList<Node>> rows = treeNodes.subMap(cropYMin, cropYMax);
+        SortedMap<Integer, ArrayList<Node>> rows = inScreenshotMode ? treeNodes : treeNodes.subMap(cropYMin, cropYMax);
         tooltipNode = null;
         for (Entry<Integer, ArrayList<Node>> row : rows.entrySet()) {
             for (Node node : row.getValue()) {
                 if (!node.visible) {
                     continue;
                 }
-                if (node.x > cropXMin) {
-                    if (node.x > cropXMax) {
+                if (inScreenshotMode || node.x > cropXMin) {
+                    if (!inScreenshotMode && node.x > cropXMax) {
                         if (node.parentNode != null && node.parentNode.x < cropXMax) {
                             node.drawParentLine();
                         }
@@ -382,7 +412,8 @@ public class GuiCraftingTree {
                     final int nodeX = widgetLeft + (int) (node.x * zoomLevel) - (int) zScrollX;
                     final int widgetTop = parent.getGuiTop() + widgetY;
                     final int nodeY = widgetTop + (int) (node.y * zoomLevel) - (int) zScrollY;
-                    if (guiMouseX >= nodeX && guiMouseY >= nodeY
+                    if (!inScreenshotMode && guiMouseX >= nodeX
+                            && guiMouseY >= nodeY
                             && guiMouseX <= (nodeX + (int) (node.width * zoomLevel))
                             && guiMouseY <= (nodeY + (int) (node.height * zoomLevel))
                             && guiMouseX >= widgetLeft
@@ -395,19 +426,140 @@ public class GuiCraftingTree {
             }
         }
         GL11.glPopMatrix();
-        float scrollXPct = MathHelper.clamp_float(scrollX / treeWidth, 0.0f, 1.0f);
-        float scrollYPct = MathHelper.clamp_float(scrollY / treeHeight, 0.0f, 1.0f);
-        parent.drawHorizontalLine(
-                (int) (widgetX + scrollXPct * (widgetW - 24)),
-                (int) (widgetX + scrollXPct * (widgetW - 24)) + 24,
-                widgetY + widgetH - 2,
-                0xFFDDDDDD);
-        parent.drawVerticalLine(
-                widgetX + widgetW - 2,
-                (int) (widgetY + scrollYPct * (widgetH - 24)),
-                (int) (widgetY + scrollYPct * (widgetH - 24)) + 24,
-                0xFFDDDDDD);
+        if (!inScreenshotMode) {
+            float scrollXPct = MathHelper.clamp_float(scrollX / treeWidth, 0.0f, 1.0f);
+            float scrollYPct = MathHelper.clamp_float(scrollY / treeHeight, 0.0f, 1.0f);
+            parent.drawHorizontalLine(
+                    (int) (widgetX + scrollXPct * (widgetW - 24)),
+                    (int) (widgetX + scrollXPct * (widgetW - 24)) + 24,
+                    widgetY + widgetH - 2,
+                    0xFFDDDDDD);
+            parent.drawVerticalLine(
+                    widgetX + widgetW - 2,
+                    (int) (widgetY + scrollYPct * (widgetH - 24)),
+                    (int) (widgetY + scrollYPct * (widgetH - 24)) + 24,
+                    0xFFDDDDDD);
+        }
         GL11.glPopAttrib();
+    }
+
+    private static final DateTimeFormatter SCREENSHOT_DATE_FORMAT = DateTimeFormatter
+            .ofPattern("yyyy-MM-dd_HH.mm.ss", Locale.ROOT);
+
+    public void saveScreenshot() {
+        if (this.request == null) {
+            return;
+        }
+        final Minecraft mc = Minecraft.getMinecraft();
+        if (!OpenGlHelper.isFramebufferEnabled()) {
+            AELog.error("Could not save crafting tree screenshot: FBOs disabled/unsupported");
+            mc.ingameGUI.getChatGUI()
+                    .printChatMessage(new ChatComponentTranslation("chat.appliedenergistics2.FBOUnsupported"));
+            return;
+        }
+        try {
+            final int screenshotZoom = 2;
+            final File screenshotsDir = new File(mc.mcDataDir, "screenshots");
+            FileUtils.forceMkdir(screenshotsDir);
+            final int maxGlTexSize = GL11.glGetInteger(GL11.GL_MAX_TEXTURE_SIZE) / 2; // Divide by 2 to be safe
+            int imgWidth = screenshotZoom * (treeWidth + 32);
+            int imgHeight = screenshotZoom * (treeHeight + 32);
+            // Make sure the image can be actually allocated, worst case it'll be cropped
+            while ((long) imgWidth * (long) imgHeight >= (long) Integer.MAX_VALUE / 4) {
+                if (imgWidth > imgHeight) {
+                    imgWidth /= 2;
+                } else {
+                    imgHeight /= 2;
+                }
+            }
+            final int xChunks = (int) Platform.ceilDiv(imgWidth, maxGlTexSize);
+            final int yChunks = (int) Platform.ceilDiv(imgHeight, maxGlTexSize);
+            final int fbWidth = Math.min(imgWidth, maxGlTexSize);
+            final int fbHeight = Math.min(imgHeight, maxGlTexSize);
+            final BufferedImage outputImg = new BufferedImage(imgWidth, imgHeight, BufferedImage.TYPE_INT_ARGB);
+            final IntBuffer downloadBuffer = BufferUtils.createIntBuffer(fbWidth * fbHeight);
+            GL11.glPushMatrix();
+            GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS);
+            final Framebuffer fb = new Framebuffer(fbWidth, fbHeight, true);
+            GL11.glMatrixMode(GL11.GL_PROJECTION);
+            GL11.glLoadIdentity();
+            GL11.glOrtho(0, fbWidth / (float) screenshotZoom, fbHeight / (float) screenshotZoom, 0, 1000, 3000);
+            GL11.glMatrixMode(GL11.GL_MODELVIEW);
+            GL11.glLoadIdentity();
+            GL11.glDisable(GL11.GL_DEPTH_TEST);
+            try {
+                fb.bindFramebuffer(true);
+                for (int xChunk = 0; xChunk < xChunks; xChunk++) {
+                    final int xStart = xChunk * maxGlTexSize;
+                    final int xEnd = Math.min((xChunk + 1) * maxGlTexSize, imgWidth);
+                    final int xChunkSize = xEnd - xStart;
+                    for (int yChunk = 0; yChunk < yChunks; yChunk++) {
+                        final int yStart = yChunk * maxGlTexSize;
+                        final int yEnd = Math.min((yChunk + 1) * maxGlTexSize, imgHeight);
+                        final int yChunkSize = yEnd - yStart;
+
+                        GL11.glPushMatrix();
+                        GL11.glTranslatef(
+                                8 - xStart / (float) screenshotZoom,
+                                8 - yStart / (float) screenshotZoom,
+                                -2000.0f);
+                        GL11.glClear(GL11.GL_COLOR_BUFFER_BIT | GL11.GL_DEPTH_BUFFER_BIT);
+                        draw(-1000, -1000, true);
+                        GL11.glPopMatrix();
+
+                        GL11.glBindTexture(GL11.GL_TEXTURE_2D, fb.framebufferTexture);
+                        GL11.glGetTexImage(
+                                GL11.GL_TEXTURE_2D,
+                                0,
+                                GL12.GL_BGRA,
+                                GL12.GL_UNSIGNED_INT_8_8_8_8_REV,
+                                downloadBuffer);
+
+                        for (int y = 0; y < yChunkSize; y++) {
+                            for (int x = 0; x < xChunkSize; x++) {
+                                outputImg.setRGB(
+                                        x + xStart,
+                                        y + yStart,
+                                        downloadBuffer.get((fbHeight - 1 - y) * fbWidth + x));
+                            }
+                        }
+                    }
+                }
+            } finally {
+                fb.deleteFramebuffer();
+                GL11.glViewport(0, 0, mc.displayWidth, mc.displayHeight);
+            }
+            GL11.glPopAttrib();
+            GL11.glPopMatrix();
+
+            final String date = SCREENSHOT_DATE_FORMAT.format(LocalDateTime.now());
+            String filename = String.format("%s-ae2.png", date);
+            File outFile = new File(screenshotsDir, filename);
+            if (outFile.exists()) {
+                for (int i = 1; i < 99; i++) {
+                    filename = String.format("%s-ae2-%d.png", date, i);
+                    outFile = new File(screenshotsDir, filename);
+                    if (!outFile.exists()) {
+                        break;
+                    }
+                }
+                if (outFile.exists()) {
+                    throw new FileAlreadyExistsException(filename);
+                }
+            }
+            ImageIO.write(outputImg, "png", outFile);
+
+            AELog.info("Saved crafting tree screenshot to %s", filename);
+            ChatComponentText chatLink = new ChatComponentText(filename);
+            chatLink.getChatStyle()
+                    .setChatClickEvent(new ClickEvent(ClickEvent.Action.OPEN_FILE, outFile.getAbsolutePath()));
+            chatLink.getChatStyle().setUnderlined(Boolean.valueOf(true));
+            mc.ingameGUI.getChatGUI().printChatMessage(new ChatComponentTranslation("screenshot.success", chatLink));
+        } catch (Exception e) {
+            AELog.warn(e, "Could not save crafting tree screenshot");
+            mc.ingameGUI.getChatGUI()
+                    .printChatMessage(new ChatComponentTranslation("screenshot.failure", e.getMessage()));
+        }
     }
 
     public void drawTooltip(int guiMouseX, int guiMouseY) {

--- a/src/main/java/appeng/client/gui/widgets/GuiSimpleImgButton.java
+++ b/src/main/java/appeng/client/gui/widgets/GuiSimpleImgButton.java
@@ -1,0 +1,147 @@
+package appeng.client.gui.widgets;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiButton;
+
+import org.lwjgl.opengl.GL11;
+
+import appeng.client.texture.ExtraBlockTextures;
+
+public class GuiSimpleImgButton extends GuiButton implements ITooltip {
+
+    private boolean halfSize = false;
+    private String fillVar;
+    private int iconIndex;
+    private String tooltip;
+
+    public GuiSimpleImgButton(final int x, final int y, final int iconIndex, final String tooltip) {
+        super(0, 0, 16, "");
+
+        this.xPosition = x;
+        this.yPosition = y;
+        this.width = 16;
+        this.height = 16;
+        this.iconIndex = iconIndex;
+        this.tooltip = tooltip;
+    }
+
+    public void setVisibility(final boolean vis) {
+        this.visible = vis;
+        this.enabled = vis;
+    }
+
+    @Override
+    public void drawButton(final Minecraft par1Minecraft, final int par2, final int par3) {
+        if (this.visible) {
+            if (this.halfSize) {
+                this.width = 8;
+                this.height = 8;
+
+                GL11.glPushMatrix();
+                GL11.glTranslatef(this.xPosition, this.yPosition, 0.0F);
+                GL11.glScalef(0.5f, 0.5f, 0.5f);
+
+                if (this.enabled) {
+                    GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
+                } else {
+                    GL11.glColor4f(0.5f, 0.5f, 0.5f, 1.0f);
+                }
+
+                par1Minecraft.renderEngine.bindTexture(ExtraBlockTextures.GuiTexture("guis/states.png"));
+                this.field_146123_n = par2 >= this.xPosition && par3 >= this.yPosition
+                        && par2 < this.xPosition + this.width
+                        && par3 < this.yPosition + this.height;
+
+                final int uv_y = (int) Math.floor(iconIndex / 16);
+                final int uv_x = iconIndex - uv_y * 16;
+
+                this.drawTexturedModalRect(0, 0, 256 - 16, 256 - 16, 16, 16);
+                this.drawTexturedModalRect(0, 0, uv_x * 16, uv_y * 16, 16, 16);
+                this.mouseDragged(par1Minecraft, par2, par3);
+
+                GL11.glPopMatrix();
+            } else {
+                if (this.enabled) {
+                    GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
+                } else {
+                    GL11.glColor4f(0.5f, 0.5f, 0.5f, 1.0f);
+                }
+
+                par1Minecraft.renderEngine.bindTexture(ExtraBlockTextures.GuiTexture("guis/states.png"));
+                this.field_146123_n = par2 >= this.xPosition && par3 >= this.yPosition
+                        && par2 < this.xPosition + this.width
+                        && par3 < this.yPosition + this.height;
+
+                final int uv_y = (int) Math.floor(iconIndex / 16);
+                final int uv_x = iconIndex - uv_y * 16;
+
+                this.drawTexturedModalRect(this.xPosition, this.yPosition, 256 - 16, 256 - 16, 16, 16);
+                this.drawTexturedModalRect(this.xPosition, this.yPosition, uv_x * 16, uv_y * 16, 16, 16);
+                this.mouseDragged(par1Minecraft, par2, par3);
+            }
+        }
+        GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
+    }
+
+    @Override
+    public String getMessage() {
+        return tooltip;
+    }
+
+    @Override
+    public int xPos() {
+        return this.xPosition;
+    }
+
+    @Override
+    public int yPos() {
+        return this.yPosition;
+    }
+
+    @Override
+    public int getWidth() {
+        return this.halfSize ? 8 : 16;
+    }
+
+    @Override
+    public int getHeight() {
+        return this.halfSize ? 8 : 16;
+    }
+
+    @Override
+    public boolean isVisible() {
+        return this.visible;
+    }
+
+    public boolean isHalfSize() {
+        return this.halfSize;
+    }
+
+    public void setHalfSize(final boolean halfSize) {
+        this.halfSize = halfSize;
+    }
+
+    public String getFillVar() {
+        return this.fillVar;
+    }
+
+    public void setFillVar(final String fillVar) {
+        this.fillVar = fillVar;
+    }
+
+    public int getIconIndex() {
+        return iconIndex;
+    }
+
+    public void setIconIndex(int iconIndex) {
+        this.iconIndex = iconIndex;
+    }
+
+    public String getTooltip() {
+        return tooltip;
+    }
+
+    public void setTooltip(String tooltip) {
+        this.tooltip = tooltip;
+    }
+}

--- a/src/main/java/appeng/client/gui/widgets/GuiSimpleImgButton.java
+++ b/src/main/java/appeng/client/gui/widgets/GuiSimpleImgButton.java
@@ -9,8 +9,6 @@ import appeng.client.texture.ExtraBlockTextures;
 
 public class GuiSimpleImgButton extends GuiButton implements ITooltip {
 
-    private boolean halfSize = false;
-    private String fillVar;
     private int iconIndex;
     private String tooltip;
 
@@ -33,52 +31,23 @@ public class GuiSimpleImgButton extends GuiButton implements ITooltip {
     @Override
     public void drawButton(final Minecraft par1Minecraft, final int par2, final int par3) {
         if (this.visible) {
-            if (this.halfSize) {
-                this.width = 8;
-                this.height = 8;
-
-                GL11.glPushMatrix();
-                GL11.glTranslatef(this.xPosition, this.yPosition, 0.0F);
-                GL11.glScalef(0.5f, 0.5f, 0.5f);
-
-                if (this.enabled) {
-                    GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
-                } else {
-                    GL11.glColor4f(0.5f, 0.5f, 0.5f, 1.0f);
-                }
-
-                par1Minecraft.renderEngine.bindTexture(ExtraBlockTextures.GuiTexture("guis/states.png"));
-                this.field_146123_n = par2 >= this.xPosition && par3 >= this.yPosition
-                        && par2 < this.xPosition + this.width
-                        && par3 < this.yPosition + this.height;
-
-                final int uv_y = (int) Math.floor(iconIndex / 16);
-                final int uv_x = iconIndex - uv_y * 16;
-
-                this.drawTexturedModalRect(0, 0, 256 - 16, 256 - 16, 16, 16);
-                this.drawTexturedModalRect(0, 0, uv_x * 16, uv_y * 16, 16, 16);
-                this.mouseDragged(par1Minecraft, par2, par3);
-
-                GL11.glPopMatrix();
+            if (this.enabled) {
+                GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
             } else {
-                if (this.enabled) {
-                    GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
-                } else {
-                    GL11.glColor4f(0.5f, 0.5f, 0.5f, 1.0f);
-                }
-
-                par1Minecraft.renderEngine.bindTexture(ExtraBlockTextures.GuiTexture("guis/states.png"));
-                this.field_146123_n = par2 >= this.xPosition && par3 >= this.yPosition
-                        && par2 < this.xPosition + this.width
-                        && par3 < this.yPosition + this.height;
-
-                final int uv_y = (int) Math.floor(iconIndex / 16);
-                final int uv_x = iconIndex - uv_y * 16;
-
-                this.drawTexturedModalRect(this.xPosition, this.yPosition, 256 - 16, 256 - 16, 16, 16);
-                this.drawTexturedModalRect(this.xPosition, this.yPosition, uv_x * 16, uv_y * 16, 16, 16);
-                this.mouseDragged(par1Minecraft, par2, par3);
+                GL11.glColor4f(0.5f, 0.5f, 0.5f, 1.0f);
             }
+
+            par1Minecraft.renderEngine.bindTexture(ExtraBlockTextures.GuiTexture("guis/states.png"));
+            this.field_146123_n = par2 >= this.xPosition && par3 >= this.yPosition
+                    && par2 < this.xPosition + this.width
+                    && par3 < this.yPosition + this.height;
+
+            final int uv_y = iconIndex / 16;
+            final int uv_x = iconIndex - uv_y * 16;
+
+            this.drawTexturedModalRect(this.xPosition, this.yPosition, 256 - 16, 256 - 16, 16, 16);
+            this.drawTexturedModalRect(this.xPosition, this.yPosition, uv_x * 16, uv_y * 16, 16, 16);
+            this.mouseDragged(par1Minecraft, par2, par3);
         }
         GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
     }
@@ -100,33 +69,17 @@ public class GuiSimpleImgButton extends GuiButton implements ITooltip {
 
     @Override
     public int getWidth() {
-        return this.halfSize ? 8 : 16;
+        return 16;
     }
 
     @Override
     public int getHeight() {
-        return this.halfSize ? 8 : 16;
+        return 16;
     }
 
     @Override
     public boolean isVisible() {
         return this.visible;
-    }
-
-    public boolean isHalfSize() {
-        return this.halfSize;
-    }
-
-    public void setHalfSize(final boolean halfSize) {
-        this.halfSize = halfSize;
-    }
-
-    public String getFillVar() {
-        return this.fillVar;
-    }
-
-    public void setFillVar(final String fillVar) {
-        this.fillVar = fillVar;
     }
 
     public int getIconIndex() {

--- a/src/main/java/appeng/core/localization/ButtonToolTips.java
+++ b/src/main/java/appeng/core/localization/ButtonToolTips.java
@@ -93,6 +93,7 @@ public enum ButtonToolTips {
     TerminalStyle_Full,
     TerminalStyle_Tall,
     TerminalStyle_Small,
+    SaveAsImage,
 
     Stash,
     StashDesc,

--- a/src/main/resources/assets/appliedenergistics2/lang/en_US.lang
+++ b/src/main/resources/assets/appliedenergistics2/lang/en_US.lang
@@ -104,6 +104,7 @@ chat.appliedenergistics2.TunnelOutputsAreAt=Tunnel outputs are at:
 chat.appliedenergistics2.InterfaceInOtherDim=Interface located at dimension: %d and cant be highlighted
 chat.appliedenergistics2.InterfaceHighlighted=The interface is now highlighted at %d, %d, %d
 chat.appliedenergistics2.CraftingItemsWentMissing=Could not start craft, ingredient went missing: %d * %s
+chat.appliedenergistics2.FBOUnsupported=OpenGL FBOs not supported, cannot export image
 # Creative Tabs
 itemGroup.appliedenergistics2=Applied Energistics 2
 itemGroup.appliedenergistics2.facades=Applied Energistics 2 - Facades
@@ -368,6 +369,7 @@ gui.tooltips.appliedenergistics2.TerminalStyle=Terminal Style
 gui.tooltips.appliedenergistics2.TerminalStyle_Full=Full Screen Terminal
 gui.tooltips.appliedenergistics2.TerminalStyle_Tall=Tall Centered Terminal
 gui.tooltips.appliedenergistics2.TerminalStyle_Small=Small Centered Terminal
+gui.tooltips.appliedenergistics2.SaveAsImage=Save as image
 
 gui.tooltips.appliedenergistics2.DoesntDespawn=This item won't de-spawn.
 gui.tooltips.appliedenergistics2.EmitterMode=Crafting Emitter Mode


### PR DESCRIPTION
Adds zooming into the crafting tree with the scroll wheel and a button to export the full tree to a png file in the screenshots folder.
Example export:
![2023-06-06_21 34 27-ae2](https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/assets/1017004/170877c5-c0ac-40cd-9abe-b8d2f1184843)

Closes <https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13532>
