### PR TITLE
RF Attunement Expansion for P2Ps

### DIFF
--- a/src/main/java/appeng/integration/modules/RF.java
+++ b/src/main/java/appeng/integration/modules/RF.java
@@ -57,11 +57,15 @@ public final class RF implements IIntegrationModule {
         this.registerRFAttunement("ThermalExpansion", "Cell", OreDictionary.WILDCARD_VALUE);
         this.registerRFAttunement("ThermalExpansion", "Dynamo", OreDictionary.WILDCARD_VALUE);
 
-        // Fluxduct
+        // Leadstone Fluxduct
         this.registerRFAttunement("ThermalDynamics", "ThermalDynamics_0", 0);
+        // Hardened Fluxduct
         this.registerRFAttunement("ThermalDynamics", "ThermalDynamics_0", 1);
+        // Redstone Fluxduct
         this.registerRFAttunement("ThermalDynamics", "ThermalDynamics_0", 2);
+        // Resonant Fluxduct
         this.registerRFAttunement("ThermalDynamics", "ThermalDynamics_0", 4);
+        // Cryo-Stabilized Fluxduct
         this.registerRFAttunement("ThermalDynamics", "ThermalDynamics_0", 6);
 
         this.registerRFAttunement("EnderIO", "itemPowerConduit", OreDictionary.WILDCARD_VALUE);

--- a/src/main/java/appeng/integration/modules/RF.java
+++ b/src/main/java/appeng/integration/modules/RF.java
@@ -59,6 +59,10 @@ public final class RF implements IIntegrationModule {
 
         // Fluxduct
         this.registerRFAttunement("ThermalDynamics", "ThermalDynamics_0", 0);
+        this.registerRFAttunement("ThermalDynamics", "ThermalDynamics_0", 1);
+        this.registerRFAttunement("ThermalDynamics", "ThermalDynamics_0", 2);
+        this.registerRFAttunement("ThermalDynamics", "ThermalDynamics_0", 4);
+        this.registerRFAttunement("ThermalDynamics", "ThermalDynamics_0", 6);
 
         this.registerRFAttunement("EnderIO", "itemPowerConduit", OreDictionary.WILDCARD_VALUE);
         this.registerRFAttunement("EnderIO", "blockCapacitorBank", 0);


### PR DESCRIPTION
Allow all Thermal Dynamics Fluxducts to attune P2Ps to Redstone Flux.

This adds compat to the following Fluxducts:
- Hardened
- Redstone
- Resonant
- Cryo-Stabilized