### PR TITLE
Add Dynamic Font Size for Terminals

### DIFF
--- a/src/main/java/appeng/api/config/Settings.java
+++ b/src/main/java/appeng/api/config/Settings.java
@@ -77,7 +77,9 @@ public enum Settings {
 
     LOCK_CRAFTING_MODE(EnumSet.allOf(LockCraftingMode.class)),
 
-    PRIORITY_CARD_MODE(EnumSet.allOf(PriorityCardMode.class));
+    PRIORITY_CARD_MODE(EnumSet.allOf(PriorityCardMode.class)),
+
+    TERMINAL_FONT_SIZE(EnumSet.allOf(TerminalFontSize.class));
 
     private final EnumSet<? extends Enum<?>> values;
 

--- a/src/main/java/appeng/api/config/TerminalFontSize.java
+++ b/src/main/java/appeng/api/config/TerminalFontSize.java
@@ -1,0 +1,9 @@
+package appeng.api.config;
+
+public enum TerminalFontSize {
+    SMALL,
+
+    DYNAMIC,
+
+    LARGE
+}

--- a/src/main/java/appeng/client/gui/AEBaseGui.java
+++ b/src/main/java/appeng/client/gui/AEBaseGui.java
@@ -56,6 +56,7 @@ import appeng.container.slot.AppEngCraftingSlot;
 import appeng.container.slot.AppEngSlot;
 import appeng.container.slot.AppEngSlot.hasCalculatedValidness;
 import appeng.container.slot.OptionalSlotFake;
+import appeng.container.slot.OptionalSlotRestrictedInput;
 import appeng.container.slot.SlotCraftingTerm;
 import appeng.container.slot.SlotDisabled;
 import appeng.container.slot.SlotFake;
@@ -64,6 +65,7 @@ import appeng.container.slot.SlotInaccessible;
 import appeng.container.slot.SlotOutput;
 import appeng.container.slot.SlotPatternTerm;
 import appeng.container.slot.SlotRestrictedInput;
+import appeng.core.AEConfig;
 import appeng.core.AELog;
 import appeng.core.AppEng;
 import appeng.core.localization.GuiColors;
@@ -968,8 +970,15 @@ public abstract class AEBaseGui extends GuiContainer {
         translatedRenderItem
                 .renderItemAndEffectIntoGUI(this.fontRendererObj, this.mc.getTextureManager(), itemstack, i, j);
         translatedRenderItem.zLevel = 200.0f;
-        translatedRenderItem
-                .renderItemOverlayIntoGUI(this.fontRendererObj, this.mc.getTextureManager(), itemstack, i, j, s);
+        translatedRenderItem.renderItemOverlayIntoGUI(
+                this.fontRendererObj,
+                this.mc.getTextureManager(),
+                itemstack,
+                i,
+                j,
+                s,
+                (slotIn instanceof OptionalSlotRestrictedInput) ? AEConfig.instance.getTerminalFontSize() : null);
+
         translatedRenderItem.zLevel = 0.0f;
     }
 

--- a/src/main/java/appeng/client/gui/AEBaseMEGui.java
+++ b/src/main/java/appeng/client/gui/AEBaseMEGui.java
@@ -18,6 +18,7 @@ import net.minecraft.inventory.Container;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 
+import appeng.api.config.TerminalFontSize;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.client.me.SlotME;
 import appeng.container.slot.SlotFake;
@@ -38,7 +39,7 @@ public abstract class AEBaseMEGui extends AEBaseGui implements IGuiTooltipHandle
             final Slot s = this.getSlot(mouseX, mouseY);
             final boolean isSlotME = s instanceof SlotME;
             if (isSlotME || s instanceof SlotFake) {
-                final int BigNumber = AEConfig.instance.useTerminalUseLargeFont() ? 999 : 9999;
+                final int BigNumber = AEConfig.instance.getTerminalFontSize() == TerminalFontSize.SMALL ? 9999 : 999;
 
                 IAEItemStack myStack = null;
 
@@ -83,7 +84,7 @@ public abstract class AEBaseMEGui extends AEBaseGui implements IGuiTooltipHandle
     public void renderToolTip(final ItemStack stack, final int x, final int y) {
         final Slot s = this.getSlot(x, y);
         if ((s instanceof SlotME || s instanceof SlotFake) && stack != null) {
-            final int BigNumber = AEConfig.instance.useTerminalUseLargeFont() ? 999 : 9999;
+            final int BigNumber = AEConfig.instance.getTerminalFontSize() == TerminalFontSize.SMALL ? 9999 : 999;
 
             IAEItemStack myStack = null;
 

--- a/src/main/java/appeng/client/render/AERenderItem.java
+++ b/src/main/java/appeng/client/render/AERenderItem.java
@@ -15,11 +15,12 @@ public abstract class AERenderItem extends RenderItem {
     private static final ISlimReadableNumberConverter SLIM_CONVERTER = ReadableNumberConverter.INSTANCE;
     private static final IWideReadableNumberConverter WIDE_CONVERTER = ReadableNumberConverter.INSTANCE;
 
-    public void drawStackSize(int offsetX, int offsetY, long stackSize, FontRenderer font, Enum fontSize) {
+    public void drawStackSize(int offsetX, int offsetY, long stackSize, FontRenderer font, TerminalFontSize fontSize) {
         drawStackSize(offsetX, offsetY, getToBeRenderedStackSize(stackSize, fontSize), font, fontSize);
     }
 
-    public void drawStackSize(int offsetX, int offsetY, String customText, FontRenderer font, Enum fontSize) {
+    public void drawStackSize(int offsetX, int offsetY, String customText, FontRenderer font,
+            TerminalFontSize fontSize) {
         float scale = 1.0f;
         float shiftX = 0f;
         float shiftY = 0f;
@@ -71,7 +72,7 @@ public abstract class AERenderItem extends RenderItem {
         }
     }
 
-    protected String getToBeRenderedStackSize(final long originalSize, Enum fontSize) {
+    protected String getToBeRenderedStackSize(final long originalSize, TerminalFontSize fontSize) {
         if (fontSize == TerminalFontSize.LARGE) {
             return SLIM_CONVERTER.toSlimReadableForm(originalSize);
         } else {

--- a/src/main/java/appeng/client/render/AERenderItem.java
+++ b/src/main/java/appeng/client/render/AERenderItem.java
@@ -1,0 +1,81 @@
+package appeng.client.render;
+
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.renderer.entity.RenderItem;
+
+import org.lwjgl.opengl.GL11;
+
+import appeng.api.config.TerminalFontSize;
+import appeng.util.ISlimReadableNumberConverter;
+import appeng.util.IWideReadableNumberConverter;
+import appeng.util.ReadableNumberConverter;
+
+public abstract class AERenderItem extends RenderItem {
+
+    private static final ISlimReadableNumberConverter SLIM_CONVERTER = ReadableNumberConverter.INSTANCE;
+    private static final IWideReadableNumberConverter WIDE_CONVERTER = ReadableNumberConverter.INSTANCE;
+
+    public void drawStackSize(int offsetX, int offsetY, long stackSize, FontRenderer font, Enum fontSize) {
+        drawStackSize(offsetX, offsetY, getToBeRenderedStackSize(stackSize, fontSize), font, fontSize);
+    }
+
+    public void drawStackSize(int offsetX, int offsetY, String customText, FontRenderer font, Enum fontSize) {
+        float scale = 1.0f;
+        float shiftX = 0f;
+        float shiftY = 0f;
+
+        if (fontSize == TerminalFontSize.LARGE && customText.length() > 3) {
+            fontSize = TerminalFontSize.DYNAMIC;
+        }
+
+        if (fontSize == TerminalFontSize.SMALL) {
+            scale = 0.5f;
+            shiftX = 2;
+            shiftY = 1;
+        } else if (fontSize == TerminalFontSize.LARGE) {
+            scale = 0.85f;
+        } else if (fontSize == TerminalFontSize.DYNAMIC) {
+            if (customText.length() == 3) {
+                scale = 0.786f;
+                shiftX = 0.5f;
+            } else if (customText.length() == 4) {
+                scale = 0.644f;
+                shiftX = 1f;
+                shiftY = 0.5f;
+            } else if (customText.length() > 4) {
+                scale = 0.5f;
+                shiftX = 2;
+                shiftY = 1;
+            } else {
+                scale = 0.85f;
+            }
+        }
+
+        if (scale == 1.0f) {
+            font.drawStringWithShadow(
+                    customText,
+                    offsetX + 16 + 1 - font.getStringWidth(customText),
+                    offsetY + 16 - 7,
+                    16777215);
+        } else {
+            final float inverseScaleFactor = 1.0f / scale;
+            GL11.glScaled(scale, scale, scale);
+
+            final int X = (int) (((float) offsetX - shiftX + 16.0f + 1.0f - font.getStringWidth(customText) * scale)
+                    * inverseScaleFactor);
+            final int Y = (int) (((float) offsetY - shiftY + 16.0f - 7.0f * scale) * inverseScaleFactor);
+
+            font.drawStringWithShadow(customText, X, Y, 16777215);
+
+            GL11.glScaled(inverseScaleFactor, inverseScaleFactor, inverseScaleFactor);
+        }
+    }
+
+    protected String getToBeRenderedStackSize(final long originalSize, Enum fontSize) {
+        if (fontSize == TerminalFontSize.LARGE) {
+            return SLIM_CONVERTER.toSlimReadableForm(originalSize);
+        } else {
+            return WIDE_CONVERTER.toWideReadableForm(originalSize);
+        }
+    }
+}

--- a/src/main/java/appeng/client/render/AppEngRenderItem.java
+++ b/src/main/java/appeng/client/render/AppEngRenderItem.java
@@ -17,21 +17,18 @@ import javax.annotation.Nonnull;
 
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 
 import org.lwjgl.opengl.GL11;
 
+import appeng.api.config.TerminalFontSize;
 import appeng.api.storage.IItemDisplayRegistry.ItemRenderHook;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.client.me.SlotME;
 import appeng.core.AEConfig;
 import appeng.core.localization.GuiText;
-import appeng.util.ISlimReadableNumberConverter;
-import appeng.util.IWideReadableNumberConverter;
-import appeng.util.ReadableNumberConverter;
 
 /**
  * @author AlgorithmX2
@@ -39,10 +36,7 @@ import appeng.util.ReadableNumberConverter;
  * @version rv2
  * @since rv0
  */
-public class AppEngRenderItem extends RenderItem {
-
-    private static final ISlimReadableNumberConverter SLIM_CONVERTER = ReadableNumberConverter.INSTANCE;
-    private static final IWideReadableNumberConverter WIDE_CONVERTER = ReadableNumberConverter.INSTANCE;
+public class AppEngRenderItem extends AERenderItem {
 
     private IAEItemStack aeStack = null;
     private Slot slot = null;
@@ -76,11 +70,8 @@ public class AppEngRenderItem extends RenderItem {
             if (skip) {
                 return;
             }
-            final float scaleFactor = AEConfig.instance.useTerminalUseLargeFont() ? 0.85f : 0.5f;
-            final float inverseScaleFactor = 1.0f / scaleFactor;
-            final int offset = AEConfig.instance.useTerminalUseLargeFont() ? 0 : -1;
-
             final boolean unicodeFlag = fontRenderer.getUnicodeFlag();
+            final Enum fontSize = AEConfig.instance.getTerminalFontSize();
             fontRenderer.setUnicodeFlag(false);
 
             if (showDurabilitybar && is.getItem().showDurabilityBar(is)) {
@@ -108,20 +99,12 @@ public class AppEngRenderItem extends RenderItem {
             }
 
             if (is.stackSize == 0 && showCraftLabelText && aeStack != null && aeStack.isCraftable()) {
-                final String craftLabelText = AEConfig.instance.useTerminalUseLargeFont()
-                        ? GuiText.LargeFontCraft.getLocal()
-                        : GuiText.SmallFontCraft.getLocal();
+                final String craftLabelText = fontSize == TerminalFontSize.SMALL ? GuiText.SmallFontCraft.getLocal()
+                        : GuiText.LargeFontCraft.getLocal();
 
                 GL11.glDisable(GL11.GL_LIGHTING);
                 GL11.glPushMatrix();
-                GL11.glScaled(scaleFactor, scaleFactor, scaleFactor);
-
-                final int X = (int) (((float) par4 + offset
-                        + 16.0f
-                        - fontRenderer.getStringWidth(craftLabelText) * scaleFactor) * inverseScaleFactor);
-                final int Y = (int) (((float) par5 + offset + 16.0f - 7.0f * scaleFactor) * inverseScaleFactor);
-                fontRenderer.drawStringWithShadow(craftLabelText, X, Y, 16777215);
-
+                this.drawStackSize(par4, par5, craftLabelText, fontRenderer, fontSize);
                 GL11.glPopMatrix();
                 GL11.glEnable(GL11.GL_LIGHTING);
             }
@@ -131,31 +114,15 @@ public class AppEngRenderItem extends RenderItem {
             if ((amount != 0 && showStackSize) || (slot != null && slot instanceof SlotME
                     && ((SlotME) slot).getAEStack() != null
                     && !((SlotME) slot).getAEStack().isCraftable())) {
-                final String stackSize = this.getToBeRenderedStackSize(amount);
 
                 GL11.glDisable(GL11.GL_LIGHTING);
                 GL11.glPushMatrix();
-                GL11.glScaled(scaleFactor, scaleFactor, scaleFactor);
-
-                final int X = (int) (((float) par4 + offset
-                        + 16.0f
-                        - fontRenderer.getStringWidth(stackSize) * scaleFactor) * inverseScaleFactor);
-                final int Y = (int) (((float) par5 + offset + 16.0f - 7.0f * scaleFactor) * inverseScaleFactor);
-                fontRenderer.drawStringWithShadow(stackSize, X, Y, 16777215);
-
+                this.drawStackSize(par4, par5, amount, fontRenderer, fontSize);
                 GL11.glPopMatrix();
                 GL11.glEnable(GL11.GL_LIGHTING);
             }
 
             fontRenderer.setUnicodeFlag(unicodeFlag);
-        }
-    }
-
-    private String getToBeRenderedStackSize(final long originalSize) {
-        if (AEConfig.instance.useTerminalUseLargeFont()) {
-            return SLIM_CONVERTER.toSlimReadableForm(originalSize);
-        } else {
-            return WIDE_CONVERTER.toWideReadableForm(originalSize);
         }
     }
 

--- a/src/main/java/appeng/client/render/AppEngRenderItem.java
+++ b/src/main/java/appeng/client/render/AppEngRenderItem.java
@@ -71,7 +71,7 @@ public class AppEngRenderItem extends AERenderItem {
                 return;
             }
             final boolean unicodeFlag = fontRenderer.getUnicodeFlag();
-            final Enum fontSize = AEConfig.instance.getTerminalFontSize();
+            final TerminalFontSize fontSize = AEConfig.instance.getTerminalFontSize();
             fontRenderer.setUnicodeFlag(false);
 
             if (showDurabilitybar && is.getItem().showDurabilityBar(is)) {

--- a/src/main/java/appeng/client/render/TranslatedRenderItem.java
+++ b/src/main/java/appeng/client/render/TranslatedRenderItem.java
@@ -4,22 +4,27 @@ import static appeng.client.render.AppEngRenderItem.POST_HOOKS;
 
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.item.ItemStack;
 
 import org.lwjgl.opengl.GL11;
 
+import appeng.api.config.TerminalFontSize;
 import appeng.api.storage.IItemDisplayRegistry.ItemRenderHook;
 
 /**
  * Uses translations instead of depth test to perform rendering.
  */
-public class TranslatedRenderItem extends RenderItem {
+public class TranslatedRenderItem extends AERenderItem {
 
     @Override
     public void renderItemOverlayIntoGUI(FontRenderer font, TextureManager texManager, ItemStack stack, int x, int y,
             String customText) {
+        renderItemOverlayIntoGUI(font, texManager, stack, x, y, customText, null);
+    }
+
+    public void renderItemOverlayIntoGUI(FontRenderer font, TextureManager texManager, ItemStack stack, int x, int y,
+            String customText, TerminalFontSize fontSize) {
         if (stack != null) {
             boolean skip = false;
             boolean showDurabilitybar = true;
@@ -37,10 +42,14 @@ public class TranslatedRenderItem extends RenderItem {
             GL11.glPushMatrix();
             if ((showStackSize && stack.stackSize > 1) || (showCraftLabelText && customText != null)) {
                 GL11.glTranslatef(0.0f, 0.0f, this.zLevel);
-                String s1 = customText == null ? String.valueOf(stack.stackSize) : customText;
                 GL11.glDisable(GL11.GL_LIGHTING);
                 GL11.glDisable(GL11.GL_BLEND);
-                font.drawStringWithShadow(s1, x + 19 - 2 - font.getStringWidth(s1), y + 6 + 3, 16777215);
+                this.drawStackSize(
+                        x,
+                        y,
+                        customText != null ? customText : getToBeRenderedStackSize(stack.stackSize, fontSize),
+                        font,
+                        fontSize);
                 GL11.glEnable(GL11.GL_LIGHTING);
                 GL11.glTranslatef(0.0f, 0.0f, -this.zLevel);
             }

--- a/src/main/java/appeng/core/AEConfig.java
+++ b/src/main/java/appeng/core/AEConfig.java
@@ -27,6 +27,7 @@ import appeng.api.config.PowerUnits;
 import appeng.api.config.SearchBoxMode;
 import appeng.api.config.Settings;
 import appeng.api.config.SortDir;
+import appeng.api.config.TerminalFontSize;
 import appeng.api.config.TerminalStyle;
 import appeng.api.config.YesNo;
 import appeng.api.util.IConfigManager;
@@ -79,7 +80,6 @@ public final class AEConfig extends Configuration implements IConfigurableObject
             "Brass", "Platinum", "Nickel", "Invar", "Aluminium", "Electrum", "Osmium", "Zinc" };
     public double oreDoublePercentage = 90.0;
     public boolean enableEffects = true;
-    public boolean useLargeFonts = false;
     public boolean useColoredCraftingStatus;
     public boolean preserveSearchBar = true;
     public boolean showOnlyInterfacesWithFreeSlotsInInterfaceTerminal = false;
@@ -156,6 +156,7 @@ public final class AEConfig extends Configuration implements IConfigurableObject
         this.settings.registerSetting(Settings.CRAFTING_STATUS, CraftingStatus.TILE);
         this.settings.registerSetting(Settings.CRAFTING_SORT_BY, CraftingSortOrder.NAME);
         this.settings.registerSetting(Settings.SORT_DIRECTION, SortDir.ASCENDING);
+        this.settings.registerSetting(Settings.TERMINAL_FONT_SIZE, TerminalFontSize.SMALL);
 
         this.spawnChargedChance = (float) (1.0
                 - this.get("worldGen", "spawnChargedChance", 1.0 - this.spawnChargedChance)
@@ -305,7 +306,6 @@ public final class AEConfig extends Configuration implements IConfigurableObject
         this.disableColoredCableRecipesInNEI = this.get("Client", "disableColoredCableRecipesInNEI", true)
                 .getBoolean(true);
         this.enableEffects = this.get("Client", "enableEffects", true).getBoolean(true);
-        this.useLargeFonts = this.get("Client", "useTerminalUseLargeFont", false).getBoolean(false);
         this.useColoredCraftingStatus = this.get("Client", "useColoredCraftingStatus", true).getBoolean(true);
         this.preserveSearchBar = this.get("Client", "preserveSearchBar", true).getBoolean(true);
         this.showOnlyInterfacesWithFreeSlotsInInterfaceTerminal = this
@@ -503,8 +503,8 @@ public final class AEConfig extends Configuration implements IConfigurableObject
         return this.settings;
     }
 
-    public boolean useTerminalUseLargeFont() {
-        return this.useLargeFonts;
+    public TerminalFontSize getTerminalFontSize() {
+        return (TerminalFontSize) settings.getSetting(Settings.TERMINAL_FONT_SIZE);
     }
 
     public int craftItemsByStackAmounts(final int i) {


### PR DESCRIPTION
Saved small & large font size. Added dynamic font size for large monitor (some users asc me can i do it or no)

## ME Interface
|| prev | new |
| ---- | ---- | ---- |
| small | ![image](https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/assets/31038811/9e12092a-8d5b-4e79-940a-6c149ad5f406) | ![image](https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/assets/31038811/12fa8ba3-23a1-4062-8ece-6cd0061a94e2) |
|dynamic | no | ![image](https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/assets/31038811/840bfc1f-d550-4e5d-8ffe-729197526f5d) | 
| large | ![image](https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/assets/31038811/49266cdd-d0e1-44b6-9ed3-d78fcee32313) | ![image](https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/assets/31038811/225422a4-f051-4217-a7b9-385cbaa071b9) |


## Terminal
|| prev | new |
| ---- | ---- | ---- |
| small | ![image](https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/assets/31038811/cfd9a6c5-0433-4f2c-889b-3f2d3a959d30) | ![image](https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/assets/31038811/16db4f54-5372-470c-8fb0-03695402c470) |
| dynamic | no | ![image](https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/assets/31038811/3481fef6-f350-4565-af58-dc9c5449bf77) |
| large | ![image](https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/assets/31038811/23ded0a5-ee9d-4950-938d-6c536eec73a1) | ![image](https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/assets/31038811/3a2b672b-97ef-4d13-8e3b-edb64ba4530e) |

issue: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/issues/471