### PR TITLE
Fix some nodes being blocked from updating at all

### DIFF
--- a/src/main/java/appeng/me/cache/TickManagerCache.java
+++ b/src/main/java/appeng/me/cache/TickManagerCache.java
@@ -132,8 +132,8 @@ public class TickManagerCache implements ITickManager {
     public void removeNode(final IGridNode gridNode, final IGridHost machine) {
         if (machine instanceof IGridTickable) {
             this.alertable.remove(gridNode);
-            this.sleeping.remove(gridNode);
-            this.awake.remove(gridNode);
+            this.upcomingTicks.remove(this.sleeping.remove(gridNode));
+            this.upcomingTicks.remove(this.awake.remove(gridNode));
         }
     }
 
@@ -197,6 +197,7 @@ public class TickManagerCache implements ITickManager {
             final TickTracker gt = this.awake.get(node);
             this.awake.remove(node);
             this.sleeping.put(node, gt);
+            this.upcomingTicks.remove(gt);
 
             return true;
         }


### PR DESCRIPTION
# The issue
I've had this issue on my server where some nodes (imports/exporters mostly) would stop ticking after a while. I could track it down to duplicated TickTrackers present in the `upcomingTicks` `PriorityQueue` causing parts of the internal binary heap to never update at all. 
The duplication happens when nodes are put to sleep and then wake up, because they are not removed from the `upcomingTicks` queue when they go to sleep. Note that they can be removed once they are ready to update and `doBusWork` returns `TickRateModulation#SLEEP`.

# Reproduction
The issue can be reproduced by putting a node to sleep and waking it multiple, causing its `TickTracker` to be present multiple times in the `upcomingTicks` queue (i.e. the sand exporter). Once the second exporter is connected it gets into a position where it will never receive updates again. The binary heap represented as a binary tree would look like this:

(When the enderpearl exporter wakes up)
![image](https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/assets/36999320/8d2e5c5e-21ba-405c-8b52-a918675e7290)
(After the sand exporter updates once. The position of the enderpearl exporter will make it unable to update, due to the nature of the `siftDown` algorithm)
![image](https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/assets/36999320/ef7014a6-7676-4aa2-a5a5-0c25c728d90c)

(Reproduction video. Neighbor change causes update -> No destination makes it sleep; Destination makes it wake up)
https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/assets/36999320/3ef802a0-578e-497b-a300-26aa14a3abb9

### Server example
Here's an example of what happened on my server. One can see that the whole right sub-tree is blocked from updating by the right child of the root which is present multiple times. The duplicates will be sifted up in the left sub-tree and once they update, reset the priority of the "blocking" node as well.
![graph](https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/assets/36999320/5c693f71-d665-4b2f-a963-ff2c1be373ec)

# Fix
Remove the TickTracker instances from the queue when a node goes to sleep and when it is removed from the grid (the second part shouldn't be required to fix this bug, but still very much makes sense in my opinion).
