### PR TITLE
Optimize craft execution with many co-processors

### DIFF
--- a/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
+++ b/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
@@ -563,160 +563,156 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
             }
 
             final ICraftingPatternDetails details = e.getKey();
-
             if (!this.canCraft(details, details.getCondensedInputs())) {
                 i.remove(); // No need to revisit this task on next executeCrafting this tick
                 continue;
-            } else {
-                InventoryCrafting ic = null;
-                boolean pushedPattern = false;
+            }
 
-                for (final ICraftingMedium m : cc.getMediums(e.getKey())) {
-                    if (e.getValue().value <= 0 || knownBusyMediums.contains(m)) {
-                        continue;
+            InventoryCrafting ic = null;
+            boolean pushedPattern = false;
+
+            for (final ICraftingMedium m : cc.getMediums(e.getKey())) {
+                if (e.getValue().value <= 0 || knownBusyMediums.contains(m)) {
+                    continue;
+                }
+
+                if (m.isBusy()) {
+                    knownBusyMediums.add(m);
+                    continue;
+                }
+
+                double sum = 0;
+                if (ic == null) {
+                    final IAEItemStack[] input = details.getInputs();
+
+                    for (final IAEItemStack anInput : input) {
+                        if (anInput != null) {
+                            sum += anInput.getStackSize();
+                        }
                     }
+                    // upgraded interface uses more power
+                    if (m instanceof DualityInterface)
+                        sum *= Math.pow(4.0, ((DualityInterface) m).getInstalledUpgrades(Upgrades.PATTERN_CAPACITY));
 
-                    if (m.isBusy()) {
-                        knownBusyMediums.add(m);
-                        continue;
-                    } else {
-                        double sum = 0;
-                        if (ic == null) {
-                            final IAEItemStack[] input = details.getInputs();
+                    // check if there is enough power
+                    if (eg.extractAEPower(sum, Actionable.SIMULATE, PowerMultiplier.CONFIG) < sum - 0.01) continue;
 
-                            for (final IAEItemStack anInput : input) {
-                                if (anInput != null) {
-                                    sum += anInput.getStackSize();
+                    ic = details.isCraftable() ? new InventoryCrafting(new ContainerNull(), 3, 3)
+                            : new InventoryCrafting(new ContainerNull(), details.getInputs().length, 1);
+
+                    boolean found = false;
+                    for (int x = 0; x < input.length; x++) {
+                        if (input[x] != null) {
+                            found = false;
+                            for (IAEItemStack ias : getExtractItems(input[x], details)) {
+                                if (details.isCraftable()
+                                        && !details.isValidItemForSlot(x, ias.getItemStack(), this.getWorld())) {
+                                    continue;
+                                }
+                                final IAEItemStack ais = this.inventory
+                                        .extractItems(ias, Actionable.MODULATE, this.machineSrc);
+                                final ItemStack is = ais == null ? null : ais.getItemStack();
+                                if (is == null) continue;
+                                found = true;
+                                ic.setInventorySlotContents(x, is);
+                                if (!details.canBeSubstitute() && is.stackSize == input[x].getStackSize()) {
+                                    this.postChange(input[x], this.machineSrc);
+                                    break;
+                                } else {
+                                    this.postChange(AEItemStack.create(is), this.machineSrc);
                                 }
                             }
-                            // upgraded interface uses more power
-                            if (m instanceof DualityInterface) sum *= Math
-                                    .pow(4.0, ((DualityInterface) m).getInstalledUpgrades(Upgrades.PATTERN_CAPACITY));
-
-                            // check if there is enough power
-                            if (eg.extractAEPower(sum, Actionable.SIMULATE, PowerMultiplier.CONFIG) < sum - 0.01)
-                                continue;
-
-                            ic = details.isCraftable() ? new InventoryCrafting(new ContainerNull(), 3, 3)
-                                    : new InventoryCrafting(new ContainerNull(), details.getInputs().length, 1);
-
-                            boolean found = false;
-                            for (int x = 0; x < input.length; x++) {
-                                if (input[x] != null) {
-                                    found = false;
-                                    for (IAEItemStack ias : getExtractItems(input[x], details)) {
-                                        if (details.isCraftable() && !details
-                                                .isValidItemForSlot(x, ias.getItemStack(), this.getWorld())) {
-                                            continue;
-                                        }
-                                        final IAEItemStack ais = this.inventory
-                                                .extractItems(ias, Actionable.MODULATE, this.machineSrc);
-                                        final ItemStack is = ais == null ? null : ais.getItemStack();
-                                        if (is == null) continue;
-                                        found = true;
-                                        ic.setInventorySlotContents(x, is);
-                                        if (!details.canBeSubstitute() && is.stackSize == input[x].getStackSize()) {
-                                            this.postChange(input[x], this.machineSrc);
-                                            break;
-                                        } else {
-                                            this.postChange(AEItemStack.create(is), this.machineSrc);
-                                        }
-                                    }
-                                    if (!found) {
-                                        break;
-                                    }
-                                }
-                            }
-
                             if (!found) {
-                                // put stuff back..
-                                for (int x = 0; x < ic.getSizeInventory(); x++) {
-                                    final ItemStack is = ic.getStackInSlot(x);
-                                    if (is != null) {
-                                        this.inventory.injectItems(
-                                                AEItemStack.create(is),
-                                                Actionable.MODULATE,
-                                                this.machineSrc);
-                                    }
-                                }
-                                ic = null;
                                 break;
                             }
                         }
+                    }
 
-                        if (m.pushPattern(details, ic)) {
-                            eg.extractAEPower(sum, Actionable.MODULATE, PowerMultiplier.CONFIG);
-                            this.somethingChanged = true;
-                            this.remainingOperations--;
-                            pushedPattern = true;
-
-                            for (final IAEItemStack out : details.getCondensedOutputs()) {
-                                this.postChange(out, this.machineSrc);
-                                this.waitingFor.add(out.copy());
-                                this.postCraftingStatusChange(out.copy());
-                                providers.computeIfAbsent(out, k -> new ArrayList<>());
-                                List<DimensionalCoord> list = providers.get(out);
-                                if (m instanceof ICraftingProvider) {
-                                    TileEntity tile = this.getTile(m);
-                                    if (tile == null) continue;
-                                    DimensionalCoord tileDimensionalCoord = new DimensionalCoord(tile);
-                                    boolean isAdded = false;
-                                    for (DimensionalCoord dimensionalCoord : list) {
-                                        if (dimensionalCoord.isEqual(tileDimensionalCoord)) {
-                                            isAdded = true;
-                                            break;
-                                        }
-                                    }
-                                    if (!isAdded) {
-                                        list.add(tileDimensionalCoord);
-                                    }
-                                }
-                            }
-
-                            if (details.isCraftable()) {
-                                FMLCommonHandler.instance().firePlayerCraftingEvent(
-                                        Platform.getPlayer((WorldServer) this.getWorld()),
-                                        details.getOutput(ic, this.getWorld()),
-                                        ic);
-
-                                for (int x = 0; x < ic.getSizeInventory(); x++) {
-                                    final ItemStack output = Platform.getContainerItem(ic.getStackInSlot(x));
-                                    if (output != null) {
-                                        final IAEItemStack cItem = AEItemStack.create(output);
-                                        this.postChange(cItem, this.machineSrc);
-                                        this.waitingFor.add(cItem);
-                                        this.postCraftingStatusChange(cItem);
-                                    }
-                                }
-                            }
-
-                            ic = null; // hand off complete!
-                            this.markDirty();
-
-                            e.getValue().value--;
-                            if (e.getValue().value <= 0) {
-                                continue;
-                            }
-
-                            if (this.remainingOperations == 0) {
-                                return;
+                    if (!found) {
+                        // put stuff back..
+                        for (int x = 0; x < ic.getSizeInventory(); x++) {
+                            final ItemStack is = ic.getStackInSlot(x);
+                            if (is != null) {
+                                this.inventory
+                                        .injectItems(AEItemStack.create(is), Actionable.MODULATE, this.machineSrc);
                             }
                         }
+                        ic = null;
+                        break;
                     }
                 }
 
-                if (!pushedPattern) {
-                    // No need to revisit this task on next executeCrafting this tick
-                    i.remove();
-                }
+                if (m.pushPattern(details, ic)) {
+                    eg.extractAEPower(sum, Actionable.MODULATE, PowerMultiplier.CONFIG);
+                    this.somethingChanged = true;
+                    this.remainingOperations--;
+                    pushedPattern = true;
 
-                if (ic != null) {
-                    // put stuff back..
-                    for (int x = 0; x < ic.getSizeInventory(); x++) {
-                        final ItemStack is = ic.getStackInSlot(x);
-                        if (is != null) {
-                            this.inventory.injectItems(AEItemStack.create(is), Actionable.MODULATE, this.machineSrc);
+                    for (final IAEItemStack out : details.getCondensedOutputs()) {
+                        this.postChange(out, this.machineSrc);
+                        this.waitingFor.add(out.copy());
+                        this.postCraftingStatusChange(out.copy());
+                        providers.computeIfAbsent(out, k -> new ArrayList<>());
+                        List<DimensionalCoord> list = providers.get(out);
+                        if (m instanceof ICraftingProvider) {
+                            TileEntity tile = this.getTile(m);
+                            if (tile == null) continue;
+                            DimensionalCoord tileDimensionalCoord = new DimensionalCoord(tile);
+                            boolean isAdded = false;
+                            for (DimensionalCoord dimensionalCoord : list) {
+                                if (dimensionalCoord.isEqual(tileDimensionalCoord)) {
+                                    isAdded = true;
+                                    break;
+                                }
+                            }
+                            if (!isAdded) {
+                                list.add(tileDimensionalCoord);
+                            }
                         }
+                    }
+
+                    if (details.isCraftable()) {
+                        FMLCommonHandler.instance().firePlayerCraftingEvent(
+                                Platform.getPlayer((WorldServer) this.getWorld()),
+                                details.getOutput(ic, this.getWorld()),
+                                ic);
+
+                        for (int x = 0; x < ic.getSizeInventory(); x++) {
+                            final ItemStack output = Platform.getContainerItem(ic.getStackInSlot(x));
+                            if (output != null) {
+                                final IAEItemStack cItem = AEItemStack.create(output);
+                                this.postChange(cItem, this.machineSrc);
+                                this.waitingFor.add(cItem);
+                                this.postCraftingStatusChange(cItem);
+                            }
+                        }
+                    }
+
+                    ic = null; // hand off complete!
+                    this.markDirty();
+
+                    e.getValue().value--;
+                    if (e.getValue().value <= 0) {
+                        continue;
+                    }
+
+                    if (this.remainingOperations == 0) {
+                        return;
+                    }
+                }
+            }
+
+            if (!pushedPattern) {
+                // No need to revisit this task on next executeCrafting this tick
+                i.remove();
+            }
+
+            if (ic != null) {
+                // put stuff back..
+                for (int x = 0; x < ic.getSizeInventory(); x++) {
+                    final ItemStack is = ic.getStackInSlot(x);
+                    if (is != null) {
+                        this.inventory.injectItems(AEItemStack.create(is), Actionable.MODULATE, this.machineSrc);
                     }
                 }
             }


### PR DESCRIPTION
Two optimizations to craft execution to reduce lag from having high amounts of co-processors. I think there are more optimizations that can be done here, but these two were relatively easy to implement and seem high value.

1. Do not process tasks that we know cannot be worked this tick more than once.
    Endgame crafts can have upwards of 1000 tasks, but it is very rare for even half of them to be workable at any given time.

    Profile showing high lag from a large craft (EOH) on a CPU with many co-processors:
![image](https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/assets/73182109/4cdc29f7-e83b-4566-95a4-54094a40c110)

2. Do not check crafting mediums that we already found to be busy multiple times. Especially checking if blocking mode interfaces are busy can be expensive.
    Profile showing high lag from constantly checking busy status:
![image](https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/assets/73182109/3ed13e6b-099c-4fa4-b108-a6fb5e3faa68)

In testing it is still possible to choke a server with 70k co-procs and a very large craft, but to a much lesser extent than before.

First commit is logic changes, the second is readability changes.