### PR TITLE
Remove backbone recipes and add deprecation tooltip

### DIFF
--- a/src/main/java/appeng/core/api/definitions/ApiParts.java
+++ b/src/main/java/appeng/core/api/definitions/ApiParts.java
@@ -79,9 +79,9 @@ public final class ApiParts implements IParts {
         this.cableDense = constructor.constructColoredDefinition(itemMultiPart, PartType.CableDense);
         this.cableDenseCovered = constructor.constructColoredDefinition(itemMultiPart, PartType.CableDenseCovered);
         this.cableUltraDenseSmart = constructor
-                .constructColoredDefinition(itemMultiPart, PartType.CableUltraDenseSmart);
+                .constructColoredDefinition(itemMultiPart, PartType.CableUltraDenseSmart, true);
         this.cableUltraDenseCovered = constructor
-                .constructColoredDefinition(itemMultiPart, PartType.CableUltraDenseCovered);
+                .constructColoredDefinition(itemMultiPart, PartType.CableUltraDenseCovered, true);
         // this.lumenCableSmart = Optional.absent(); // has yet to be implemented, no PartType defined for it yet
         // this.lumenCableCovered = Optional.absent(); // has yet to be implemented, no PartType defined for it yet
         // this.lumenCableGlass = Optional.absent(); // has yet to be implemented, no PartType defined for it yet

--- a/src/main/java/appeng/core/api/definitions/DefinitionConstructor.java
+++ b/src/main/java/appeng/core/api/definitions/DefinitionConstructor.java
@@ -81,10 +81,15 @@ public class DefinitionConstructor {
     }
 
     final AEColoredItemDefinition constructColoredDefinition(final ItemMultiPart target, final PartType type) {
+        return constructColoredDefinition(target, type, false);
+    }
+
+    final AEColoredItemDefinition constructColoredDefinition(final ItemMultiPart target, final PartType type,
+            boolean deprecated) {
         final ColoredItemDefinition definition = new ColoredItemDefinition();
 
         for (final AEColor color : AEColor.values()) {
-            final ItemStackSrc multiPartSource = target.createPart(type, color);
+            final ItemStackSrc multiPartSource = target.createPart(type, color, deprecated);
 
             definition.add(color, multiPartSource);
         }

--- a/src/main/java/appeng/core/localization/GuiText.java
+++ b/src/main/java/appeng/core/localization/GuiText.java
@@ -201,7 +201,10 @@ public enum GuiText {
     // Used in a ME Interface when no appropriate TileEntity was detected near it
     Nothing,
 
-    VoidCellTooltip;
+    VoidCellTooltip,
+
+    // If a thing is deprecated
+    Deprecated;
 
     private final String root;
 

--- a/src/main/resources/assets/appliedenergistics2/lang/en_US.lang
+++ b/src/main/resources/assets/appliedenergistics2/lang/en_US.lang
@@ -269,6 +269,7 @@ gui.appliedenergistics2.HoldShiftForTooltip=Hold shift for extended tooltip
 gui.appliedenergistics2.HoldShiftClick_HIGHLIGHT_INTERFACE=Hold shift click to highlight interface
 gui.appliedenergistics2.Nothing=Nothing
 gui.appliedenergistics2.VoidCellTooltip=Deletes §4everything§7 stored on it
+gui.appliedenergistics2.Deprecated=Deprecated, will be removed soon!
 
 # GUI Colors - ARGB
 gui.color.appliedenergistics2.SearchboxFocused=6E000000

--- a/src/main/resources/assets/appliedenergistics2/recipes/network/cables/index.recipe
+++ b/src/main/resources/assets/appliedenergistics2/recipes/network/cables/index.recipe
@@ -1,7 +1,5 @@
 import=network/cables/covered.recipe
 import=network/cables/dense.recipe
 import=network/cables/dense-covered.recipe
-import=network/cables/udense.recipe
-import=network/cables/udense-covered.recipe
 import=network/cables/glass.recipe
 import=network/cables/smart.recipe


### PR DESCRIPTION
Adds a tooltip for itemparts marked "deprecated" (specifically, backbone cables). Removal of backbone recipes (they're still there but they are not imported into the recipe manager anymore)