### PR TITLE
Show names of renamed blocks in WAILA.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -9,10 +9,10 @@ dependencies {
     compileOnly('com.github.GTNewHorizons:ThaumicTinkerer:2.9.2:dev') {transitive = false}
     compileOnly('com.github.GTNewHorizons:BuildCraft:7.1.39:dev') {transitive = false}
     compileOnly('com.github.GTNewHorizons:ForgeMultipart:1.4.8:dev') {transitive = false}
-    compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.138:dev') {transitive = false}
+    compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.144:dev') {transitive = false}
     compileOnly('com.github.GTNewHorizons:Jabba:1.3.2:dev') {transitive = false}
     compileOnly('com.github.GTNewHorizons:inventory-tweaks:1.6.2:api') {transitive = false}
-    compileOnly('com.github.GTNewHorizons:OpenComputers:1.10.8-GTNH:api') {transitive = false}
+    compileOnly('com.github.GTNewHorizons:OpenComputers:1.10.9-GTNH:api') {transitive = false}
     compileOnly('com.github.GTNewHorizons:waila:1.7.2:dev') {transitive = false}
     compileOnly('com.github.GTNewHorizons:Railcraft:9.15.7:api') {transitive = false}
     compileOnly('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev')
@@ -33,7 +33,7 @@ dependencies {
     functionalTestImplementation('org.junit.platform:junit-platform-engine')
     functionalTestImplementation('org.junit.platform:junit-platform-launcher')
     functionalTestImplementation('org.junit.platform:junit-platform-reporting')
-    functionalTestImplementation('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.138:dev') {
+    functionalTestImplementation('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.144:dev') {
         exclude module: "Applied-Energistics-2-Unofficial"
     }
 
@@ -42,5 +42,5 @@ dependencies {
     runtimeOnlyNonPublishable('com.github.GTNewHorizons:GTNHLib:0.2.10:dev')
     runtimeOnlyNonPublishable('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev')
     runtimeOnlyNonPublishable('com.github.GTNewHorizons:ThaumicEnergistics:1.6.4-GTNH:dev') { transitive = false }
-    runtimeOnlyNonPublishable('com.github.GTNewHorizons:AE2FluidCraft-Rework:1.2.26-gtnh:dev') { transitive = false }
+    runtimeOnlyNonPublishable('com.github.GTNewHorizons:AE2FluidCraft-Rework:1.2.27-gtnh:dev') { transitive = false }
 }

--- a/src/main/java/appeng/integration/modules/waila/PartWailaDataProvider.java
+++ b/src/main/java/appeng/integration/modules/waila/PartWailaDataProvider.java
@@ -23,6 +23,7 @@ import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 
 import appeng.api.parts.IPart;
+import appeng.helpers.ICustomNameObject;
 import appeng.integration.modules.waila.part.BasePartWailaDataProvider;
 import appeng.integration.modules.waila.part.ChannelWailaDataProvider;
 import appeng.integration.modules.waila.part.IPartWailaDataProvider;
@@ -44,6 +45,8 @@ import mcp.mobius.waila.api.IWailaDataProvider;
  * @since rv2
  */
 public final class PartWailaDataProvider implements IWailaDataProvider {
+
+    private static final String NBT_PART_CUSTOM_NAME = "partCustomName";
 
     /**
      * Contains all providers
@@ -129,6 +132,9 @@ public final class PartWailaDataProvider implements IWailaDataProvider {
             for (final IPartWailaDataProvider provider : this.providers) {
                 provider.getWailaBody(part, currentToolTip, accessor, config);
             }
+            if (accessor.getNBTData().hasKey(NBT_PART_CUSTOM_NAME)) {
+                currentToolTip.add(accessor.getNBTData().getString(NBT_PART_CUSTOM_NAME));
+            }
         }
 
         return currentToolTip;
@@ -166,6 +172,9 @@ public final class PartWailaDataProvider implements IWailaDataProvider {
 
                 for (final IPartWailaDataProvider provider : this.providers) {
                     provider.getNBTData(player, part, te, tag, world, x, y, z);
+                }
+                if (part instanceof ICustomNameObject customNameObject && customNameObject.hasCustomName()) {
+                    tag.setString(NBT_PART_CUSTOM_NAME, customNameObject.getCustomName());
                 }
             }
         }

--- a/src/main/java/appeng/integration/modules/waila/PartWailaDataProvider.java
+++ b/src/main/java/appeng/integration/modules/waila/PartWailaDataProvider.java
@@ -16,6 +16,7 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.World;
 
@@ -133,7 +134,9 @@ public final class PartWailaDataProvider implements IWailaDataProvider {
                 provider.getWailaBody(part, currentToolTip, accessor, config);
             }
             if (accessor.getNBTData().hasKey(NBT_PART_CUSTOM_NAME)) {
-                currentToolTip.add(accessor.getNBTData().getString(NBT_PART_CUSTOM_NAME));
+                currentToolTip.add(
+                        EnumChatFormatting.WHITE.toString() + EnumChatFormatting.ITALIC
+                                + accessor.getNBTData().getString(NBT_PART_CUSTOM_NAME));
             }
         }
 

--- a/src/main/java/appeng/integration/modules/waila/PartWailaDataProvider.java
+++ b/src/main/java/appeng/integration/modules/waila/PartWailaDataProvider.java
@@ -176,7 +176,8 @@ public final class PartWailaDataProvider implements IWailaDataProvider {
                 for (final IPartWailaDataProvider provider : this.providers) {
                     provider.getNBTData(player, part, te, tag, world, x, y, z);
                 }
-                if (part instanceof ICustomNameObject customNameObject && customNameObject.hasCustomName()) {
+                if (part instanceof ICustomNameObject customNameObject && customNameObject.hasCustomName()
+                        && !customNameObject.getCustomName().isEmpty()) {
                     tag.setString(NBT_PART_CUSTOM_NAME, customNameObject.getCustomName());
                 }
             }

--- a/src/main/java/appeng/integration/modules/waila/TileWailaDataProvider.java
+++ b/src/main/java/appeng/integration/modules/waila/TileWailaDataProvider.java
@@ -20,6 +20,7 @@ import net.minecraft.world.World;
 
 import com.google.common.collect.Lists;
 
+import appeng.helpers.ICustomNameObject;
 import appeng.integration.modules.waila.tile.ChargerWailaDataProvider;
 import appeng.integration.modules.waila.tile.CraftingMonitorWailaDataProvider;
 import appeng.integration.modules.waila.tile.InterfaceDataProvider;
@@ -37,6 +38,8 @@ import mcp.mobius.waila.api.IWailaDataProvider;
  * @since rv2
  */
 public final class TileWailaDataProvider implements IWailaDataProvider {
+
+    private static final String NBT_TILE_CUSTOM_NAME = "tileCustomName";
 
     /**
      * Contains all providers
@@ -77,6 +80,9 @@ public final class TileWailaDataProvider implements IWailaDataProvider {
         for (final IWailaDataProvider provider : this.providers) {
             provider.getWailaBody(itemStack, currentToolTip, accessor, config);
         }
+        if (accessor.getNBTData().hasKey(NBT_TILE_CUSTOM_NAME)) {
+            currentToolTip.add(accessor.getNBTData().getString(NBT_TILE_CUSTOM_NAME));
+        }
 
         return currentToolTip;
     }
@@ -96,6 +102,9 @@ public final class TileWailaDataProvider implements IWailaDataProvider {
             final World world, final int x, final int y, final int z) {
         for (final IWailaDataProvider provider : this.providers) {
             provider.getNBTData(player, te, tag, world, x, y, z);
+        }
+        if (te instanceof ICustomNameObject customNameObject && customNameObject.hasCustomName()) {
+            tag.setString(NBT_TILE_CUSTOM_NAME, customNameObject.getCustomName());
         }
 
         return tag;

--- a/src/main/java/appeng/integration/modules/waila/TileWailaDataProvider.java
+++ b/src/main/java/appeng/integration/modules/waila/TileWailaDataProvider.java
@@ -106,7 +106,8 @@ public final class TileWailaDataProvider implements IWailaDataProvider {
         for (final IWailaDataProvider provider : this.providers) {
             provider.getNBTData(player, te, tag, world, x, y, z);
         }
-        if (te instanceof ICustomNameObject customNameObject && customNameObject.hasCustomName()) {
+        if (te instanceof ICustomNameObject customNameObject && customNameObject.hasCustomName()
+                && !customNameObject.getCustomName().isEmpty()) {
             tag.setString(NBT_TILE_CUSTOM_NAME, customNameObject.getCustomName());
         }
 

--- a/src/main/java/appeng/integration/modules/waila/TileWailaDataProvider.java
+++ b/src/main/java/appeng/integration/modules/waila/TileWailaDataProvider.java
@@ -16,6 +16,7 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.world.World;
 
 import com.google.common.collect.Lists;
@@ -81,7 +82,9 @@ public final class TileWailaDataProvider implements IWailaDataProvider {
             provider.getWailaBody(itemStack, currentToolTip, accessor, config);
         }
         if (accessor.getNBTData().hasKey(NBT_TILE_CUSTOM_NAME)) {
-            currentToolTip.add(accessor.getNBTData().getString(NBT_TILE_CUSTOM_NAME));
+            currentToolTip.add(
+                    EnumChatFormatting.WHITE.toString() + EnumChatFormatting.ITALIC
+                            + accessor.getNBTData().getString(NBT_TILE_CUSTOM_NAME));
         }
 
         return currentToolTip;

--- a/src/main/java/appeng/integration/modules/waila/part/P2PStateWailaDataProvider.java
+++ b/src/main/java/appeng/integration/modules/waila/part/P2PStateWailaDataProvider.java
@@ -73,7 +73,6 @@ public final class P2PStateWailaDataProvider extends BasePartWailaDataProvider {
                 final String local = ButtonToolTips.P2PFrequency.getLocal();
 
                 currentToolTip.add(String.format(local, freqTooltip));
-                if (nbtData.hasKey(TAG_CUSTOMNAME)) currentToolTip.add(nbtData.getString(TAG_CUSTOMNAME));
             }
         }
 
@@ -88,8 +87,6 @@ public final class P2PStateWailaDataProvider extends BasePartWailaDataProvider {
             if (!tunnel.isPowered()) {
                 return tag;
             }
-
-            if (tunnel.hasCustomName()) tag.setString(TAG_CUSTOMNAME, tunnel.getCustomName());
 
             tag.setLong(TAG_P2P_FREQUENCY, tunnel.getFrequency());
 

--- a/src/main/java/appeng/parts/p2p/PartP2PTunnel.java
+++ b/src/main/java/appeng/parts/p2p/PartP2PTunnel.java
@@ -205,7 +205,9 @@ public abstract class PartP2PTunnel<T extends PartP2PTunnel> extends PartBasicSt
         final P2PCache p2p = newTunnel.getProxy().getP2P();
         p2p.updateFreq(newTunnel, freq);
         PartP2PTunnel input = p2p.getInput(freq);
-        if (input != null) newTunnel.setCustomNameInternal(input.getCustomName());
+        if (input != null && input.hasCustomName()) {
+            newTunnel.setCustomNameInternal(input.getCustomName());
+        }
     }
 
     @Override


### PR DESCRIPTION
When you rename an ME component using the quartz knife, the custom name will now show in WAILA.

The motivation for this was a situation where you have several interfaces attached to the same multiblock (for example, using input buses with different circuits), to be able to quickly see which interface is which without having to look inside or label them with signs and such. But the change works with any ME part that you can rename (which is most of them).

Example from my survival world:
![](https://i.imgur.com/NFXwVYe.png)

Incidentally, this fixes a small bug: previously, when you connected a p2p tunnel, the output side would always get a custom name, even if the input side was not renamed before. This means that output sides of p2p tunnels which were connected before this change will show a name like "P2P Tunnel - ME". New tunnels linked after this change are unaffected; they will only show a custom name if you actually rename them.