### PR TITLE
Crafting input interface terminal supports

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -5,7 +5,7 @@ dependencies {
     implementation('curse.maven:cofh-core-69162:2388751')
     implementation('com.github.GTNewHorizons:BuildCraft:7.1.33:dev') {transitive = false}
     compileOnly('com.github.GTNewHorizons:ForgeMultipart:1.3.3:dev') {transitive = false}
-    compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.50:dev') {transitive = false}
+    compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.159:dev') {transitive = false}
     compileOnly('com.github.GTNewHorizons:Jabba:1.2.22:dev') {transitive = false}
     compileOnly('com.github.GTNewHorizons:inventory-tweaks:1.5.16:api') {transitive = false}
     compileOnly('com.github.GTNewHorizons:OpenComputers:1.9.5-GTNH:api') {transitive = false}
@@ -24,7 +24,7 @@ dependencies {
     functionalTestImplementation('org.junit.platform:junit-platform-engine')
     functionalTestImplementation('org.junit.platform:junit-platform-launcher')
     functionalTestImplementation('org.junit.platform:junit-platform-reporting')
-    functionalTestImplementation('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.50:dev') {
+    functionalTestImplementation('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.159:dev') {
         exclude module: "Applied-Energistics-2-Unofficial"
     }
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -5,7 +5,7 @@ dependencies {
     implementation('curse.maven:cofh-core-69162:2388751')
     implementation('com.github.GTNewHorizons:BuildCraft:7.1.33:dev') {transitive = false}
     compileOnly('com.github.GTNewHorizons:ForgeMultipart:1.3.3:dev') {transitive = false}
-    compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.159:dev') {transitive = false}
+    compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.50:dev') {transitive = false}
     compileOnly('com.github.GTNewHorizons:Jabba:1.2.22:dev') {transitive = false}
     compileOnly('com.github.GTNewHorizons:inventory-tweaks:1.5.16:api') {transitive = false}
     compileOnly('com.github.GTNewHorizons:OpenComputers:1.9.5-GTNH:api') {transitive = false}
@@ -24,7 +24,7 @@ dependencies {
     functionalTestImplementation('org.junit.platform:junit-platform-engine')
     functionalTestImplementation('org.junit.platform:junit-platform-launcher')
     functionalTestImplementation('org.junit.platform:junit-platform-reporting')
-    functionalTestImplementation('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.159:dev') {
+    functionalTestImplementation('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.50:dev') {
         exclude module: "Applied-Energistics-2-Unofficial"
     }
 }

--- a/src/main/java/appeng/client/gui/implementations/GuiInterfaceTerminal.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiInterfaceTerminal.java
@@ -633,7 +633,8 @@ public class GuiInterfaceTerminal extends AEBaseGui implements IDropToFillTextFi
                 : Integer.MAX_VALUE;
     }
 
-    private ClientDCInternalInv getById(final long id, final long sortBy, final String unlocalizedName, final int sizeInit) {
+    private ClientDCInternalInv getById(final long id, final long sortBy, final String unlocalizedName,
+            final int sizeInit) {
         ClientDCInternalInv o = this.byId.get(id);
 
         if (o == null) {

--- a/src/main/java/appeng/client/gui/implementations/GuiInterfaceTerminal.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiInterfaceTerminal.java
@@ -431,8 +431,9 @@ public class GuiInterfaceTerminal extends AEBaseGui implements IDropToFillTextFi
                 try {
                     final long id = Long.parseLong(key.substring(1), Character.MAX_RADIX);
                     final NBTTagCompound invData = in.getCompoundTag(key);
+                    int size = invData.getInteger("size");
                     final ClientDCInternalInv current = this
-                            .getById(id, invData.getLong("sortBy"), invData.getString("un"));
+                            .getById(id, invData.getLong("sortBy"), invData.getString("un"), size);
                     int X = invData.getInteger("x");
                     int Y = invData.getInteger("y");
                     int Z = invData.getInteger("z");
@@ -632,11 +633,11 @@ public class GuiInterfaceTerminal extends AEBaseGui implements IDropToFillTextFi
                 : Integer.MAX_VALUE;
     }
 
-    private ClientDCInternalInv getById(final long id, final long sortBy, final String unlocalizedName) {
+    private ClientDCInternalInv getById(final long id, final long sortBy, final String unlocalizedName, final int sizeInit) {
         ClientDCInternalInv o = this.byId.get(id);
 
         if (o == null) {
-            this.byId.put(id, o = new ClientDCInternalInv(9, id, sortBy, unlocalizedName));
+            this.byId.put(id, o = new ClientDCInternalInv(sizeInit, id, sortBy, unlocalizedName));
             this.refreshList = true;
         }
 

--- a/src/main/java/appeng/container/implementations/ContainerInterfaceTerminal.java
+++ b/src/main/java/appeng/container/implementations/ContainerInterfaceTerminal.java
@@ -106,8 +106,6 @@ public final class ContainerInterfaceTerminal extends AEBaseContainer {
         }
 
         if (total != this.supportedInterfaces.size() || missing) {
-            System.out.println(
-                    "RegenList because " + total + " != " + this.supportedInterfaces.size() + " || " + missing);
             this.regenList(this.data);
         } else {
             for (final InvTracker inv : supportedInterfaces.values()) {

--- a/src/main/java/appeng/container/implementations/ContainerInterfaceTerminal.java
+++ b/src/main/java/appeng/container/implementations/ContainerInterfaceTerminal.java
@@ -14,9 +14,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.StreamSupport;
 
-import appeng.helpers.InterfaceTerminalSupportedClassProvider;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.IInventory;
@@ -36,6 +34,7 @@ import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketCompressedNBT;
 import appeng.helpers.IInterfaceTerminalSupport;
 import appeng.helpers.IInterfaceTerminalSupport.PatternsConfiguration;
+import appeng.helpers.InterfaceTerminalSupportedClassProvider;
 import appeng.helpers.InventoryAction;
 import appeng.items.misc.ItemEncodedPattern;
 import appeng.parts.reporting.PartInterfaceTerminal;
@@ -107,7 +106,8 @@ public final class ContainerInterfaceTerminal extends AEBaseContainer {
         }
 
         if (total != this.supportedInterfaces.size() || missing) {
-            System.out.println("RegenList because " + total + " != " + this.supportedInterfaces.size() + " || " + missing);
+            System.out.println(
+                    "RegenList because " + total + " != " + this.supportedInterfaces.size() + " || " + missing);
             this.regenList(this.data);
         } else {
             for (final InvTracker inv : supportedInterfaces.values()) {
@@ -270,7 +270,8 @@ public final class ContainerInterfaceTerminal extends AEBaseContainer {
                         final var configurations = terminalSupport.getPatternsConfigurations();
 
                         for (int i = 0; i < configurations.length; ++i) {
-                            this.supportedInterfaces.put(terminalSupport, new InvTracker(terminalSupport, configurations[i], i));
+                            this.supportedInterfaces
+                                    .put(terminalSupport, new InvTracker(terminalSupport, configurations[i], i));
                         }
                     }
                 }

--- a/src/main/java/appeng/container/implementations/ContainerInterfaceTerminal.java
+++ b/src/main/java/appeng/container/implementations/ContainerInterfaceTerminal.java
@@ -53,9 +53,8 @@ public final class ContainerInterfaceTerminal extends AEBaseContainer {
      */
     private static long autoBase = Long.MIN_VALUE;
 
-    private final Multimap<IInterfaceTerminalSupport, InvTracker> diList = HashMultimap.create();
+    private final Multimap<IInterfaceTerminalSupport, InvTracker> supportedInterfaces = HashMultimap.create();
     private final Map<Long, InvTracker> byId = new HashMap<>();
-    // private final Map<Long, InvTracker> byId = new HashMap<>();
     private IGrid grid;
     private NBTTagCompound data = new NBTTagCompound();
 
@@ -94,7 +93,7 @@ public final class ContainerInterfaceTerminal extends AEBaseContainer {
                     for (final IGridNode gn : this.grid.getMachines(clz)) {
                         final IInterfaceTerminalSupport interfaceTerminalSupport = (IInterfaceTerminalSupport) gn
                                 .getMachine();
-                        final Collection<InvTracker> t = diList.get(interfaceTerminalSupport);
+                        final Collection<InvTracker> t = supportedInterfaces.get(interfaceTerminalSupport);
                         final String name = interfaceTerminalSupport.getName();
                         missing = t.isEmpty() || t.stream().anyMatch(it -> !it.unlocalizedName.equals(name));
                         total += interfaceTerminalSupport.getPatternsConfigurations().length;
@@ -106,10 +105,10 @@ public final class ContainerInterfaceTerminal extends AEBaseContainer {
             }
         }
 
-        if (total != this.diList.size() || missing) {
+        if (total != this.supportedInterfaces.size() || missing) {
             this.regenList(this.data);
         } else {
-            for (final InvTracker inv : diList.values()) {
+            for (final InvTracker inv : supportedInterfaces.values()) {
                 for (int x = 0; x < inv.client.getSizeInventory(); x++) {
                     if (this.isDifferent(inv.server.getStackInSlot(inv.offset + x), inv.client.getStackInSlot(x))) {
                         this.addItems(this.data, inv, x, 1);
@@ -255,7 +254,7 @@ public final class ContainerInterfaceTerminal extends AEBaseContainer {
 
     private void regenList(final NBTTagCompound data) {
         this.byId.clear();
-        this.diList.clear();
+        this.supportedInterfaces.clear();
 
         final IActionHost host = this.getActionHost();
         if (host != null) {
@@ -271,7 +270,7 @@ public final class ContainerInterfaceTerminal extends AEBaseContainer {
                         final var configurations = terminalSupport.getPatternsConfigurations();
 
                         for (int i = 0; i < configurations.length; ++i) {
-                            this.diList.put(terminalSupport, new InvTracker(terminalSupport, configurations[i], i));
+                            this.supportedInterfaces.put(terminalSupport, new InvTracker(terminalSupport, configurations[i], i));
                         }
                     }
                 }
@@ -280,7 +279,7 @@ public final class ContainerInterfaceTerminal extends AEBaseContainer {
 
         data.setBoolean("clear", true);
 
-        for (final InvTracker inv : this.diList.values()) {
+        for (final InvTracker inv : this.supportedInterfaces.values()) {
             this.byId.put(inv.which, inv);
             this.addItems(data, inv, 0, inv.client.getSizeInventory());
         }

--- a/src/main/java/appeng/container/implementations/ContainerInterfaceTerminal.java
+++ b/src/main/java/appeng/container/implementations/ContainerInterfaceTerminal.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.StreamSupport;
 
+import appeng.helpers.InterfaceTerminalSupportedClassProvider;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.IInventory;
@@ -87,12 +88,12 @@ public final class ContainerInterfaceTerminal extends AEBaseContainer {
         if (host != null) {
             final IGridNode agn = host.getActionableNode();
             if (agn != null && agn.isActive()) {
-                var clzWithInterfaceSupport = StreamSupport.stream(grid.getMachinesClasses().spliterator(), false)
-                        .filter(IInterfaceTerminalSupport.class::isAssignableFrom).distinct().toArray(Class[]::new);
-                for (var clz : clzWithInterfaceSupport) {
+                for (var clz : InterfaceTerminalSupportedClassProvider.getSupportedClasses()) {
                     for (final IGridNode gn : this.grid.getMachines(clz)) {
                         final IInterfaceTerminalSupport interfaceTerminalSupport = (IInterfaceTerminalSupport) gn
                                 .getMachine();
+                        if (!gn.isActive() || !interfaceTerminalSupport.shouldDisplay()) continue;
+
                         final Collection<InvTracker> t = supportedInterfaces.get(interfaceTerminalSupport);
                         final String name = interfaceTerminalSupport.getName();
                         missing = t.isEmpty() || t.stream().anyMatch(it -> !it.unlocalizedName.equals(name));
@@ -106,6 +107,7 @@ public final class ContainerInterfaceTerminal extends AEBaseContainer {
         }
 
         if (total != this.supportedInterfaces.size() || missing) {
+            System.out.println("RegenList because " + total + " != " + this.supportedInterfaces.size() + " || " + missing);
             this.regenList(this.data);
         } else {
             for (final InvTracker inv : supportedInterfaces.values()) {
@@ -260,9 +262,7 @@ public final class ContainerInterfaceTerminal extends AEBaseContainer {
         if (host != null) {
             final IGridNode agn = host.getActionableNode();
             if (agn != null && agn.isActive()) {
-                var clzWithInterfaceSupport = StreamSupport.stream(grid.getMachinesClasses().spliterator(), false)
-                        .filter(IInterfaceTerminalSupport.class::isAssignableFrom).distinct().toArray(Class[]::new);
-                for (var clz : clzWithInterfaceSupport) {
+                for (var clz : InterfaceTerminalSupportedClassProvider.getSupportedClasses()) {
                     for (final IGridNode gn : this.grid.getMachines(clz)) {
                         final IInterfaceTerminalSupport terminalSupport = (IInterfaceTerminalSupport) gn.getMachine();
                         if (!gn.isActive() || !terminalSupport.shouldDisplay()) continue;

--- a/src/main/java/appeng/container/implementations/ContainerInterfaceTerminal.java
+++ b/src/main/java/appeng/container/implementations/ContainerInterfaceTerminal.java
@@ -15,10 +15,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-import appeng.api.networking.IGridHost;
-import appeng.api.util.DimensionalCoord;
-import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_InputBus;
-import gregtech.common.tileentities.machines.GT_MetaTileEntity_Hatch_CraftingInput_ME;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.IInventory;
@@ -33,8 +29,10 @@ import appeng.api.config.Settings;
 import appeng.api.config.Upgrades;
 import appeng.api.config.YesNo;
 import appeng.api.networking.IGrid;
+import appeng.api.networking.IGridHost;
 import appeng.api.networking.IGridNode;
 import appeng.api.networking.security.IActionHost;
+import appeng.api.util.DimensionalCoord;
 import appeng.container.AEBaseContainer;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketCompressedNBT;
@@ -53,6 +51,7 @@ import appeng.util.inv.AdaptorIInventory;
 import appeng.util.inv.AdaptorPlayerHand;
 import appeng.util.inv.ItemSlot;
 import appeng.util.inv.WrapperInvSlot;
+import gregtech.common.tileentities.machines.GT_MetaTileEntity_Hatch_CraftingInput_ME;
 
 public final class ContainerInterfaceTerminal extends AEBaseContainer {
 
@@ -309,16 +308,19 @@ public final class ContainerInterfaceTerminal extends AEBaseContainer {
                 }
 
                 for (final IGridNode gn : this.grid.getMachines(GT_MetaTileEntity_Hatch_CraftingInput_ME.class)) {
-                    final GT_MetaTileEntity_Hatch_CraftingInput_ME hatch = (GT_MetaTileEntity_Hatch_CraftingInput_ME) gn.getMachine();
+                    final GT_MetaTileEntity_Hatch_CraftingInput_ME hatch = (GT_MetaTileEntity_Hatch_CraftingInput_ME) gn
+                            .getMachine();
                     if (gn.isActive()) {
                         for (int i = 0; i < 4; ++i) {
-                            this.diList.put(hatch,
-                                    new InvTracker(hatch.getLocation(), 0,
+                            this.diList.put(
+                                    hatch,
+                                    new InvTracker(
+                                            hatch.getLocation(),
+                                            0,
                                             hatch,
-                                            hatch.getInventoryName(),
-                                            i*8,
-                                            8)
-                            );
+                                            hatch.hasCustomName() ? hatch.getCustomName() : hatch.getInventoryName(),
+                                            i * 8,
+                                            8));
                         }
                     }
                 }
@@ -395,13 +397,13 @@ public final class ContainerInterfaceTerminal extends AEBaseContainer {
             this(dual.getLocation(), dual.getSortValue(), patterns, unlocalizedName, offset, size);
         }
 
-        public InvTracker(final DimensionalCoord coord, long sortValue, final IInventory patterns, final String unlocalizedName,
-                          int offset, int size) {
+        public InvTracker(final DimensionalCoord coord, long sortValue, final IInventory patterns,
+                final String unlocalizedName, int offset, int size) {
             this(coord.x, coord.y, coord.z, coord.getDimension(), sortValue, patterns, unlocalizedName, offset, size);
         }
 
-        public InvTracker(int x, int y, int z, int dim, long sortValue, final IInventory patterns, final String unlocalizedName,
-                          int offset, int size) {
+        public InvTracker(int x, int y, int z, int dim, long sortValue, final IInventory patterns,
+                final String unlocalizedName, int offset, int size) {
             this.server = patterns;
             this.client = new AppEngInternalInventory(null, size);
             this.unlocalizedName = unlocalizedName;

--- a/src/main/java/appeng/container/implementations/ContainerInterfaceTerminal.java
+++ b/src/main/java/appeng/container/implementations/ContainerInterfaceTerminal.java
@@ -466,7 +466,7 @@ public final class ContainerInterfaceTerminal extends AEBaseContainer {
                     }
 
                     total += (ih.getInterfaceDuality().getInstalledUpgrades(Upgrades.PATTERN_CAPACITY) + 1);
-                } else {
+                } else if (gh instanceof GT_MetaTileEntity_Hatch_CraftingInput_ME) {
                     if (ContainerInterfaceTerminal.this.diList.get(gh).isEmpty()) missing = true;
                     total += 4;
                 }

--- a/src/main/java/appeng/container/implementations/ContainerInterfaceTerminal.java
+++ b/src/main/java/appeng/container/implementations/ContainerInterfaceTerminal.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.StreamSupport;
 
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.entity.player.InventoryPlayer;
@@ -25,33 +26,25 @@ import net.minecraftforge.common.util.ForgeDirection;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 
-import appeng.api.config.Settings;
-import appeng.api.config.Upgrades;
-import appeng.api.config.YesNo;
 import appeng.api.networking.IGrid;
-import appeng.api.networking.IGridHost;
 import appeng.api.networking.IGridNode;
 import appeng.api.networking.security.IActionHost;
 import appeng.api.util.DimensionalCoord;
 import appeng.container.AEBaseContainer;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketCompressedNBT;
-import appeng.helpers.DualityInterface;
-import appeng.helpers.IInterfaceHost;
+import appeng.helpers.IInterfaceTerminalSupport;
+import appeng.helpers.IInterfaceTerminalSupport.PatternsConfiguration;
 import appeng.helpers.InventoryAction;
 import appeng.items.misc.ItemEncodedPattern;
-import appeng.parts.misc.PartInterface;
-import appeng.parts.p2p.PartP2PInterface;
 import appeng.parts.reporting.PartInterfaceTerminal;
 import appeng.tile.inventory.AppEngInternalInventory;
-import appeng.tile.misc.TileInterface;
 import appeng.util.InventoryAdaptor;
 import appeng.util.Platform;
 import appeng.util.inv.AdaptorIInventory;
 import appeng.util.inv.AdaptorPlayerHand;
 import appeng.util.inv.ItemSlot;
 import appeng.util.inv.WrapperInvSlot;
-import gregtech.common.tileentities.machines.GT_MetaTileEntity_Hatch_CraftingInput_ME;
 
 public final class ContainerInterfaceTerminal extends AEBaseContainer {
 
@@ -60,7 +53,7 @@ public final class ContainerInterfaceTerminal extends AEBaseContainer {
      */
     private static long autoBase = Long.MIN_VALUE;
 
-    private final Multimap<IGridHost, InvTracker> diList = HashMultimap.create();
+    private final Multimap<IInterfaceTerminalSupport, InvTracker> diList = HashMultimap.create();
     private final Map<Long, InvTracker> byId = new HashMap<>();
     // private final Map<Long, InvTracker> byId = new HashMap<>();
     private IGrid grid;
@@ -95,28 +88,20 @@ public final class ContainerInterfaceTerminal extends AEBaseContainer {
         if (host != null) {
             final IGridNode agn = host.getActionableNode();
             if (agn != null && agn.isActive()) {
-                for (final IGridNode gn : this.grid.getMachines(TileInterface.class)) {
-                    InterfaceCheck interfaceCheck = new InterfaceCheck().invoke(gn);
-                    total += interfaceCheck.getTotal();
-                    missing |= interfaceCheck.isMissing();
-                }
-
-                for (final IGridNode gn : this.grid.getMachines(PartInterface.class)) {
-                    InterfaceCheck interfaceCheck = new InterfaceCheck().invoke(gn);
-                    total += interfaceCheck.getTotal();
-                    missing |= interfaceCheck.isMissing();
-                }
-
-                for (final IGridNode gn : this.grid.getMachines(PartP2PInterface.class)) {
-                    InterfaceCheck interfaceCheck = new InterfaceCheck().invoke(gn);
-                    total += interfaceCheck.getTotal();
-                    missing |= interfaceCheck.isMissing();
-                }
-
-                for (final IGridNode gn : this.grid.getMachines(GT_MetaTileEntity_Hatch_CraftingInput_ME.class)) {
-                    InterfaceCheck interfaceCheck = new InterfaceCheck().invoke(gn);
-                    total += interfaceCheck.getTotal();
-                    missing |= interfaceCheck.isMissing();
+                var clzWithInterfaceSupport = StreamSupport.stream(grid.getMachinesClasses().spliterator(), false)
+                        .filter(IInterfaceTerminalSupport.class::isAssignableFrom).distinct().toArray(Class[]::new);
+                for (var clz : clzWithInterfaceSupport) {
+                    for (final IGridNode gn : this.grid.getMachines(clz)) {
+                        final IInterfaceTerminalSupport interfaceTerminalSupport = (IInterfaceTerminalSupport) gn
+                                .getMachine();
+                        final Collection<InvTracker> t = diList.get(interfaceTerminalSupport);
+                        final String name = interfaceTerminalSupport.getName();
+                        missing = t.isEmpty() || t.stream().anyMatch(it -> !it.unlocalizedName.equals(name));
+                        total += interfaceTerminalSupport.getPatternsConfigurations().length;
+                        if (missing) break;
+                    }
+                    // we can stop if any is missing. The value of `total` is not important if `missing == true`
+                    if (missing) break;
                 }
             }
         }
@@ -276,51 +261,17 @@ public final class ContainerInterfaceTerminal extends AEBaseContainer {
         if (host != null) {
             final IGridNode agn = host.getActionableNode();
             if (agn != null && agn.isActive()) {
-                for (final IGridNode gn : this.grid.getMachines(TileInterface.class)) {
-                    final IInterfaceHost ih = (IInterfaceHost) gn.getMachine();
-                    final DualityInterface dual = ih.getInterfaceDuality();
-                    if (gn.isActive() && dual.getConfigManager().getSetting(Settings.INTERFACE_TERMINAL) == YesNo.YES) {
-                        for (int i = 0; i <= dual.getInstalledUpgrades(Upgrades.PATTERN_CAPACITY); ++i) {
-                            this.diList.put(ih, new InvTracker(dual, dual.getPatterns(), dual.getTermName(), i * 9, 9));
-                        }
-                    }
-                }
+                var clzWithInterfaceSupport = StreamSupport.stream(grid.getMachinesClasses().spliterator(), false)
+                        .filter(IInterfaceTerminalSupport.class::isAssignableFrom).distinct().toArray(Class[]::new);
+                for (var clz : clzWithInterfaceSupport) {
+                    for (final IGridNode gn : this.grid.getMachines(clz)) {
+                        final IInterfaceTerminalSupport terminalSupport = (IInterfaceTerminalSupport) gn.getMachine();
+                        if (!gn.isActive() || !terminalSupport.shouldDisplay()) continue;
 
-                for (final IGridNode gn : this.grid.getMachines(PartInterface.class)) {
-                    final IInterfaceHost ih = (IInterfaceHost) gn.getMachine();
-                    final DualityInterface dual = ih.getInterfaceDuality();
-                    if (gn.isActive() && dual.getConfigManager().getSetting(Settings.INTERFACE_TERMINAL) == YesNo.YES) {
-                        for (int i = 0; i <= dual.getInstalledUpgrades(Upgrades.PATTERN_CAPACITY); ++i) {
-                            this.diList.put(ih, new InvTracker(dual, dual.getPatterns(), dual.getTermName(), i * 9, 9));
-                        }
-                    }
-                }
+                        final var configurations = terminalSupport.getPatternsConfigurations();
 
-                for (final IGridNode gn : this.grid.getMachines(PartP2PInterface.class)) {
-                    final IInterfaceHost ih = (IInterfaceHost) gn.getMachine();
-                    final DualityInterface dual = ih.getInterfaceDuality();
-                    if (gn.isActive() && dual.getConfigManager().getSetting(Settings.INTERFACE_TERMINAL) == YesNo.YES
-                            && !((PartP2PInterface) ih).isOutput()) {
-                        for (int i = 0; i <= dual.getInstalledUpgrades(Upgrades.PATTERN_CAPACITY); ++i) {
-                            this.diList.put(ih, new InvTracker(dual, dual.getPatterns(), dual.getTermName(), i * 9, 9));
-                        }
-                    }
-                }
-
-                for (final IGridNode gn : this.grid.getMachines(GT_MetaTileEntity_Hatch_CraftingInput_ME.class)) {
-                    final GT_MetaTileEntity_Hatch_CraftingInput_ME hatch = (GT_MetaTileEntity_Hatch_CraftingInput_ME) gn
-                            .getMachine();
-                    if (gn.isActive()) {
-                        for (int i = 0; i < 4; ++i) {
-                            this.diList.put(
-                                    hatch,
-                                    new InvTracker(
-                                            hatch.getLocation(),
-                                            0,
-                                            hatch,
-                                            hatch.hasCustomName() ? hatch.getCustomName() : hatch.getInventoryName(),
-                                            i * 8,
-                                            8));
+                        for (int i = 0; i < configurations.length; ++i) {
+                            this.diList.put(terminalSupport, new InvTracker(terminalSupport, configurations[i], i));
                         }
                     }
                 }
@@ -392,11 +343,6 @@ public final class ContainerInterfaceTerminal extends AEBaseContainer {
         private final int Z;
         private final int dim;
 
-        public InvTracker(final DualityInterface dual, final IInventory patterns, final String unlocalizedName,
-                int offset, int size) {
-            this(dual.getLocation(), dual.getSortValue(), patterns, unlocalizedName, offset, size);
-        }
-
         public InvTracker(final DimensionalCoord coord, long sortValue, final IInventory patterns,
                 final String unlocalizedName, int offset, int size) {
             this(coord.x, coord.y, coord.z, coord.getDimension(), sortValue, patterns, unlocalizedName, offset, size);
@@ -414,6 +360,16 @@ public final class ContainerInterfaceTerminal extends AEBaseContainer {
             this.Z = z;
             this.dim = dim;
         }
+
+        public InvTracker(IInterfaceTerminalSupport terminalSupport, PatternsConfiguration configuration, int index) {
+            this(
+                    terminalSupport.getLocation(),
+                    terminalSupport.getSortValue(),
+                    terminalSupport.getPatterns(index),
+                    terminalSupport.getName(),
+                    configuration.offset,
+                    configuration.size);
+        }
     }
 
     private static class PatternInvSlot extends WrapperInvSlot {
@@ -425,53 +381,6 @@ public final class ContainerInterfaceTerminal extends AEBaseContainer {
         @Override
         public boolean isItemValid(final ItemStack itemstack) {
             return itemstack != null && itemstack.getItem() instanceof ItemEncodedPattern;
-        }
-    }
-
-    private class InterfaceCheck {
-
-        int total = 0;
-        boolean missing = false;
-
-        public InterfaceCheck() {}
-
-        public int getTotal() {
-            return total;
-        }
-
-        public boolean isMissing() {
-            return missing;
-        }
-
-        public InterfaceCheck invoke(IGridNode gn) {
-            if (gn.isActive()) {
-                final IGridHost gh = gn.getMachine();
-                if (gh instanceof IInterfaceHost ih) {
-                    if (ih.getInterfaceDuality().getConfigManager().getSetting(Settings.INTERFACE_TERMINAL) == YesNo.NO
-                            || ih instanceof PartP2PInterface && ((PartP2PInterface) ih).isOutput()) {
-                        return this;
-                    }
-
-                    final Collection<InvTracker> t = ContainerInterfaceTerminal.this.diList.get(ih);
-
-                    if (t.isEmpty()) {
-                        missing = true;
-                    } else {
-                        final DualityInterface dual = ih.getInterfaceDuality();
-                        for (InvTracker it : t) {
-                            if (!it.unlocalizedName.equals(dual.getTermName())) {
-                                missing = true;
-                            }
-                        }
-                    }
-
-                    total += (ih.getInterfaceDuality().getInstalledUpgrades(Upgrades.PATTERN_CAPACITY) + 1);
-                } else if (gh instanceof GT_MetaTileEntity_Hatch_CraftingInput_ME) {
-                    if (ContainerInterfaceTerminal.this.diList.get(gh).isEmpty()) missing = true;
-                    total += 4;
-                }
-            }
-            return this;
         }
     }
 }

--- a/src/main/java/appeng/helpers/IInterfaceHost.java
+++ b/src/main/java/appeng/helpers/IInterfaceHost.java
@@ -10,16 +10,23 @@
 
 package appeng.helpers;
 
+import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.List;
 
+import net.minecraft.inventory.IInventory;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import appeng.api.config.Settings;
+import appeng.api.config.Upgrades;
+import appeng.api.config.YesNo;
 import appeng.api.implementations.IUpgradeableHost;
 import appeng.api.networking.crafting.ICraftingProvider;
 import appeng.api.networking.crafting.ICraftingRequester;
 
-public interface IInterfaceHost extends ICraftingProvider, IUpgradeableHost, ICraftingRequester {
+public interface IInterfaceHost
+        extends ICraftingProvider, IUpgradeableHost, ICraftingRequester, IInterfaceTerminalSupport {
 
     DualityInterface getInterfaceDuality();
 
@@ -28,4 +35,34 @@ public interface IInterfaceHost extends ICraftingProvider, IUpgradeableHost, ICr
     TileEntity getTileEntity();
 
     void saveChanges();
+
+    @Override
+    default PatternsConfiguration[] getPatternsConfigurations() {
+        DualityInterface dual = getInterfaceDuality();
+        List<PatternsConfiguration> patterns = new ArrayList<>();
+        for (int i = 0; i <= dual.getInstalledUpgrades(Upgrades.PATTERN_CAPACITY); ++i) {
+            patterns.add(new PatternsConfiguration(i * 9, 9));
+        }
+        return patterns.toArray(new PatternsConfiguration[0]);
+    }
+
+    @Override
+    default IInventory getPatterns(int index) {
+        return getInterfaceDuality().getPatterns();
+    }
+
+    @Override
+    default boolean shouldDisplay() {
+        return getInterfaceDuality().getConfigManager().getSetting(Settings.INTERFACE_TERMINAL) == YesNo.YES;
+    }
+
+    @Override
+    default String getName() {
+        return getInterfaceDuality().getTermName();
+    }
+
+    @Override
+    default long getSortValue() {
+        return getInterfaceDuality().getSortValue();
+    }
 }

--- a/src/main/java/appeng/helpers/IInterfaceTerminalSupport.java
+++ b/src/main/java/appeng/helpers/IInterfaceTerminalSupport.java
@@ -1,11 +1,12 @@
 package appeng.helpers;
 
+import appeng.api.networking.IGridHost;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.tileentity.TileEntity;
 
 import appeng.api.util.DimensionalCoord;
 
-public interface IInterfaceTerminalSupport {
+public interface IInterfaceTerminalSupport extends IGridHost {
 
     class PatternsConfiguration {
 
@@ -29,7 +30,8 @@ public interface IInterfaceTerminalSupport {
     TileEntity getTileEntity();
 
     default long getSortValue() {
-        return 0;
+        var te = getTileEntity();
+        return ((long) te.zCoord << 24) ^ ((long) te.xCoord << 8) ^ te.yCoord;
     }
 
     default boolean shouldDisplay() {

--- a/src/main/java/appeng/helpers/IInterfaceTerminalSupport.java
+++ b/src/main/java/appeng/helpers/IInterfaceTerminalSupport.java
@@ -1,9 +1,9 @@
 package appeng.helpers;
 
-import appeng.api.networking.IGridHost;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.tileentity.TileEntity;
 
+import appeng.api.networking.IGridHost;
 import appeng.api.util.DimensionalCoord;
 
 public interface IInterfaceTerminalSupport extends IGridHost {

--- a/src/main/java/appeng/helpers/IInterfaceTerminalSupport.java
+++ b/src/main/java/appeng/helpers/IInterfaceTerminalSupport.java
@@ -1,0 +1,38 @@
+package appeng.helpers;
+
+import net.minecraft.inventory.IInventory;
+import net.minecraft.tileentity.TileEntity;
+
+import appeng.api.util.DimensionalCoord;
+
+public interface IInterfaceTerminalSupport {
+
+    class PatternsConfiguration {
+
+        public int offset;
+        public int size;
+
+        public PatternsConfiguration(int offset, int size) {
+            this.offset = offset;
+            this.size = size;
+        }
+    }
+
+    DimensionalCoord getLocation();
+
+    PatternsConfiguration[] getPatternsConfigurations();
+
+    IInventory getPatterns(int index);
+
+    String getName();
+
+    TileEntity getTileEntity();
+
+    default long getSortValue() {
+        return 0;
+    }
+
+    default boolean shouldDisplay() {
+        return true;
+    }
+}

--- a/src/main/java/appeng/helpers/InterfaceTerminalSupportedClassProvider.java
+++ b/src/main/java/appeng/helpers/InterfaceTerminalSupportedClassProvider.java
@@ -1,0 +1,27 @@
+package appeng.helpers;
+
+import appeng.api.networking.IGridHost;
+import appeng.parts.misc.PartInterface;
+import appeng.parts.p2p.PartP2PInterface;
+import appeng.tile.misc.TileInterface;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class InterfaceTerminalSupportedClassProvider {
+    private static final Set<Class<? extends IInterfaceTerminalSupport>> supportedClasses = new HashSet<>();
+
+    static {
+        supportedClasses.add(TileInterface.class);
+        supportedClasses.add(PartInterface.class);
+        supportedClasses.add(PartP2PInterface.class);
+    }
+
+    public static Set<Class<? extends IInterfaceTerminalSupport>> getSupportedClasses() {
+        return supportedClasses;
+    }
+
+    public static void register(Class<? extends IInterfaceTerminalSupport> clazz) {
+        supportedClasses.add(clazz);
+    }
+}

--- a/src/main/java/appeng/helpers/InterfaceTerminalSupportedClassProvider.java
+++ b/src/main/java/appeng/helpers/InterfaceTerminalSupportedClassProvider.java
@@ -1,14 +1,14 @@
 package appeng.helpers;
 
-import appeng.api.networking.IGridHost;
+import java.util.HashSet;
+import java.util.Set;
+
 import appeng.parts.misc.PartInterface;
 import appeng.parts.p2p.PartP2PInterface;
 import appeng.tile.misc.TileInterface;
 
-import java.util.HashSet;
-import java.util.Set;
-
 public class InterfaceTerminalSupportedClassProvider {
+
     private static final Set<Class<? extends IInterfaceTerminalSupport>> supportedClasses = new HashSet<>();
 
     static {

--- a/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
+++ b/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
@@ -15,6 +15,7 @@ import java.util.*;
 import java.util.Map.Entry;
 import java.util.stream.IntStream;
 
+import gregtech.common.tileentities.machines.GT_MetaTileEntity_Hatch_CraftingInput_ME;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.ItemStack;
@@ -1226,6 +1227,8 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
             return ((DualityInterface) craftingProvider).getHost().getTile();
         } else if (craftingProvider instanceof AEBaseTile) {
             return ((AEBaseTile) craftingProvider).getTile();
+        } else if (craftingProvider instanceof GT_MetaTileEntity_Hatch_CraftingInput_ME craftingInput) {
+            return (TileEntity) craftingInput.getBaseMetaTileEntity();
         }
         try {
             Method method = craftingProvider.getClass().getMethod("getTile");

--- a/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
+++ b/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
@@ -59,6 +59,7 @@ import appeng.crafting.CraftingLink;
 import appeng.crafting.CraftingWatcher;
 import appeng.crafting.MECraftingInventory;
 import appeng.helpers.DualityInterface;
+import appeng.helpers.IInterfaceTerminalSupport;
 import appeng.me.cache.CraftingGridCache;
 import appeng.me.cluster.IAECluster;
 import appeng.tile.AEBaseTile;
@@ -67,7 +68,6 @@ import appeng.tile.crafting.TileCraftingTile;
 import appeng.util.Platform;
 import appeng.util.item.AEItemStack;
 import cpw.mods.fml.common.FMLCommonHandler;
-import gregtech.common.tileentities.machines.GT_MetaTileEntity_Hatch_CraftingInput_ME;
 
 public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
 
@@ -1227,8 +1227,8 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
             return ((DualityInterface) craftingProvider).getHost().getTile();
         } else if (craftingProvider instanceof AEBaseTile) {
             return ((AEBaseTile) craftingProvider).getTile();
-        } else if (craftingProvider instanceof GT_MetaTileEntity_Hatch_CraftingInput_ME craftingInput) {
-            return (TileEntity) craftingInput.getBaseMetaTileEntity();
+        } else if (craftingProvider instanceof IInterfaceTerminalSupport interfaceTerminalSupport) {
+            return interfaceTerminalSupport.getTileEntity();
         }
         try {
             Method method = craftingProvider.getClass().getMethod("getTile");

--- a/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
+++ b/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
@@ -15,7 +15,6 @@ import java.util.*;
 import java.util.Map.Entry;
 import java.util.stream.IntStream;
 
-import gregtech.common.tileentities.machines.GT_MetaTileEntity_Hatch_CraftingInput_ME;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.ItemStack;
@@ -68,6 +67,7 @@ import appeng.tile.crafting.TileCraftingTile;
 import appeng.util.Platform;
 import appeng.util.item.AEItemStack;
 import cpw.mods.fml.common.FMLCommonHandler;
+import gregtech.common.tileentities.machines.GT_MetaTileEntity_Hatch_CraftingInput_ME;
 
 public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
 

--- a/src/main/java/appeng/parts/p2p/PartP2PInterface.java
+++ b/src/main/java/appeng/parts/p2p/PartP2PInterface.java
@@ -385,4 +385,9 @@ public class PartP2PInterface extends PartP2PTunnelStatic<PartP2PInterface>
     public void onTunnelNetworkChange() {
         this.duality.updateCraftingList();
     }
+
+    @Override
+    public boolean shouldDisplay() {
+        return IInterfaceHost.super.shouldDisplay() && !isOutput();
+    }
 }


### PR DESCRIPTION
![1](https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/assets/7413706/13cca39d-5e7e-4e9c-a21b-ace7fd353746)
![2](https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/assets/7413706/efadc6a1-aa3b-4a8c-944d-60b674da7f77)
![3](https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/assets/7413706/e5c6ee72-f8ec-478a-9f3e-c7c47d6b4318)

* Make crafting input hatches show up in interface terminal.
* Custom name with quartz knife
* Block highlight in crafting status
* Does not support the wireless versions

Other half in https://github.com/GTNewHorizons/GT5-Unofficial/pull/2200 which needs to be merged after.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14116
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14088