### PR TITLE
Move cursor to the end when initializing text field

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
@@ -346,6 +346,7 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
             this.searchField.setText(memoryText, true);
             repo.setSearchString(memoryText);
         }
+        this.searchField.setCursorPositionEnd();
 
         this.setScrollBar();
 

--- a/src/main/java/appeng/client/gui/widgets/MEGuiTextField.java
+++ b/src/main/java/appeng/client/gui/widgets/MEGuiTextField.java
@@ -165,6 +165,10 @@ public class MEGuiTextField implements ITooltip {
         setText(text, false);
     }
 
+    public void setCursorPositionEnd() {
+        field.setCursorPositionEnd();
+    }
+
     public void setFocused(boolean focus) {
         if (field.isFocused() == focus) {
             return;


### PR DESCRIPTION
Since the cursor position was being restored before the cursor was set, it was setting the position to 0.