### PR TITLE
Use simple array list instead of two maps to manage inventories in NetworkInventoryHandler

### DIFF
--- a/src/main/java/appeng/me/storage/NetworkInventoryHandler.java
+++ b/src/main/java/appeng/me/storage/NetworkInventoryHandler.java
@@ -141,7 +141,10 @@ public class NetworkInventoryHandler<T extends IAEStack<T>> implements IMEInvent
 
                 i++;
 
-                if (i >= size) break outer;
+                if (i >= size) {
+                    if (passTwoIndex == -1) break outer; // If pass 2 also has no work to do, we're fully done
+                    else break; // Otherwise pass 2 will run till the end again and then break out of the outer loop
+                }
 
                 inv = priorityInventory.get(i);
 

--- a/src/main/java/appeng/util/SortedArrayList.java
+++ b/src/main/java/appeng/util/SortedArrayList.java
@@ -1,0 +1,47 @@
+package appeng.util;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+
+public class SortedArrayList<E> extends ArrayList<E> {
+
+    private final Comparator<? super E> comparator;
+
+    public SortedArrayList(Comparator<? super E> comparator) {
+        this.comparator = comparator;
+    }
+
+    @Override
+    public boolean add(E e) {
+        int index = Collections.binarySearch(this, e, comparator);
+        if (index < 0) {
+            index = -(index + 1);
+        }
+
+        super.add(index, e);
+        return true;
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends E> c) {
+        boolean result = super.addAll(c);
+        sort(comparator);
+        return result;
+    }
+
+    @Override
+    public boolean addAll(int index, Collection<? extends E> c) {
+        boolean result = super.addAll(index, c);
+        sort(comparator);
+        return result;
+    }
+
+    @Override
+    public E set(int index, E element) {
+        E result = super.set(index, element);
+        sort(comparator);
+        return result;
+    }
+}


### PR DESCRIPTION
Finally got around to trying this [again](https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/423). Should hopefully work properly this time. Tested it for a while on our server.

The code is a bit harder to understand now, but from my benchmarks it offers a 1.5x speed improvement. 

For the reviewer: Here's a simplified diagram of how the loop operates and switches between pass 1 and pass 2.
![image](https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/assets/36999320/46241316-30a1-4577-b152-4af8e9fed6c7)
