### PR TITLE
null texture check for dense cables and so on

### DIFF
--- a/src/main/java/appeng/client/texture/CableBusTextures.java
+++ b/src/main/java/appeng/client/texture/CableBusTextures.java
@@ -10,6 +10,8 @@
 
 package appeng.client.texture;
 
+import javax.annotation.Nonnull;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.renderer.texture.TextureMap;
@@ -233,6 +235,18 @@ public enum CableBusTextures {
         }
 
         return missingTexture;
+    }
+
+    @SideOnly(Side.CLIENT)
+    @Nonnull
+    public static IIcon checkTexture(IIcon val) {
+        if (val == null) {
+            val = CableBusTextures.getMissing();
+        }
+
+        assert val != null;
+
+        return val;
     }
 
     public String getName() {

--- a/src/main/java/appeng/parts/networking/PartCable.java
+++ b/src/main/java/appeng/parts/networking/PartCable.java
@@ -206,7 +206,7 @@ public class PartCable extends AEBasePart implements IPartCable {
     }
 
     public IIcon getGlassTexture(final AEColor c) {
-        IIcon val = switch (c) {
+        return CableBusTextures.checkTexture(switch (c) {
             case Black -> CableBusTextures.MECable_Black.getIcon();
             case Blue -> CableBusTextures.MECable_Blue.getIcon();
             case Brown -> CableBusTextures.MECable_Brown.getIcon();
@@ -227,16 +227,7 @@ public class PartCable extends AEBasePart implements IPartCable {
                 final AEColoredItemDefinition cable = AEApi.instance().definitions().parts().cableGlass();
                 yield cable.stack(AEColor.Transparent, 1).getIconIndex();
             }
-        };
-
-        if (val == null) {
-            val = CableBusTextures.getMissing();
-        }
-
-        // this can't be null
-        assert val != null;
-
-        return val;
+        });
     }
 
     @Override
@@ -460,7 +451,7 @@ public class PartCable extends AEBasePart implements IPartCable {
     }
 
     public IIcon getCoveredTexture(final AEColor c) {
-        IIcon val = switch (c) {
+        return CableBusTextures.checkTexture(switch (c) {
             case Black -> CableBusTextures.MECovered_Black.getIcon();
             case Blue -> CableBusTextures.MECovered_Blue.getIcon();
             case Brown -> CableBusTextures.MECovered_Brown.getIcon();
@@ -481,16 +472,7 @@ public class PartCable extends AEBasePart implements IPartCable {
                 final AEColoredItemDefinition coveredCable = AEApi.instance().definitions().parts().cableCovered();
                 yield coveredCable.stack(AEColor.Transparent, 1).getIconIndex();
             }
-        };
-
-        if (val == null) {
-            val = CableBusTextures.getMissing();
-        }
-
-        // this can't be null
-        assert val != null;
-
-        return val;
+        });
     }
 
     protected boolean nonLinear(final EnumSet<ForgeDirection> sides) {
@@ -708,7 +690,7 @@ public class PartCable extends AEBasePart implements IPartCable {
     }
 
     IIcon getSmartTexture(final AEColor c) {
-        IIcon val = switch (c) {
+        return CableBusTextures.checkTexture(switch (c) {
             case Black -> CableBusTextures.MESmart_Black.getIcon();
             case Blue -> CableBusTextures.MESmart_Blue.getIcon();
             case Brown -> CableBusTextures.MESmart_Brown.getIcon();
@@ -729,16 +711,7 @@ public class PartCable extends AEBasePart implements IPartCable {
                 final AEColoredItemDefinition smartCable = AEApi.instance().definitions().parts().cableSmart();
                 yield smartCable.stack(AEColor.Transparent, 1).getIconIndex();
             }
-        };
-
-        if (val == null) {
-            val = CableBusTextures.getMissing();
-        }
-
-        // this can't be null
-        assert val != null;
-
-        return val;
+        });
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/appeng/parts/networking/PartDenseCable.java
+++ b/src/main/java/appeng/parts/networking/PartDenseCable.java
@@ -152,7 +152,8 @@ public class PartDenseCable extends PartCable {
     @Override
     public IIcon getTexture(final AEColor c) {
         if (c == AEColor.Transparent) {
-            return AEApi.instance().definitions().parts().cableSmart().stack(AEColor.Transparent, 1).getIconIndex();
+            CableBusTextures.checkTexture(
+                    AEApi.instance().definitions().parts().cableSmart().stack(AEColor.Transparent, 1).getIconIndex());
         }
 
         return this.getSmartTexture(c);
@@ -343,59 +344,25 @@ public class PartDenseCable extends PartCable {
     }
 
     protected IIcon getDenseTexture(final AEColor c) {
-        switch (c) {
-            case Black -> {
-                return CableBusTextures.MEDense_Black.getIcon();
-            }
-            case Blue -> {
-                return CableBusTextures.MEDense_Blue.getIcon();
-            }
-            case Brown -> {
-                return CableBusTextures.MEDense_Brown.getIcon();
-            }
-            case Cyan -> {
-                return CableBusTextures.MEDense_Cyan.getIcon();
-            }
-            case Gray -> {
-                return CableBusTextures.MEDense_Gray.getIcon();
-            }
-            case Green -> {
-                return CableBusTextures.MEDense_Green.getIcon();
-            }
-            case LightBlue -> {
-                return CableBusTextures.MEDense_LightBlue.getIcon();
-            }
-            case LightGray -> {
-                return CableBusTextures.MEDense_LightGrey.getIcon();
-            }
-            case Lime -> {
-                return CableBusTextures.MEDense_Lime.getIcon();
-            }
-            case Magenta -> {
-                return CableBusTextures.MEDense_Magenta.getIcon();
-            }
-            case Orange -> {
-                return CableBusTextures.MEDense_Orange.getIcon();
-            }
-            case Pink -> {
-                return CableBusTextures.MEDense_Pink.getIcon();
-            }
-            case Purple -> {
-                return CableBusTextures.MEDense_Purple.getIcon();
-            }
-            case Red -> {
-                return CableBusTextures.MEDense_Red.getIcon();
-            }
-            case White -> {
-                return CableBusTextures.MEDense_White.getIcon();
-            }
-            case Yellow -> {
-                return CableBusTextures.MEDense_Yellow.getIcon();
-            }
-            default -> {}
-        }
-
-        return this.getItemStack().getIconIndex();
+        return CableBusTextures.checkTexture(switch (c) {
+            case Black -> CableBusTextures.MEDense_Black.getIcon();
+            case Blue -> CableBusTextures.MEDense_Blue.getIcon();
+            case Brown -> CableBusTextures.MEDense_Brown.getIcon();
+            case Cyan -> CableBusTextures.MEDense_Cyan.getIcon();
+            case Gray -> CableBusTextures.MEDense_Gray.getIcon();
+            case Green -> CableBusTextures.MEDense_Green.getIcon();
+            case LightBlue -> CableBusTextures.MEDense_LightBlue.getIcon();
+            case LightGray -> CableBusTextures.MEDense_LightGrey.getIcon();
+            case Lime -> CableBusTextures.MEDense_Lime.getIcon();
+            case Magenta -> CableBusTextures.MEDense_Magenta.getIcon();
+            case Orange -> CableBusTextures.MEDense_Orange.getIcon();
+            case Pink -> CableBusTextures.MEDense_Pink.getIcon();
+            case Purple -> CableBusTextures.MEDense_Purple.getIcon();
+            case Red -> CableBusTextures.MEDense_Red.getIcon();
+            case White -> CableBusTextures.MEDense_White.getIcon();
+            case Yellow -> CableBusTextures.MEDense_Yellow.getIcon();
+            default -> this.getItemStack().getIconIndex();
+        });
     }
 
     private boolean isDense(final ForgeDirection of) {

--- a/src/main/java/appeng/parts/networking/PartDenseCableCovered.java
+++ b/src/main/java/appeng/parts/networking/PartDenseCableCovered.java
@@ -138,7 +138,8 @@ public class PartDenseCableCovered extends PartCable {
     @Override
     public IIcon getTexture(final AEColor c) {
         if (c == AEColor.Transparent) {
-            return AEApi.instance().definitions().parts().cableCovered().stack(AEColor.Transparent, 1).getIconIndex();
+            return CableBusTextures.checkTexture(
+                    AEApi.instance().definitions().parts().cableCovered().stack(AEColor.Transparent, 1).getIconIndex());
         }
 
         return this.getCoveredTexture(c);
@@ -256,59 +257,25 @@ public class PartDenseCableCovered extends PartCable {
     }
 
     protected IIcon getDenseCoveredTexture(final AEColor c) {
-        switch (c) {
-            case Black -> {
-                return CableBusTextures.MEDenseCovered_Black.getIcon();
-            }
-            case Blue -> {
-                return CableBusTextures.MEDenseCovered_Blue.getIcon();
-            }
-            case Brown -> {
-                return CableBusTextures.MEDenseCovered_Brown.getIcon();
-            }
-            case Cyan -> {
-                return CableBusTextures.MEDenseCovered_Cyan.getIcon();
-            }
-            case Gray -> {
-                return CableBusTextures.MEDenseCovered_Gray.getIcon();
-            }
-            case Green -> {
-                return CableBusTextures.MEDenseCovered_Green.getIcon();
-            }
-            case LightBlue -> {
-                return CableBusTextures.MEDenseCovered_LightBlue.getIcon();
-            }
-            case LightGray -> {
-                return CableBusTextures.MEDenseCovered_LightGrey.getIcon();
-            }
-            case Lime -> {
-                return CableBusTextures.MEDenseCovered_Lime.getIcon();
-            }
-            case Magenta -> {
-                return CableBusTextures.MEDenseCovered_Magenta.getIcon();
-            }
-            case Orange -> {
-                return CableBusTextures.MEDenseCovered_Orange.getIcon();
-            }
-            case Pink -> {
-                return CableBusTextures.MEDenseCovered_Pink.getIcon();
-            }
-            case Purple -> {
-                return CableBusTextures.MEDenseCovered_Purple.getIcon();
-            }
-            case Red -> {
-                return CableBusTextures.MEDenseCovered_Red.getIcon();
-            }
-            case White -> {
-                return CableBusTextures.MEDenseCovered_White.getIcon();
-            }
-            case Yellow -> {
-                return CableBusTextures.MEDenseCovered_Yellow.getIcon();
-            }
-            default -> {}
-        }
-
-        return this.getItemStack().getIconIndex();
+        return CableBusTextures.checkTexture(switch (c) {
+            case Black -> CableBusTextures.MEDenseCovered_Black.getIcon();
+            case Blue -> CableBusTextures.MEDenseCovered_Blue.getIcon();
+            case Brown -> CableBusTextures.MEDenseCovered_Brown.getIcon();
+            case Cyan -> CableBusTextures.MEDenseCovered_Cyan.getIcon();
+            case Gray -> CableBusTextures.MEDenseCovered_Gray.getIcon();
+            case Green -> CableBusTextures.MEDenseCovered_Green.getIcon();
+            case LightBlue -> CableBusTextures.MEDenseCovered_LightBlue.getIcon();
+            case LightGray -> CableBusTextures.MEDenseCovered_LightGrey.getIcon();
+            case Lime -> CableBusTextures.MEDenseCovered_Lime.getIcon();
+            case Magenta -> CableBusTextures.MEDenseCovered_Magenta.getIcon();
+            case Orange -> CableBusTextures.MEDenseCovered_Orange.getIcon();
+            case Pink -> CableBusTextures.MEDenseCovered_Pink.getIcon();
+            case Purple -> CableBusTextures.MEDenseCovered_Purple.getIcon();
+            case Red -> CableBusTextures.MEDenseCovered_Red.getIcon();
+            case White -> CableBusTextures.MEDenseCovered_White.getIcon();
+            case Yellow -> CableBusTextures.MEDenseCovered_Yellow.getIcon();
+            default -> this.getItemStack().getIconIndex();
+        });
     }
 
     private boolean isDense(final ForgeDirection of) {

--- a/src/main/java/appeng/parts/networking/PartQuartzFiber.java
+++ b/src/main/java/appeng/parts/networking/PartQuartzFiber.java
@@ -33,6 +33,7 @@ import appeng.api.parts.IPartCollisionHelper;
 import appeng.api.parts.IPartHost;
 import appeng.api.parts.IPartRenderHelper;
 import appeng.api.util.AECableType;
+import appeng.client.texture.CableBusTextures;
 import appeng.me.GridAccessException;
 import appeng.me.helpers.AENetworkProxy;
 import appeng.parts.AEBasePart;
@@ -82,7 +83,7 @@ public class PartQuartzFiber extends AEBasePart implements IEnergyGridProvider {
     @SideOnly(Side.CLIENT)
     public void renderStatic(final int x, final int y, final int z, final IPartRenderHelper rh,
             final RenderBlocks renderer) {
-        final IIcon myIcon = this.getItemStack().getIconIndex();
+        final IIcon myIcon = CableBusTextures.checkTexture(this.getItemStack().getIconIndex());
         rh.setTexture(myIcon);
         rh.setBounds(6, 6, 10, 10, 10, 16);
         rh.renderBlock(x, y, z, renderer);

--- a/src/main/java/appeng/parts/networking/PartUltraDenseCableCovered.java
+++ b/src/main/java/appeng/parts/networking/PartUltraDenseCableCovered.java
@@ -26,8 +26,9 @@ public class PartUltraDenseCableCovered extends PartDenseCableCovered {
     @Override
     public IIcon getTexture(final AEColor c) {
         if (c == AEColor.Transparent) {
-            return AEApi.instance().definitions().parts().cableUltraDenseCovered().stack(AEColor.Transparent, 1)
-                    .getIconIndex();
+            return CableBusTextures.checkTexture(
+                    AEApi.instance().definitions().parts().cableUltraDenseCovered().stack(AEColor.Transparent, 1)
+                            .getIconIndex());
         }
 
         return this.getDenseCoveredTexture(c);
@@ -35,58 +36,24 @@ public class PartUltraDenseCableCovered extends PartDenseCableCovered {
 
     @Override
     protected IIcon getDenseCoveredTexture(final AEColor c) {
-        switch (c) {
-            case Black -> {
-                return CableBusTextures.MEUltraDenseCovered_Black.getIcon();
-            }
-            case Blue -> {
-                return CableBusTextures.MEUltraDenseCovered_Blue.getIcon();
-            }
-            case Brown -> {
-                return CableBusTextures.MEUltraDenseCovered_Brown.getIcon();
-            }
-            case Cyan -> {
-                return CableBusTextures.MEUltraDenseCovered_Cyan.getIcon();
-            }
-            case Gray -> {
-                return CableBusTextures.MEUltraDenseCovered_Gray.getIcon();
-            }
-            case Green -> {
-                return CableBusTextures.MEUltraDenseCovered_Green.getIcon();
-            }
-            case LightBlue -> {
-                return CableBusTextures.MEUltraDenseCovered_LightBlue.getIcon();
-            }
-            case LightGray -> {
-                return CableBusTextures.MEUltraDenseCovered_LightGrey.getIcon();
-            }
-            case Lime -> {
-                return CableBusTextures.MEUltraDenseCovered_Lime.getIcon();
-            }
-            case Magenta -> {
-                return CableBusTextures.MEUltraDenseCovered_Magenta.getIcon();
-            }
-            case Orange -> {
-                return CableBusTextures.MEUltraDenseCovered_Orange.getIcon();
-            }
-            case Pink -> {
-                return CableBusTextures.MEUltraDenseCovered_Pink.getIcon();
-            }
-            case Purple -> {
-                return CableBusTextures.MEUltraDenseCovered_Purple.getIcon();
-            }
-            case Red -> {
-                return CableBusTextures.MEUltraDenseCovered_Red.getIcon();
-            }
-            case White -> {
-                return CableBusTextures.MEUltraDenseCovered_White.getIcon();
-            }
-            case Yellow -> {
-                return CableBusTextures.MEUltraDenseCovered_Yellow.getIcon();
-            }
-            default -> {}
-        }
-
-        return this.getItemStack().getIconIndex();
+        return CableBusTextures.checkTexture(switch (c) {
+            case Black -> CableBusTextures.MEUltraDenseCovered_Black.getIcon();
+            case Blue -> CableBusTextures.MEUltraDenseCovered_Blue.getIcon();
+            case Brown -> CableBusTextures.MEUltraDenseCovered_Brown.getIcon();
+            case Cyan -> CableBusTextures.MEUltraDenseCovered_Cyan.getIcon();
+            case Gray -> CableBusTextures.MEUltraDenseCovered_Gray.getIcon();
+            case Green -> CableBusTextures.MEUltraDenseCovered_Green.getIcon();
+            case LightBlue -> CableBusTextures.MEUltraDenseCovered_LightBlue.getIcon();
+            case LightGray -> CableBusTextures.MEUltraDenseCovered_LightGrey.getIcon();
+            case Lime -> CableBusTextures.MEUltraDenseCovered_Lime.getIcon();
+            case Magenta -> CableBusTextures.MEUltraDenseCovered_Magenta.getIcon();
+            case Orange -> CableBusTextures.MEUltraDenseCovered_Orange.getIcon();
+            case Pink -> CableBusTextures.MEUltraDenseCovered_Pink.getIcon();
+            case Purple -> CableBusTextures.MEUltraDenseCovered_Purple.getIcon();
+            case Red -> CableBusTextures.MEUltraDenseCovered_Red.getIcon();
+            case White -> CableBusTextures.MEUltraDenseCovered_White.getIcon();
+            case Yellow -> CableBusTextures.MEUltraDenseCovered_Yellow.getIcon();
+            default -> this.getItemStack().getIconIndex();
+        });
     }
 }

--- a/src/main/java/appeng/parts/networking/PartUltraDenseCableSmart.java
+++ b/src/main/java/appeng/parts/networking/PartUltraDenseCableSmart.java
@@ -26,8 +26,9 @@ public class PartUltraDenseCableSmart extends PartDenseCable {
     @Override
     public IIcon getTexture(final AEColor c) {
         if (c == AEColor.Transparent) {
-            return AEApi.instance().definitions().parts().cableUltraDenseSmart().stack(AEColor.Transparent, 1)
-                    .getIconIndex();
+            return CableBusTextures.checkTexture(
+                    AEApi.instance().definitions().parts().cableUltraDenseSmart().stack(AEColor.Transparent, 1)
+                            .getIconIndex());
         }
 
         return this.getDenseTexture(c);
@@ -35,58 +36,24 @@ public class PartUltraDenseCableSmart extends PartDenseCable {
 
     @Override
     protected IIcon getDenseTexture(final AEColor c) {
-        switch (c) {
-            case Black -> {
-                return CableBusTextures.MEUltraDense_Black.getIcon();
-            }
-            case Blue -> {
-                return CableBusTextures.MEUltraDense_Blue.getIcon();
-            }
-            case Brown -> {
-                return CableBusTextures.MEUltraDense_Brown.getIcon();
-            }
-            case Cyan -> {
-                return CableBusTextures.MEUltraDense_Cyan.getIcon();
-            }
-            case Gray -> {
-                return CableBusTextures.MEUltraDense_Gray.getIcon();
-            }
-            case Green -> {
-                return CableBusTextures.MEUltraDense_Green.getIcon();
-            }
-            case LightBlue -> {
-                return CableBusTextures.MEUltraDense_LightBlue.getIcon();
-            }
-            case LightGray -> {
-                return CableBusTextures.MEUltraDense_LightGrey.getIcon();
-            }
-            case Lime -> {
-                return CableBusTextures.MEUltraDense_Lime.getIcon();
-            }
-            case Magenta -> {
-                return CableBusTextures.MEUltraDense_Magenta.getIcon();
-            }
-            case Orange -> {
-                return CableBusTextures.MEUltraDense_Orange.getIcon();
-            }
-            case Pink -> {
-                return CableBusTextures.MEUltraDense_Pink.getIcon();
-            }
-            case Purple -> {
-                return CableBusTextures.MEUltraDense_Purple.getIcon();
-            }
-            case Red -> {
-                return CableBusTextures.MEUltraDense_Red.getIcon();
-            }
-            case White -> {
-                return CableBusTextures.MEUltraDense_White.getIcon();
-            }
-            case Yellow -> {
-                return CableBusTextures.MEUltraDense_Yellow.getIcon();
-            }
-            default -> {}
-        }
-
-        return this.getItemStack().getIconIndex();
+        return CableBusTextures.checkTexture(switch (c) {
+            case Black -> CableBusTextures.MEUltraDense_Black.getIcon();
+            case Blue -> CableBusTextures.MEUltraDense_Blue.getIcon();
+            case Brown -> CableBusTextures.MEUltraDense_Brown.getIcon();
+            case Cyan -> CableBusTextures.MEUltraDense_Cyan.getIcon();
+            case Gray -> CableBusTextures.MEUltraDense_Gray.getIcon();
+            case Green -> CableBusTextures.MEUltraDense_Green.getIcon();
+            case LightBlue -> CableBusTextures.MEUltraDense_LightBlue.getIcon();
+            case LightGray -> CableBusTextures.MEUltraDense_LightGrey.getIcon();
+            case Lime -> CableBusTextures.MEUltraDense_Lime.getIcon();
+            case Magenta -> CableBusTextures.MEUltraDense_Magenta.getIcon();
+            case Orange -> CableBusTextures.MEUltraDense_Orange.getIcon();
+            case Pink -> CableBusTextures.MEUltraDense_Pink.getIcon();
+            case Purple -> CableBusTextures.MEUltraDense_Purple.getIcon();
+            case Red -> CableBusTextures.MEUltraDense_Red.getIcon();
+            case White -> CableBusTextures.MEUltraDense_White.getIcon();
+            case Yellow -> CableBusTextures.MEUltraDense_Yellow.getIcon();
+            default -> this.getItemStack().getIconIndex();
+        });
     }
 }


### PR DESCRIPTION
Goes with [#514](https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/514). No idea why there are null textures but same crash also occurred with dense cables while I'm playing on the latest release. And this fixed my problem. 