### PR TITLE
Remove `compareTo` Override in AECommand

### DIFF
--- a/src/main/java/appeng/server/AECommand.java
+++ b/src/main/java/appeng/server/AECommand.java
@@ -34,14 +34,6 @@ public final class AECommand extends CommandBase {
         return 0;
     }
 
-    /**
-     * wtf?
-     */
-    @Override
-    public int compareTo(final Object arg0) {
-        return 1;
-    }
-
     @Override
     public String getCommandName() {
         return "ae2";


### PR DESCRIPTION
`CommandBase` (which `AECommand` extends) implements the `Comparable` interface via `ICommand`. The default implementation compares the command names. This is done to get a list of commands in alphabetical order when auto-completing a command or using `/help`. The override in `AECommand` always returned 1, breaking that ordering.
This was discovered using [HelpFixer](https://www.curseforge.com/minecraft/mc-mods/helpfixer):
```
[14:03:36] [Server thread/WARN] [FML/HelpFixer]: [HelpFixer] Command ae2 incorrectly overrides compareTo: appeng.server.AECommand
```