### PR TITLE
Return the correct number of rejectted items when inserting large stacks into storage cells.

### DIFF
--- a/src/main/java/appeng/me/storage/CellInventory.java
+++ b/src/main/java/appeng/me/storage/CellInventory.java
@@ -222,11 +222,11 @@ public class CellInventory implements ICellInventory {
 
             if (remainingItemCount > 0) {
                 if (input.getStackSize() > remainingItemCount) {
-                    final IAEItemStack toReturn = AEItemStack.create(sharedItemStack);
+                    final IAEItemStack toReturn = input.copy();
                     toReturn.decStackSize(remainingItemCount);
 
                     if (mode == Actionable.MODULATE) {
-                        final IAEItemStack toWrite = AEItemStack.create(sharedItemStack);
+                        final IAEItemStack toWrite = input.copy();
                         toWrite.setStackSize(remainingItemCount);
 
                         this.cellItems.add(toWrite);

--- a/src/main/java/appeng/me/storage/CellInventory.java
+++ b/src/main/java/appeng/me/storage/CellInventory.java
@@ -111,7 +111,7 @@ public class CellInventory implements ICellInventory {
         }
     }
 
-    private static boolean isStorageCell(final ItemStack itemStack) {
+    private static boolean isStorageCell(final IAEItemStack itemStack) {
         if (itemStack == null) {
             return false;
         }
@@ -175,10 +175,8 @@ public class CellInventory implements ICellInventory {
             return input;
         }
 
-        final ItemStack sharedItemStack = input.getItemStack();
-
-        if (CellInventory.isStorageCell(sharedItemStack)) {
-            final IMEInventory<IAEItemStack> meInventory = getCell(sharedItemStack, null);
+        if (CellInventory.isStorageCell(input)) {
+            final IMEInventory<IAEItemStack> meInventory = getCell(input.getItemStack(), null);
 
             if (meInventory != null && !this.isEmpty(meInventory)) {
                 return input;


### PR DESCRIPTION
Previously, if you tried to insert more than 2^31 of a new type of item into an item stack, it would calculate the number of items to reject as if you tried to insert 2^31 items.

In particular, this would cause an IO Port on a subnet attached to a main net with an export-only storage bus to try to insert more items than possible into a cell, which would cause the excess items to be returned to be stored in the subnet, if possible.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15916.