### PR TITLE
ME IO Port Tweaks

### DIFF
--- a/src/main/java/appeng/tile/storage/TileIOPort.java
+++ b/src/main/java/appeng/tile/storage/TileIOPort.java
@@ -152,6 +152,12 @@ public class TileIOPort extends AENetworkInvTile implements IUpgradeableHost, IC
         }
     }
 
+    @Override
+    public void gridChanged() {
+        super.gridChanged();
+        updateTask();
+    }
+
     public void updateRedstoneState() {
         final YesNo currentState = this.worldObj.isBlockIndirectlyGettingPowered(this.xCoord, this.yCoord, this.zCoord)
                 ? YesNo.YES

--- a/src/main/java/appeng/tile/storage/TileIOPort.java
+++ b/src/main/java/appeng/tile/storage/TileIOPort.java
@@ -237,13 +237,20 @@ public class TileIOPort extends AENetworkInvTile implements IUpgradeableHost, IC
     }
 
     @Override
+    public boolean isItemValidForSlot(final int i, final ItemStack itemstack) {
+        return itemstack != null && AEApi.instance().registries().cell().isCellHandled(itemstack);
+
+    }
+
+    @Override
     public boolean canInsertItem(final int slotIndex, final ItemStack insertingItem, final int side) {
-        for (final int inputSlotIndex : this.input) {
-            if (inputSlotIndex == slotIndex) {
-                return true;
+        if (isItemValidForSlot(slotIndex, insertingItem)) {
+            for (final int inputSlotIndex : this.input) {
+                if (inputSlotIndex == slotIndex) {
+                    return true;
+                }
             }
         }
-
         return false;
     }
 

--- a/src/main/java/appeng/tile/storage/TileIOPort.java
+++ b/src/main/java/appeng/tile/storage/TileIOPort.java
@@ -87,6 +87,11 @@ public class TileIOPort extends AENetworkInvTile implements IUpgradeableHost, IC
             OUTPUT_SLOT_INDEX_CENTER_LEFT, OUTPUT_SLOT_INDEX_CENTER_RIGHT, OUTPUT_SLOT_INDEX_BOTTOM_LEFT,
             OUTPUT_SLOT_INDEX_BOTTOM_RIGHT };
 
+    private final int[] slots = { INPUT_SLOT_INDEX_TOP_LEFT, INPUT_SLOT_INDEX_TOP_RIGHT, INPUT_SLOT_INDEX_CENTER_LEFT,
+            INPUT_SLOT_INDEX_CENTER_RIGHT, INPUT_SLOT_INDEX_BOTTOM_LEFT, INPUT_SLOT_INDEX_BOTTOM_RIGHT,
+            OUTPUT_SLOT_INDEX_TOP_LEFT, OUTPUT_SLOT_INDEX_TOP_RIGHT, OUTPUT_SLOT_INDEX_CENTER_LEFT,
+            OUTPUT_SLOT_INDEX_CENTER_RIGHT, OUTPUT_SLOT_INDEX_BOTTOM_LEFT, OUTPUT_SLOT_INDEX_BOTTOM_RIGHT };
+
     private final AppEngInternalInventory cells;
     private final UpgradeInventory upgrades;
 
@@ -239,7 +244,6 @@ public class TileIOPort extends AENetworkInvTile implements IUpgradeableHost, IC
     @Override
     public boolean isItemValidForSlot(final int i, final ItemStack itemstack) {
         return itemstack != null && AEApi.instance().registries().cell().isCellHandled(itemstack);
-
     }
 
     @Override
@@ -261,17 +265,12 @@ public class TileIOPort extends AENetworkInvTile implements IUpgradeableHost, IC
                 return true;
             }
         }
-
         return false;
     }
 
     @Override
     public int[] getAccessibleSlotsBySide(final ForgeDirection d) {
-        if (d == ForgeDirection.UP || d == ForgeDirection.DOWN) {
-            return this.input;
-        }
-
-        return this.output;
+        return slots;
     }
 
     @Override


### PR DESCRIPTION
Three minor changes:

* The ME IO port now restarts operation when it is disconnected and reconnected to an ME network. In particular this happens on singleplayer world restart. Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14807 and https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13482.
* Cells can be inserted into and extracted from any side of the ME IO port. As before, cells can only be inserted into the input slots, and extracted from the output slots. Resolves https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14786.
* Only valid storage cells can now be inserted into the ME IO port.