### PR TITLE
Wrap fake player instances in WeakReference

### DIFF
--- a/src/main/java/appeng/util/Platform.java
+++ b/src/main/java/appeng/util/Platform.java
@@ -10,6 +10,7 @@
 
 package appeng.util;
 
+import java.lang.ref.WeakReference;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.security.InvalidParameterException;
@@ -150,7 +151,7 @@ public class Platform {
      * random source, use it for item drop locations...
      */
     private static final Random RANDOM_GENERATOR = new Random();
-    private static final WeakHashMap<World, EntityPlayer> FAKE_PLAYERS = new WeakHashMap<>();
+    private static final WeakHashMap<World, WeakReference<EntityPlayer>> FAKE_PLAYERS = new WeakHashMap<>();
     private static Field tagList;
     private static Class playerInstance;
     private static Method getOrCreateChunkWatcher;
@@ -880,13 +881,16 @@ public class Platform {
             throw new InvalidParameterException("World is null.");
         }
 
-        final EntityPlayer wrp = FAKE_PLAYERS.get(w);
-        if (wrp != null) {
-            return wrp;
+        final WeakReference<EntityPlayer> weakRef = FAKE_PLAYERS.get(w);
+        if (weakRef != null) {
+            EntityPlayer fakePlayer = weakRef.get();
+            if (fakePlayer != null) {
+                return fakePlayer;
+            }
         }
 
         final EntityPlayer p = FakePlayerFactory.get(w, fakeProfile);
-        FAKE_PLAYERS.put(w, p);
+        FAKE_PLAYERS.put(w, new WeakReference<>(p));
         return p;
     }
 


### PR DESCRIPTION
This fixes a memory leak where World instances are kept alive by fake player instances. The `WeakHashMap` only stores its keys using `WeakReference`s but not its values. The values are only set to `null` once some operation is performed on the map. 
In some cases, after the `World` has been GC'd, no further operation will be performed to allow collection of the value, therefore keeping unused world instances alive. For example if you switch from an AE2-world to a non-AE2-world or if you switch from SP to MP.
This behavior is not relevant on the server.

Also recommended here https://github.com/MinecraftForge/MinecraftForge/blob/1.7.10/src/main/java/net/minecraftforge/common/util/FakePlayerFactory.java#L33