### PR TITLE
Drop static P2Ps as they are, not ME P2Ps

### DIFF
--- a/src/main/java/appeng/parts/p2p/PartP2PTunnelStatic.java
+++ b/src/main/java/appeng/parts/p2p/PartP2PTunnelStatic.java
@@ -11,6 +11,7 @@ import appeng.api.implementations.items.IMemoryCard;
 import appeng.api.implementations.items.MemoryCardMessages;
 import appeng.api.parts.IPart;
 import appeng.api.parts.IPartItem;
+import appeng.api.parts.PartItemStack;
 import appeng.me.GridAccessException;
 import appeng.me.cache.P2PCache;
 import appeng.util.Platform;
@@ -70,5 +71,13 @@ public abstract class PartP2PTunnelStatic<T extends PartP2PTunnelStatic> extends
             printConnectionInfo(player);
         }
         return false;
+    }
+
+    @Override
+    public ItemStack getItemStack(PartItemStack type) {
+        if (type == PartItemStack.World || type == PartItemStack.Network || type == PartItemStack.Wrench) {
+            return super.getItemStack(type);
+        }
+        return super.getItemStack(PartItemStack.Pick);
     }
 }


### PR DESCRIPTION
Resulted in some item voiding (since statics are crafted, not attuned)

Honestly this code looks like crap to me but java doesn't let you bypass a super method :/