### PR TITLE
The terminal style button in some GUIs is independent of others

### DIFF
--- a/src/main/java/appeng/api/config/Settings.java
+++ b/src/main/java/appeng/api/config/Settings.java
@@ -79,7 +79,9 @@ public enum Settings {
 
     PRIORITY_CARD_MODE(EnumSet.allOf(PriorityCardMode.class)),
 
-    TERMINAL_FONT_SIZE(EnumSet.allOf(TerminalFontSize.class));
+    TERMINAL_FONT_SIZE(EnumSet.allOf(TerminalFontSize.class)),
+
+    CRAFT_GUI_STYLE(EnumSet.of(TerminalStyle.TALL, TerminalStyle.SMALL));
 
     private final EnumSet<? extends Enum<?>> values;
 

--- a/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
@@ -158,7 +158,7 @@ public class GuiCraftConfirm extends AEBaseGui implements ICraftingCPUTableHolde
     public GuiCraftConfirm(final InventoryPlayer inventoryPlayer, final ITerminalHost te) {
         super(new ContainerCraftConfirm(inventoryPlayer, te));
         this.craftingTree = new GuiCraftingTree(this, 9, 19, 203, 192);
-        this.tallMode = AEConfig.instance.getConfigManager().getSetting(Settings.TERMINAL_STYLE) == TerminalStyle.TALL;
+        this.tallMode = AEConfig.instance.getConfigManager().getSetting(Settings.CRAFT_GUI_STYLE) == TerminalStyle.TALL;
         recalculateScreenSize();
 
         scrollbar = new GuiScrollbar();
@@ -860,6 +860,8 @@ public class GuiCraftConfirm extends AEBaseGui implements ICraftingCPUTableHolde
             final Enum next = Platform.rotateEnum(cv, backwards, iBtn.getSetting().getPossibleValues());
             if (btn == this.switchTallMode) {
                 tallMode = next == TerminalStyle.TALL;
+                AEConfig.instance.settings
+                        .putSetting(Settings.CRAFT_GUI_STYLE, tallMode ? TerminalStyle.TALL : TerminalStyle.SMALL);
                 recalculateScreenSize();
                 this.setWorldAndResolution(mc, width, height);
             } else if (btn == this.sortingModeButton) {

--- a/src/main/java/appeng/client/gui/implementations/GuiCraftingStatus.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCraftingStatus.java
@@ -60,7 +60,7 @@ public class GuiCraftingStatus extends GuiCraftingCPU implements ICraftingCPUTab
         super(new ContainerCraftingStatus(inventoryPlayer, te));
 
         this.status = (ContainerCraftingStatus) this.inventorySlots;
-        this.tallMode = AEConfig.instance.getConfigManager().getSetting(Settings.TERMINAL_STYLE) == TerminalStyle.TALL;
+        this.tallMode = AEConfig.instance.getConfigManager().getSetting(Settings.CRAFT_GUI_STYLE) == TerminalStyle.TALL;
         recalculateScreenSize();
 
         final Object target = this.status.getTarget();
@@ -123,6 +123,8 @@ public class GuiCraftingStatus extends GuiCraftingCPU implements ICraftingCPUTab
         } else if (btn == this.switchTallMode) {
             tallMode = !tallMode;
             switchTallMode.set(tallMode ? TerminalStyle.TALL : TerminalStyle.SMALL);
+            AEConfig.instance.getConfigManager()
+                    .putSetting(Settings.CRAFT_GUI_STYLE, tallMode ? TerminalStyle.TALL : TerminalStyle.SMALL);
             recalculateScreenSize();
             this.setWorldAndResolution(mc, width, height);
         }

--- a/src/main/java/appeng/core/AEConfig.java
+++ b/src/main/java/appeng/core/AEConfig.java
@@ -157,6 +157,7 @@ public final class AEConfig extends Configuration implements IConfigurableObject
         this.settings.registerSetting(Settings.CRAFTING_SORT_BY, CraftingSortOrder.NAME);
         this.settings.registerSetting(Settings.SORT_DIRECTION, SortDir.ASCENDING);
         this.settings.registerSetting(Settings.TERMINAL_FONT_SIZE, TerminalFontSize.SMALL);
+        this.settings.registerSetting(Settings.CRAFT_GUI_STYLE, TerminalStyle.TALL);
 
         this.spawnChargedChance = (float) (1.0
                 - this.get("worldGen", "spawnChargedChance", 1.0 - this.spawnChargedChance)


### PR DESCRIPTION
In craft confirmation and status gui, the terminal style button depends on the button specified in the terminal and this is not always convenient. I suggest to keep the state of the button in the confirmation and status gui separate from the state of other terminal style buttons.