### PR TITLE
PreCrafting mode to add crafting plans when items missing

### DIFF
--- a/src/functionalTest/java/appeng/test/mockme/MockAESystem.java
+++ b/src/functionalTest/java/appeng/test/mockme/MockAESystem.java
@@ -58,7 +58,7 @@ public class MockAESystem implements ICellProvider {
             dirtyPatterns = false;
             this.cgCache.setMockPatternsFromMethods();
         }
-        return new CraftingJobV2(world, grid, dummyActionSource, AEItemStack.create(request), null);
+        return new CraftingJobV2(world, grid, dummyActionSource, AEItemStack.create(request), false, null);
     }
 
     public PatternBuilder newProcessingPattern() {

--- a/src/main/java/appeng/api/networking/crafting/ICraftingGrid.java
+++ b/src/main/java/appeng/api/networking/crafting/ICraftingGrid.java
@@ -56,7 +56,7 @@ public interface ICraftingGrid extends IGridCache {
      *         on this, your be waiting forever.
      */
     Future<ICraftingJob> beginCraftingJob(World world, IGrid grid, BaseActionSource actionSrc, IAEItemStack craftWhat,
-            ICraftingCallback callback);
+            boolean usePreCrafting, ICraftingCallback callback);
 
     /**
      * Submit the job to the Crafting system for processing.

--- a/src/main/java/appeng/client/gui/implementations/GuiCraftAmount.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCraftAmount.java
@@ -159,7 +159,10 @@ public class GuiCraftAmount extends AEBaseGui {
 
     @Override
     public void drawBG(final int offsetX, final int offsetY, final int mouseX, final int mouseY) {
-        this.next.displayString = isShiftKeyDown() ? GuiText.Start.getLocal() : GuiText.Next.getLocal();
+
+        if (isCtrlKeyDown()) this.next.displayString = GuiText.PreCraftStart.getLocal();
+        else if (isShiftKeyDown()) this.next.displayString = GuiText.Start.getLocal();
+        else this.next.displayString = GuiText.Next.getLocal();
 
         this.bindTexture("guis/craftAmt.png");
         this.drawTexturedModalRect(offsetX, offsetY, 0, 0, this.xSize, this.ySize);
@@ -215,7 +218,8 @@ public class GuiCraftAmount extends AEBaseGui {
                     resultI = (int) ArithHelper.round(resultD, 0);
                 }
 
-                NetworkHandler.instance.sendToServer(new PacketCraftRequest(resultI, isShiftKeyDown()));
+                NetworkHandler.instance
+                        .sendToServer(new PacketCraftRequest(resultI, isShiftKeyDown(), isCtrlKeyDown()));
             }
         } catch (final NumberFormatException e) {
             // nope..

--- a/src/main/java/appeng/core/localization/GuiText.java
+++ b/src/main/java/appeng/core/localization/GuiText.java
@@ -201,7 +201,10 @@ public enum GuiText {
     // Used in a ME Interface when no appropriate TileEntity was detected near it
     Nothing,
 
-    VoidCellTooltip;
+    VoidCellTooltip,
+
+    // Pre-Crafting
+    PreCraftStart;
 
     private final String root;
 

--- a/src/main/java/appeng/core/sync/packets/PacketCraftRequest.java
+++ b/src/main/java/appeng/core/sync/packets/PacketCraftRequest.java
@@ -35,21 +35,26 @@ public class PacketCraftRequest extends AppEngPacket {
     private final long amount;
     private final boolean heldShift;
 
+    private final boolean heldCtrl;
+
     // automatic.
     public PacketCraftRequest(final ByteBuf stream) {
         this.heldShift = stream.readBoolean();
         this.amount = stream.readLong();
+        this.heldCtrl = stream.readBoolean();
     }
 
-    public PacketCraftRequest(final int craftAmt, final boolean shift) {
+    public PacketCraftRequest(final int craftAmt, final boolean shift, final boolean ctrl) {
         this.amount = craftAmt;
         this.heldShift = shift;
+        this.heldCtrl = ctrl;
 
         final ByteBuf data = Unpooled.buffer();
 
         data.writeInt(this.getPacketID());
         data.writeBoolean(shift);
         data.writeLong(this.amount);
+        data.writeBoolean(ctrl);
 
         this.configureWrite(data);
     }
@@ -79,6 +84,7 @@ public class PacketCraftRequest extends AppEngPacket {
                             cca.getGrid(),
                             cca.getActionSrc(),
                             cca.getItemToCraft(),
+                            this.heldCtrl,
                             null);
 
                     final ContainerOpenContext context = cca.getOpenContext();

--- a/src/main/java/appeng/crafting/v2/CraftingCalculations.java
+++ b/src/main/java/appeng/crafting/v2/CraftingCalculations.java
@@ -88,5 +88,6 @@ public class CraftingCalculations {
         registerProvider(new SimulateMissingItemResolver<>(), IAEFluidStack.class);
         registerProvider(new EmitableItemResolver(), IAEItemStack.class);
         registerProvider(new CraftableItemResolver(), IAEItemStack.class);
+        registerProvider(new PreCraftingItemResolver(), IAEItemStack.class);
     }
 }

--- a/src/main/java/appeng/crafting/v2/CraftingJobV2.java
+++ b/src/main/java/appeng/crafting/v2/CraftingJobV2.java
@@ -51,10 +51,15 @@ public class CraftingJobV2 implements ICraftingJob, Future<ICraftingJob>, ITreeS
     protected State state = State.RUNNING;
 
     public CraftingJobV2(final World world, final IGrid meGrid, final BaseActionSource actionSource,
-            final IAEItemStack what, final ICraftingCallback callback) {
+            final IAEItemStack what, final boolean usePreCrafting, final ICraftingCallback callback) {
         this.context = new CraftingContext(world, meGrid, actionSource);
         this.callback = callback;
-        this.originalRequest = new CraftingRequest<>(what, SubstitutionMode.PRECISE_FRESH, IAEItemStack.class, true);
+        this.originalRequest = new CraftingRequest<>(
+                what,
+                SubstitutionMode.PRECISE_FRESH,
+                IAEItemStack.class,
+                true,
+                usePreCrafting);
         this.context.addRequest(this.originalRequest);
         this.context.itemModel.ignore(what);
     }

--- a/src/main/java/appeng/crafting/v2/CraftingTreeSerializer.java
+++ b/src/main/java/appeng/crafting/v2/CraftingTreeSerializer.java
@@ -75,6 +75,7 @@ public final class CraftingTreeSerializer {
         registerSerializable(":te", EmitableItemResolver.EmitItemTask.class);
         registerSerializable(":tx", ExtractItemResolver.ExtractItemTask.class);
         registerSerializable(":ts", SimulateMissingItemResolver.ConjureItemTask.class);
+        registerSerializable(":tpr", PreCraftingItemResolver.PreCraftItemTask.class);
     }
 
     /**

--- a/src/main/java/appeng/crafting/v2/resolvers/CraftableItemResolver.java
+++ b/src/main/java/appeng/crafting/v2/resolvers/CraftableItemResolver.java
@@ -360,6 +360,7 @@ public class CraftableItemResolver implements CraftingRequestResolver<IAEItemSta
                                 childMode,
                                 IAEItemStack.class,
                                 allowSimulation,
+                                request.usePreCrafting,
                                 stack -> this.isValidSubstitute(input, stack, context.world, finalSlot));
                         complexRequestPerSlot.add(req);
                         newChildren.add(req);
@@ -382,6 +383,7 @@ public class CraftableItemResolver implements CraftingRequestResolver<IAEItemSta
                                     childMode,
                                     IAEItemStack.class,
                                     allowSimulation,
+                                    request.usePreCrafting,
                                     stack -> this.isValidSubstitute(recInput, stack, context.world));
                             newChildren.add(req);
                             childRecursionRequests.put(recInput, req);
@@ -395,6 +397,7 @@ public class CraftableItemResolver implements CraftingRequestResolver<IAEItemSta
                                 childMode,
                                 IAEItemStack.class,
                                 allowSimulation,
+                                request.usePreCrafting,
                                 stack -> this.isValidSubstitute(input, stack, context.world));
                         newChildren.add(req);
                         childRequests.add(new RequestAndPerCraftAmount(req, input.getStackSize()));

--- a/src/main/java/appeng/crafting/v2/resolvers/EmitableItemResolver.java
+++ b/src/main/java/appeng/crafting/v2/resolvers/EmitableItemResolver.java
@@ -73,7 +73,7 @@ public class EmitableItemResolver implements CraftingRequestResolver<IAEItemStac
         @Override
         public void populatePlan(IItemList<IAEItemStack> targetPlan) {
             if (fulfilled > 0 && request.stack instanceof IAEItemStack) {
-                targetPlan.addRequestable(request.stack.copy().setStackSize(fulfilled));
+                targetPlan.addRequestable(request.stack.copy().setCountRequestable(fulfilled));
             }
         }
 

--- a/src/main/java/appeng/crafting/v2/resolvers/PreCraftingItemResolver.java
+++ b/src/main/java/appeng/crafting/v2/resolvers/PreCraftingItemResolver.java
@@ -1,0 +1,114 @@
+package appeng.crafting.v2.resolvers;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.Nonnull;
+
+import appeng.api.storage.data.IAEItemStack;
+import appeng.api.storage.data.IItemList;
+import appeng.core.localization.GuiText;
+import appeng.crafting.MECraftingInventory;
+import appeng.crafting.v2.CraftingContext;
+import appeng.crafting.v2.CraftingRequest;
+import appeng.crafting.v2.CraftingTreeSerializer;
+import appeng.crafting.v2.ITreeSerializable;
+import appeng.me.cluster.implementations.CraftingCPUCluster;
+
+public class PreCraftingItemResolver implements CraftingRequestResolver<IAEItemStack> {
+
+    public static class PreCraftItemTask extends CraftingTask<IAEItemStack> {
+
+        private long fulfilled = 0;
+
+        public PreCraftItemTask(CraftingRequest<IAEItemStack> request) {
+            super(request, Integer.MIN_VALUE + 200); // conjure items for calculations out of thin air as
+            // a last
+        }
+
+        @SuppressWarnings("unused")
+        public PreCraftItemTask(CraftingTreeSerializer serializer, ITreeSerializable parent) throws IOException {
+            super(serializer, parent);
+
+            fulfilled = serializer.getBuffer().readLong();
+        }
+
+        @Override
+        public List<? extends ITreeSerializable> serializeTree(CraftingTreeSerializer serializer) throws IOException {
+            super.serializeTree(serializer);
+            serializer.getBuffer().writeLong(fulfilled);
+            return Collections.emptyList();
+        }
+
+        @Override
+        public void loadChildren(List<ITreeSerializable> children) throws IOException {}
+
+        @Override
+        public StepOutput calculateOneStep(CraftingContext context) {
+            state = State.SUCCESS;
+            if (request.remainingToProcess <= 0) {
+                return new StepOutput(Collections.emptyList());
+            }
+            // Assume items will be generated, triggered by the emitter
+            fulfilled = request.remainingToProcess;
+            request.fulfill(this, request.stack.copy().setStackSize(request.remainingToProcess), context);
+            return new StepOutput(Collections.emptyList());
+        }
+
+        @Override
+        public long partialRefund(CraftingContext context, long amount) {
+            if (amount > fulfilled) {
+                amount = fulfilled;
+            }
+            fulfilled -= amount;
+            return amount;
+        }
+
+        @Override
+        public void fullRefund(CraftingContext context) {
+            fulfilled = 0;
+        }
+
+        @Override
+        public void populatePlan(IItemList<IAEItemStack> targetPlan) {
+            if (fulfilled > 0 && request.stack instanceof IAEItemStack) {
+                targetPlan.addRequestable(request.stack.copy().setCountRequestable(fulfilled));
+            }
+        }
+
+        @Override
+        public void startOnCpu(CraftingContext context, CraftingCPUCluster cpuCluster,
+                MECraftingInventory craftingInv) {
+            cpuCluster.addEmitable(this.request.stack.copy());
+        }
+
+        @Override
+        public String toString() {
+            return "EmitItemTask{" + "fulfilled="
+                    + fulfilled
+                    + ", request="
+                    + request
+                    + ", priority="
+                    + priority
+                    + ", state="
+                    + state
+                    + '}';
+        }
+
+        @Override
+        public String getTooltipText() {
+            return GuiText.PreCraftStart.getLocal() + ": " + fulfilled;
+        }
+    }
+
+    @Nonnull
+    @Override
+    public List<CraftingTask> provideCraftingRequestResolvers(@Nonnull CraftingRequest<IAEItemStack> request,
+            @Nonnull CraftingContext context) {
+        if (request.usePreCrafting && request.allowSimulation) {
+            return Collections.singletonList(new PreCraftItemTask(request));
+        } else return Collections.emptyList();
+
+    }
+}

--- a/src/main/java/appeng/helpers/MultiCraftingTracker.java
+++ b/src/main/java/appeng/helpers/MultiCraftingTracker.java
@@ -96,7 +96,7 @@ public class MultiCraftingTracker {
                     final IAEItemStack aisC = ais.copy();
                     aisC.setStackSize(itemToCraft);
 
-                    this.setJob(x, cg.beginCraftingJob(w, g, mySrc, aisC, null));
+                    this.setJob(x, cg.beginCraftingJob(w, g, mySrc, aisC, false, null));
                 }
             }
         }

--- a/src/main/java/appeng/me/cache/CraftingGridCache.java
+++ b/src/main/java/appeng/me/cache/CraftingGridCache.java
@@ -439,14 +439,14 @@ public class CraftingGridCache
 
     @Override
     public Future<ICraftingJob> beginCraftingJob(final World world, final IGrid grid, final BaseActionSource actionSrc,
-            final IAEItemStack slotItem, final ICraftingCallback cb) {
+            final IAEItemStack slotItem, final boolean usePreCrafting, final ICraftingCallback cb) {
         if (world == null || grid == null || actionSrc == null || slotItem == null) {
             throw new IllegalArgumentException("Invalid Crafting Job Request");
         }
 
         final ICraftingJob job = switch (AEConfig.instance.craftingCalculatorVersion) {
             case 1 -> new CraftingJob(world, grid, actionSrc, slotItem, cb);
-            case 2 -> new CraftingJobV2(world, grid, actionSrc, slotItem, cb);
+            case 2 -> new CraftingJobV2(world, grid, actionSrc, slotItem, usePreCrafting, cb);
             default -> throw new IllegalStateException("Invalid crafting calculator version");
         };
 

--- a/src/main/resources/assets/appliedenergistics2/lang/en_US.lang
+++ b/src/main/resources/assets/appliedenergistics2/lang/en_US.lang
@@ -216,6 +216,7 @@ gui.appliedenergistics2.MultipleOutputs=%1$d%% second, %2$d%% third output.
 gui.appliedenergistics2.SelectAmount=Select Amount
 gui.appliedenergistics2.CopyMode=Copy Mode
 gui.appliedenergistics2.CopyModeDesc=Controls if the contents of the configuration pane are cleared when you remove the cell.
+gui.appliedenergistics2.PreCraftStart=PreCrafting
 gui.appliedenergistics2.Next=Next
 gui.appliedenergistics2.Lumen=Lumen
 gui.appliedenergistics2.Empty=Empty

--- a/src/main/resources/assets/appliedenergistics2/lang/zh_CN.lang
+++ b/src/main/resources/assets/appliedenergistics2/lang/zh_CN.lang
@@ -214,6 +214,7 @@ gui.appliedenergistics2.MultipleOutputs=第一副产概率%1$d%%,第二副产概
 gui.appliedenergistics2.SelectAmount=选择数量
 gui.appliedenergistics2.CopyMode=复制模式
 gui.appliedenergistics2.CopyModeDesc=控制当取出存储元件时,是否清空配置格.
+gui.appliedenergistics2.PreCraftStart=预合成
 gui.appliedenergistics2.Next=下一页
 gui.appliedenergistics2.Lumen=光通
 gui.appliedenergistics2.Empty=空


### PR DESCRIPTION
![demo](https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/assets/30284813/5b627cce-fc41-4447-98b7-7fde2d699ec5)
Press CTRL while selecting the quantity to enter PreCrafting mode. This exploits the mechanism of AE2 itself.
![image](https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/assets/30284813/31470da4-01f6-4317-b1a9-3c91dddc4671)
This feature proves to be highly advantageous in certain situations, such as when I am dealing with a complex crafting that requires a missing items. It is then possible to speed up the process by crafting other components first, thus saving time.


 
