### PR TITLE
Support stack sizes larger than 127 when transferring from NEI

### DIFF
--- a/src/main/java/appeng/core/sync/packets/PacketNEIRecipe.java
+++ b/src/main/java/appeng/core/sync/packets/PacketNEIRecipe.java
@@ -67,7 +67,14 @@ public class PacketNEIRecipe extends AppEngPacket {
                 if (list.tagCount() > 0) {
                     this.recipe[x] = new ItemStack[list.tagCount()];
                     for (int y = 0; y < list.tagCount(); y++) {
-                        this.recipe[x][y] = ItemStack.loadItemStackFromNBT(list.getCompoundTagAt(y));
+                        NBTTagCompound tag = list.getCompoundTagAt(y);
+                        ItemStack itemStack = ItemStack.loadItemStackFromNBT(tag);
+                        // Set the stack size again, but load it as a short
+                        if (itemStack != null) {
+                            itemStack.stackSize = tag.getShort("Count");
+                        }
+
+                        this.recipe[x][y] = itemStack;
                     }
                 }
             }

--- a/src/main/java/appeng/integration/modules/NEIHelpers/NEICraftingHandler.java
+++ b/src/main/java/appeng/integration/modules/NEIHelpers/NEICraftingHandler.java
@@ -90,6 +90,8 @@ public class NEICraftingHandler implements IOverlayHandler {
                             for (final ItemStack is : list) {
                                 final NBTTagCompound tag = new NBTTagCompound();
                                 is.writeToNBT(tag);
+                                // Overwrite the stack size as a short
+                                tag.setShort("Count", (short) is.stackSize);
                                 tags.appendTag(tag);
                                 if (limited) {
                                     final NBTTagCompound test = new NBTTagCompound();


### PR DESCRIPTION
This PR removed the splitting of stacks to batches of 64. Now, when transferring these recipes from NEI the stack sizes will be incorrect because NEI uses minecraft's default `writeToNBT` method which encodes the stack size as a byte.

I also made `packIngredients` public to be reused in AE2FC.

https://github.com/GTNewHorizons/GoodGenerator/pull/214/commits/16c1f042383a7dd8880d78448387afd208aa7982