### PR TITLE
Fix quartz knife cursor position

### DIFF
--- a/src/main/java/appeng/client/gui/widgets/MEGuiTextField.java
+++ b/src/main/java/appeng/client/gui/widgets/MEGuiTextField.java
@@ -152,8 +152,9 @@ public class MEGuiTextField implements ITooltip {
     public void setText(String text, boolean ignoreTrigger) {
         final String oldText = getText();
 
+        int currentCursorPos = field.getCursorPosition();
         field.setText(text);
-        field.setCursorPositionEnd();
+        field.setCursorPosition(currentCursorPos);
 
         if (!ignoreTrigger) {
             onTextChange(oldText);


### PR DESCRIPTION
This reapplies the cursor position after typing a character in the quartz knife renaming GUI. This allows editing the name in the middle of the name-string without the cursor constantly moving to the end.