### PR TITLE
Add null check and missing texture for covered cable icons

### DIFF
--- a/src/main/java/appeng/parts/networking/PartCable.java
+++ b/src/main/java/appeng/parts/networking/PartCable.java
@@ -538,9 +538,13 @@ public class PartCable extends AEBasePart implements IPartCable {
         }
 
         final AEColoredItemDefinition coveredCable = AEApi.instance().definitions().parts().cableCovered();
-        final ItemStack coveredCableStack = coveredCable.stack(AEColor.Transparent, 1);
+        IIcon val = coveredCable.stack(AEColor.Transparent, 1).getIconIndex();
 
-        return coveredCable.item(AEColor.Transparent).getIconIndex(coveredCableStack);
+        if (val == null) {
+            val = CableBusTextures.getMissing();
+        }
+
+        return val;
     }
 
     protected boolean nonLinear(final EnumSet<ForgeDirection> sides) {


### PR DESCRIPTION
Somewhat fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16075. This doesn't sort out the underlying issue, but it does add some safety to use a missing texture when it happens rather than crashing by returning a null texture.

With this fix, the behavior should be that when it occurs, fluix colored covered cables will render with a missing texture instead of their normal one, though this should only last for the time that it occurred, so in most any scenario wouldn't even be noticeable.

The underlying issue still needs investigated, but this at least makes it a bit safer by not causing a crash.