### PR TITLE
Restore the useTerminalUseLargeFont() method and add @Deprecated

### DIFF
--- a/src/main/java/appeng/core/AEConfig.java
+++ b/src/main/java/appeng/core/AEConfig.java
@@ -503,6 +503,15 @@ public final class AEConfig extends Configuration implements IConfigurableObject
         return this.settings;
     }
 
+    /**
+     * @deprecated Use the new method getTerminalFontSize() to get more options
+     * @return True if terminal large font is used, false otherwise
+     */
+    @Deprecated
+    public boolean useTerminalUseLargeFont() {
+        return getTerminalFontSize() == TerminalFontSize.LARGE;
+    }
+
     public TerminalFontSize getTerminalFontSize() {
         return (TerminalFontSize) settings.getSetting(Settings.TERMINAL_FONT_SIZE);
     }


### PR DESCRIPTION
Some methods used by additional mods should probably not be removed.
Sudden removal may cause some problems, and I think the @Deprecated tag should be used.