### PR TITLE
Add explicit support for BuildCraft, CoFH wrenches

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -11,12 +11,15 @@ dependencies {
     compileOnly('com.github.GTNewHorizons:OpenComputers:1.9.17-GTNH:api') {transitive = false}
     compileOnly('com.github.GTNewHorizons:waila:1.6.0:dev') {transitive = false}
     compileOnly('com.github.GTNewHorizons:Railcraft:9.15.0:api') {transitive = false}
-
     compileOnly('net.industrial-craft:industrialcraft-2:2.2.828-experimental:api')
     compileOnly('curse.maven:minefactory-reloaded-66672:2366150')
     compileOnly('pneumaticCraft:PneumaticCraft-1.7.10:1.12.7-152:api') {transitive = false}
     compileOnly('curse.maven:better-storage-232919:2731636')
     compileOnly('api:immibis:1')
+
+    // Uncomment to add thermal expansion + foundation for testing
+//    runtimeOnlyNonPublishable('curse.maven:thermal-foundation-222880:2388753')
+//    runtimeOnlyNonPublishable('curse.maven:thermal-expansion-69163:2388759')
 
     testImplementation('junit:junit:4.12')
     functionalTestImplementation(platform('org.junit:junit-bom:5.9.2'))

--- a/src/main/java/appeng/api/implementations/items/IAEWrench.java
+++ b/src/main/java/appeng/api/implementations/items/IAEWrench.java
@@ -17,7 +17,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 
 /**
- * Implemented on AE's wrench(s) as a substitute for if BC's API is not available.
+ * Implemented on AE's wrench(s)
  */
 public interface IAEWrench {
 

--- a/src/main/java/appeng/integration/IntegrationType.java
+++ b/src/main/java/appeng/integration/IntegrationType.java
@@ -27,6 +27,7 @@ public enum IntegrationType {
     RF(IntegrationSide.BOTH, "RedstoneFlux Power - Tiles", "CoFHAPI"),
 
     RFItem(IntegrationSide.BOTH, "RedstoneFlux Power - Items", "CoFHAPI"),
+    CoFHWrench(IntegrationSide.BOTH, "CoFHWrench", "CoFHAPI"),
 
     MFR(IntegrationSide.BOTH, "Mine Factory Reloaded", "MineFactoryReloaded"),
 

--- a/src/main/java/appeng/integration/modules/CoFHWrench.java
+++ b/src/main/java/appeng/integration/modules/CoFHWrench.java
@@ -1,0 +1,21 @@
+package appeng.integration.modules;
+
+import appeng.helpers.Reflected;
+import appeng.integration.IIntegrationModule;
+import appeng.integration.IntegrationHelper;
+
+public class CoFHWrench implements IIntegrationModule {
+
+    @Reflected
+    public static CoFHWrench instance;
+
+    public CoFHWrench() {
+        IntegrationHelper.testClassExistence(this, cofh.api.item.IToolHammer.class);
+    }
+
+    @Override
+    public void init() {}
+
+    @Override
+    public void postInit() {}
+}

--- a/src/main/java/appeng/items/tools/ToolNetworkTool.java
+++ b/src/main/java/appeng/items/tools/ToolNetworkTool.java
@@ -13,6 +13,7 @@ package appeng.items.tools;
 import java.util.EnumSet;
 
 import net.minecraft.block.Block;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
@@ -43,11 +44,15 @@ import appeng.integration.IntegrationType;
 import appeng.items.AEBaseItem;
 import appeng.items.contents.NetworkToolViewer;
 import appeng.transformer.annotations.Integration.Interface;
+import appeng.transformer.annotations.Integration.InterfaceList;
 import appeng.util.Platform;
 import buildcraft.api.tools.IToolWrench;
+import cofh.api.item.IToolHammer;
 
-@Interface(iface = "buildcraft.api.tools.IToolWrench", iname = IntegrationType.BuildCraftCore)
-public class ToolNetworkTool extends AEBaseItem implements IGuiItem, IAEWrench, IToolWrench {
+@InterfaceList(
+        value = { @Interface(iface = "cofh.api.item.IToolHammer", iname = IntegrationType.CoFHWrench),
+                @Interface(iface = "buildcraft.api.tools.IToolWrench", iname = IntegrationType.BuildCraftCore) })
+public class ToolNetworkTool extends AEBaseItem implements IGuiItem, IAEWrench, IToolWrench, IToolHammer {
 
     public ToolNetworkTool() {
         super(Optional.absent());
@@ -192,6 +197,8 @@ public class ToolNetworkTool extends AEBaseItem implements IGuiItem, IAEWrench, 
         return true;
     }
 
+    /* IToolWrench (BC) */
+
     @Override
     public boolean canWrench(final EntityPlayer player, final int x, final int y, final int z) {
         return true;
@@ -200,5 +207,17 @@ public class ToolNetworkTool extends AEBaseItem implements IGuiItem, IAEWrench, 
     @Override
     public void wrenchUsed(final EntityPlayer player, final int x, final int y, final int z) {
         player.swingItem();
+    }
+
+    /* IToolHammer (CoFH) */
+
+    @Override
+    public boolean isUsable(ItemStack itemStack, EntityLivingBase entityLivingBase, int x, int y, int z) {
+        return true;
+    }
+
+    @Override
+    public void toolUsed(ItemStack itemStack, EntityLivingBase entity, int x, int y, int z) {
+        entity.swingItem();
     }
 }

--- a/src/main/java/appeng/items/tools/quartz/ToolQuartzWrench.java
+++ b/src/main/java/appeng/items/tools/quartz/ToolQuartzWrench.java
@@ -13,6 +13,7 @@ package appeng.items.tools.quartz;
 import java.util.EnumSet;
 
 import net.minecraft.block.Block;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
@@ -28,11 +29,15 @@ import appeng.core.features.AEFeature;
 import appeng.integration.IntegrationType;
 import appeng.items.AEBaseItem;
 import appeng.transformer.annotations.Integration.Interface;
+import appeng.transformer.annotations.Integration.InterfaceList;
 import appeng.util.Platform;
 import buildcraft.api.tools.IToolWrench;
+import cofh.api.item.IToolHammer;
 
-@Interface(iface = "buildcraft.api.tools.IToolWrench", iname = IntegrationType.BuildCraftCore)
-public class ToolQuartzWrench extends AEBaseItem implements IAEWrench, IToolWrench {
+@InterfaceList(
+        value = { @Interface(iface = "cofh.api.item.IToolHammer", iname = IntegrationType.CoFHWrench),
+                @Interface(iface = "buildcraft.api.tools.IToolWrench", iname = IntegrationType.BuildCraftCore) })
+public class ToolQuartzWrench extends AEBaseItem implements IAEWrench, IToolWrench, IToolHammer {
 
     public ToolQuartzWrench(final AEFeature type) {
         super(Optional.of(type.name()));
@@ -77,7 +82,6 @@ public class ToolQuartzWrench extends AEBaseItem implements IAEWrench, IToolWren
     }
 
     @Override
-    // public boolean shouldPassSneakingClickToBlock(World w, int x, int y, int z)
     public boolean doesSneakBypassUse(final World world, final int x, final int y, final int z,
             final EntityPlayer player) {
         return true;
@@ -88,6 +92,7 @@ public class ToolQuartzWrench extends AEBaseItem implements IAEWrench, IToolWren
         return true;
     }
 
+    /* IToolWrench - BC */
     @Override
     public boolean canWrench(final EntityPlayer player, final int x, final int y, final int z) {
         return true;
@@ -96,5 +101,16 @@ public class ToolQuartzWrench extends AEBaseItem implements IAEWrench, IToolWren
     @Override
     public void wrenchUsed(final EntityPlayer player, final int x, final int y, final int z) {
         player.swingItem();
+    }
+
+    /* IToolHammer - CoFH */
+    @Override
+    public boolean isUsable(ItemStack itemStack, EntityLivingBase entity, int x, int y, int z) {
+        return true;
+    }
+
+    @Override
+    public void toolUsed(ItemStack itemStack, EntityLivingBase entity, int x, int y, int z) {
+        entity.swingItem();
     }
 }

--- a/src/main/java/appeng/parts/p2p/PartP2PTunnelStatic.java
+++ b/src/main/java/appeng/parts/p2p/PartP2PTunnelStatic.java
@@ -15,7 +15,6 @@ import appeng.api.parts.PartItemStack;
 import appeng.me.GridAccessException;
 import appeng.me.cache.P2PCache;
 import appeng.util.Platform;
-import buildcraft.api.tools.IToolWrench;
 
 /**
  * Static P2P tunnels cannot be attuned to. They can only be bound to each other.
@@ -67,9 +66,10 @@ public abstract class PartP2PTunnelStatic<T extends PartP2PTunnelStatic> extends
                 }
             }
             mc.notifyUser(player, MemoryCardMessages.INVALID_MACHINE);
-        } else if (!player.isSneaking() && is != null && is.getItem() instanceof IToolWrench && !Platform.isClient()) {
-            printConnectionInfo(player);
-        }
+        } else if (!player.isSneaking() && Platform.isServer()
+                && Platform.isWrench(player, is, (int) pos.xCoord, (int) pos.yCoord, (int) pos.zCoord)) {
+                    printConnectionInfo(player);
+                }
         return false;
     }
 

--- a/src/main/java/appeng/transformer/asm/ASMIntegration.java
+++ b/src/main/java/appeng/transformer/asm/ASMIntegration.java
@@ -35,14 +35,13 @@ public final class ASMIntegration implements IClassTransformer {
 
     @Reflected
     public ASMIntegration() {
-
-        /**
-         * Side, Display Name, ModID ClassPostFix
-         */
         for (final IntegrationType type : IntegrationType.values()) {
             IntegrationRegistry.INSTANCE.add(type);
         }
-
+        // These are kept so we don't have to search through git for stuff like this
+        /*
+         * Side, Display Name, ModID ClassPostFix
+         */
         // integrationModules.add( IntegrationSide.BOTH, "Thermal Expansion", "ThermalExpansion", IntegrationType.TE );
         // integrationModules.add( IntegrationSide.BOTH, "Mystcraft", "Mystcraft", IntegrationType.Mystcraft );
         // integrationModules.add( IntegrationSide.BOTH, "Greg Tech", "gregtech_addon", IntegrationType.GT );

--- a/src/main/java/appeng/util/Platform.java
+++ b/src/main/java/appeng/util/Platform.java
@@ -126,6 +126,7 @@ import appeng.util.item.OreHelper;
 import appeng.util.item.OreReference;
 import appeng.util.prioitylist.IPartitionList;
 import buildcraft.api.tools.IToolWrench;
+import cofh.api.item.IToolHammer;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.ModContainer;
@@ -144,8 +145,6 @@ public class Platform {
     public static final Block AIR_BLOCK = Blocks.air;
 
     public static final int DEF_OFFSET = 16;
-
-    private static final boolean isBuildCraftLoaded = Loader.isModLoaded("BuildCraft|Core");
 
     /*
      * random source, use it for item drop locations...
@@ -844,18 +843,23 @@ public class Platform {
         return false;
     }
 
-    public static boolean isWrench(final EntityPlayer player, final ItemStack eq, final int x, final int y,
+    public static boolean isWrench(final EntityPlayer player, final ItemStack stack, final int x, final int y,
             final int z) {
-        if (eq == null) {
-            return false;
-        }
+        if (stack != null) {
+            Item itemWrench = stack.getItem();
+            if (itemWrench instanceof IAEWrench wrench) {
+                return wrench.canWrench(stack, player, x, y, z);
+            }
 
-        if (isBuildCraftLoaded && eq.getItem() instanceof IToolWrench wrench) {
-            return wrench.canWrench(player, x, y, z);
-        }
+            if (IntegrationRegistry.INSTANCE.isEnabled(IntegrationType.CoFHWrench)
+                    && itemWrench instanceof IToolHammer wrench) {
+                return wrench.isUsable(stack, player, x, y, z);
+            }
 
-        if (eq.getItem() instanceof IAEWrench wrench) {
-            return wrench.canWrench(eq, player, x, y, z);
+            if (IntegrationRegistry.INSTANCE.isEnabled(IntegrationType.BuildCraftCore)
+                    && itemWrench instanceof IToolWrench wrench) {
+                return wrench.canWrench(player, x, y, z);
+            }
         }
         return false;
     }


### PR DESCRIPTION
Uses AE2's integration system to add support for Thermal Expansion wrenches
* Refactor `ToolQuartzWrench` and `ToolNetworkTool`, move BC optional interface `IToolWrench` to `IAEWrench`
* Adds `IToolHammer` to `IAEWrench`

Fixes https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/issues/395