### PR TITLE
Fix export bus ignoring inscriber slots

### DIFF
--- a/src/main/java/appeng/tile/storage/TileChest.java
+++ b/src/main/java/appeng/tile/storage/TileChest.java
@@ -200,6 +200,10 @@ public class TileChest extends AENetworkPowerTile
         return g;
     }
 
+    public BaseActionSource getActionSource() {
+        return mySrc;
+    }
+
     @Override
     public int getCellStatus(final int slot) {
         if (Platform.isClient()) {

--- a/src/main/java/appeng/util/InventoryAdaptor.java
+++ b/src/main/java/appeng/util/InventoryAdaptor.java
@@ -12,6 +12,9 @@ package appeng.util;
 
 import java.util.ArrayList;
 
+import appeng.api.storage.IMEMonitor;
+import appeng.api.storage.data.IAEItemStack;
+import appeng.tile.storage.TileChest;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.ISidedInventory;
@@ -56,7 +59,6 @@ public abstract class InventoryAdaptor implements Iterable<ItemSlot> {
         } else if (te instanceof TileEntityChest) {
             return new AdaptorIInventory(Platform.GetChestInv(te));
         } else if (te instanceof ISidedInventory si) {
-            final int[] slots = si.getAccessibleSlotsFromSide(d.ordinal());
             if (te instanceof TileInterface) {
                 return new AdaptorDualityInterface(new WrapperMCISidedInventory(si, d), (IInterfaceHost) te);
             } else if (te instanceof TileCableBus) {
@@ -66,15 +68,12 @@ public abstract class InventoryAdaptor implements Iterable<ItemSlot> {
                 } else if (part instanceof PartP2PItems p2p) {
                     return new AdaptorP2PItem(p2p);
                 }
+            } else if (te instanceof TileChest) {
+                return new AdaptorMEChest((TileChest) te);
             }
-            int stackLimit = 0;
-            if (te instanceof AEBaseInvTile) {
-                stackLimit = ((AEBaseInvTile) te).getInternalInventory().getInventoryStackLimit();
-            }
+
+            final int[] slots = si.getAccessibleSlotsFromSide(d.ordinal());
             if (si.getSizeInventory() > 0 && slots != null && slots.length > 0) {
-                if (stackLimit > 0) {
-                    return new AdaptorIInventory(new WrapperMCISidedInventory(si, d), stackLimit);
-                }
                 return new AdaptorIInventory(new WrapperMCISidedInventory(si, d));
             }
         } else if (te instanceof IInventory i) {

--- a/src/main/java/appeng/util/InventoryAdaptor.java
+++ b/src/main/java/appeng/util/InventoryAdaptor.java
@@ -12,9 +12,6 @@ package appeng.util;
 
 import java.util.ArrayList;
 
-import appeng.api.storage.IMEMonitor;
-import appeng.api.storage.data.IAEItemStack;
-import appeng.tile.storage.TileChest;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.ISidedInventory;
@@ -30,9 +27,9 @@ import appeng.integration.IntegrationRegistry;
 import appeng.integration.IntegrationType;
 import appeng.integration.abstraction.IBetterStorage;
 import appeng.parts.p2p.PartP2PItems;
-import appeng.tile.AEBaseInvTile;
 import appeng.tile.misc.TileInterface;
 import appeng.tile.networking.TileCableBus;
+import appeng.tile.storage.TileChest;
 import appeng.util.inv.*;
 
 public abstract class InventoryAdaptor implements Iterable<ItemSlot> {

--- a/src/main/java/appeng/util/inv/AdaptorMEChest.java
+++ b/src/main/java/appeng/util/inv/AdaptorMEChest.java
@@ -1,17 +1,17 @@
 package appeng.util.inv;
 
+import net.minecraft.item.ItemStack;
+
 import appeng.api.config.Actionable;
 import appeng.api.config.InsertionMode;
-import appeng.api.networking.security.MachineSource;
-import appeng.api.storage.IMEMonitor;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.tile.storage.TileChest;
 import appeng.util.item.AEItemStack;
-import net.minecraft.item.ItemStack;
 
 public class AdaptorMEChest extends AdaptorIInventory {
 
     private final TileChest meChest;
+
     public AdaptorMEChest(TileChest meChest) {
         super(meChest.getInternalInventory());
         this.meChest = meChest;
@@ -23,11 +23,8 @@ public class AdaptorMEChest extends AdaptorIInventory {
             return toBeAdded;
         }
         // Ignore insertion mode since injecting into a ME system doesn't have this concept
-        IAEItemStack result = (IAEItemStack) meChest.getItemInventory().injectItems(
-                AEItemStack.create(toBeAdded),
-                Actionable.MODULATE,
-                meChest.getActionSource()
-        );
+        IAEItemStack result = (IAEItemStack) meChest.getItemInventory()
+                .injectItems(AEItemStack.create(toBeAdded), Actionable.MODULATE, meChest.getActionSource());
         return result == null ? null : result.getItemStack();
     }
 
@@ -37,11 +34,8 @@ public class AdaptorMEChest extends AdaptorIInventory {
             return toBeSimulated;
         }
         // Ignore insertion mode since injecting into a ME system doesn't have this concept
-        IAEItemStack result = (IAEItemStack) meChest.getItemInventory().injectItems(
-                AEItemStack.create(toBeSimulated),
-                Actionable.SIMULATE,
-                meChest.getActionSource()
-        );
+        IAEItemStack result = (IAEItemStack) meChest.getItemInventory()
+                .injectItems(AEItemStack.create(toBeSimulated), Actionable.SIMULATE, meChest.getActionSource());
         return result == null ? null : result.getItemStack();
     }
 }

--- a/src/main/java/appeng/util/inv/AdaptorMEChest.java
+++ b/src/main/java/appeng/util/inv/AdaptorMEChest.java
@@ -1,0 +1,47 @@
+package appeng.util.inv;
+
+import appeng.api.config.Actionable;
+import appeng.api.config.InsertionMode;
+import appeng.api.networking.security.MachineSource;
+import appeng.api.storage.IMEMonitor;
+import appeng.api.storage.data.IAEItemStack;
+import appeng.tile.storage.TileChest;
+import appeng.util.item.AEItemStack;
+import net.minecraft.item.ItemStack;
+
+public class AdaptorMEChest extends AdaptorIInventory {
+
+    private final TileChest meChest;
+    public AdaptorMEChest(TileChest meChest) {
+        super(meChest.getInternalInventory());
+        this.meChest = meChest;
+    }
+
+    @Override
+    public ItemStack addItems(ItemStack toBeAdded, InsertionMode insertionMode) {
+        if (meChest.getItemInventory() == null) {
+            return toBeAdded;
+        }
+        // Ignore insertion mode since injecting into a ME system doesn't have this concept
+        IAEItemStack result = (IAEItemStack) meChest.getItemInventory().injectItems(
+                AEItemStack.create(toBeAdded),
+                Actionable.MODULATE,
+                meChest.getActionSource()
+        );
+        return result == null ? null : result.getItemStack();
+    }
+
+    @Override
+    public ItemStack simulateAdd(ItemStack toBeSimulated, InsertionMode insertionMode) {
+        if (meChest.getItemInventory() == null) {
+            return toBeSimulated;
+        }
+        // Ignore insertion mode since injecting into a ME system doesn't have this concept
+        IAEItemStack result = (IAEItemStack) meChest.getItemInventory().injectItems(
+                AEItemStack.create(toBeSimulated),
+                Actionable.SIMULATE,
+                meChest.getActionSource()
+        );
+        return result == null ? null : result.getItemStack();
+    }
+}

--- a/src/main/java/appeng/util/inv/AdaptorP2PItem.java
+++ b/src/main/java/appeng/util/inv/AdaptorP2PItem.java
@@ -1,4 +1,4 @@
-package appeng.util;
+package appeng.util.inv;
 
 import appeng.parts.p2p.PartP2PItems;
 import appeng.util.inv.AdaptorIInventory;

--- a/src/main/java/appeng/util/inv/AdaptorP2PItem.java
+++ b/src/main/java/appeng/util/inv/AdaptorP2PItem.java
@@ -1,7 +1,6 @@
 package appeng.util.inv;
 
 import appeng.parts.p2p.PartP2PItems;
-import appeng.util.inv.AdaptorIInventory;
 
 public class AdaptorP2PItem extends AdaptorIInventory {
 

--- a/src/main/java/appeng/util/inv/WrapperInventoryRange.java
+++ b/src/main/java/appeng/util/inv/WrapperInventoryRange.java
@@ -93,10 +93,6 @@ public class WrapperInventoryRange implements IInventory {
 
     @Override
     public int getInventoryStackLimit() {
-        if (this.src instanceof AEBaseInvTile) {
-            IInventory internalInv = ((AEBaseInvTile) this.src).getInternalInventory();
-            return internalInv.getInventoryStackLimit();
-        }
         return this.src.getInventoryStackLimit();
     }
 

--- a/src/main/java/appeng/util/inv/WrapperInventoryRange.java
+++ b/src/main/java/appeng/util/inv/WrapperInventoryRange.java
@@ -14,8 +14,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 
-import appeng.tile.AEBaseInvTile;
-
 public class WrapperInventoryRange implements IInventory {
 
     private final IInventory src;


### PR DESCRIPTION
The changes for allowing insertion into ME chests caused the export bus to ignore stack limits of the inscriber. Patch creates a dedicated me chest handler to preserve interface throughput into a me chest, while reverting the stack limit check to before.

Also moves the P2P adaptor to the correct package, whoops

Fixes https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/issues/379