### PR TITLE
Fix overflow because arithmetic used more than 33 bits

### DIFF
--- a/src/main/java/appeng/container/implementations/ContainerPatternTerm.java
+++ b/src/main/java/appeng/container/implementations/ContainerPatternTerm.java
@@ -550,8 +550,11 @@ public class ContainerPatternTerm extends ContainerMEMonitorable
 
     static boolean canDouble(SlotFake[] slots, int mult) {
         for (Slot s : slots) {
-            if (s.getStack() != null && s.getStack().stackSize * mult < 0) {
-                return false;
+            if (s.getStack() != null) {
+                long val = (long) s.getStack().stackSize * mult;
+                if (val > Integer.MAX_VALUE) {
+                    return false;
+                }
             }
         }
         return true;


### PR DESCRIPTION
Silly mistake but this time it's implemented properly (the way Java does it in multiplyExact())