### PR TITLE
Don't use global state for inventory iteration number

### DIFF
--- a/src/main/java/appeng/api/storage/IMEInventory.java
+++ b/src/main/java/appeng/api/storage/IMEInventory.java
@@ -54,22 +54,26 @@ public interface IMEInventory<StackType extends IAEStack> {
     /**
      * Request a full report of all available items, storage.
      *
-     * @param out the IItemList the results will be written too
+     * @param out       the IItemList the results will be written too
+     * @param iteration numeric id for this iteration, use {@link appeng.util.IterationCounter#fetchNewId()} to avoid
+     *                  conflicts
      * @return returns same list that was passed in, is passed out
      */
-    IItemList<StackType> getAvailableItems(IItemList<StackType> out);
+    IItemList<StackType> getAvailableItems(IItemList<StackType> out, int iteration);
 
     /**
      * Request a report of how many of a single item type are available in storage. It falls back to
      * {@link IMEInventory#getAvailableItems} if a more optimized implementation is not present.
      *
-     * @param request The item type to search for, it does not get modified
+     * @param request   The item type to search for, it does not get modified
+     * @param iteration numeric id for this iteration, use {@link appeng.util.IterationCounter#fetchNewId()} to avoid
+     *                  conflicts
      * @return A new stack with the stack size set to the count of items in storage, or null if none are present
      */
     @SuppressWarnings("unchecked") // changing the generic StackType to be correct here is too much of a breaking API
                                    // change
-    default StackType getAvailableItem(@Nonnull StackType request) {
-        return getAvailableItems((IItemList<StackType>) getChannel().createList()).findPrecise(request);
+    default StackType getAvailableItem(@Nonnull StackType request, int iteration) {
+        return getAvailableItems((IItemList<StackType>) getChannel().createList(), iteration).findPrecise(request);
     }
 
     /**

--- a/src/main/java/appeng/api/storage/IMEMonitor.java
+++ b/src/main/java/appeng/api/storage/IMEMonitor.java
@@ -24,7 +24,7 @@ public interface IMEMonitor<T extends IAEStack> extends IMEInventoryHandler<T>, 
      */
     @Override
     @Deprecated
-    IItemList<T> getAvailableItems(IItemList out);
+    IItemList<T> getAvailableItems(IItemList out, int iteration);
 
     /**
      * Get access to the full item list of the network, preferred over {@link IMEInventory} .getAvailableItems(...)

--- a/src/main/java/appeng/api/storage/MEMonitorHandler.java
+++ b/src/main/java/appeng/api/storage/MEMonitorHandler.java
@@ -26,6 +26,7 @@ import appeng.api.config.Actionable;
 import appeng.api.networking.security.BaseActionSource;
 import appeng.api.storage.data.IAEStack;
 import appeng.api.storage.data.IItemList;
+import appeng.util.IterationCounter;
 
 /**
  * Common implementation of a simple class that monitors injection/extraction of a inventory to send events to a list of
@@ -135,7 +136,7 @@ public class MEMonitorHandler<StackType extends IAEStack> implements IMEMonitor<
         if (this.hasChanged) {
             this.hasChanged = false;
             this.cachedList.resetStatus();
-            return this.getAvailableItems(this.cachedList);
+            return this.getAvailableItems(this.cachedList, IterationCounter.fetchNewId());
         }
 
         return this.cachedList;
@@ -152,13 +153,13 @@ public class MEMonitorHandler<StackType extends IAEStack> implements IMEMonitor<
     }
 
     @Override
-    public IItemList<StackType> getAvailableItems(final IItemList out) {
-        return this.getHandler().getAvailableItems(out);
+    public IItemList<StackType> getAvailableItems(final IItemList out, int iteration) {
+        return this.getHandler().getAvailableItems(out, iteration);
     }
 
     @Override
-    public StackType getAvailableItem(@Nonnull StackType request) {
-        return this.getHandler().getAvailableItem(request);
+    public StackType getAvailableItem(@Nonnull StackType request, int iteration) {
+        return this.getHandler().getAvailableItem(request, iteration);
     }
 
     @Override

--- a/src/main/java/appeng/container/implementations/ContainerCellWorkbench.java
+++ b/src/main/java/appeng/container/implementations/ContainerCellWorkbench.java
@@ -34,6 +34,7 @@ import appeng.container.slot.SlotFakeTypeOnly;
 import appeng.container.slot.SlotRestrictedInput;
 import appeng.tile.inventory.AppEngNullInventory;
 import appeng.tile.misc.TileCellWorkbench;
+import appeng.util.IterationCounter;
 import appeng.util.Platform;
 import appeng.util.iterators.NullIterator;
 
@@ -212,7 +213,8 @@ public class ContainerCellWorkbench extends ContainerUpgradeable {
 
         Iterator<IAEItemStack> i = new NullIterator<>();
         if (cellInv != null) {
-            final IItemList<IAEItemStack> list = cellInv.getAvailableItems(AEApi.instance().storage().createItemList());
+            final IItemList<IAEItemStack> list = cellInv
+                    .getAvailableItems(AEApi.instance().storage().createItemList(), IterationCounter.fetchNewId());
             i = list.iterator();
         }
 

--- a/src/main/java/appeng/container/implementations/ContainerCraftConfirm.java
+++ b/src/main/java/appeng/container/implementations/ContainerCraftConfirm.java
@@ -56,6 +56,7 @@ import appeng.parts.reporting.PartPatternTerminal;
 import appeng.parts.reporting.PartPatternTerminalEx;
 import appeng.parts.reporting.PartTerminal;
 import appeng.tile.misc.TilePatternOptimizationMatrix;
+import appeng.util.IterationCounter;
 import appeng.util.Platform;
 
 public class ContainerCraftConfirm extends AEBaseContainer implements ICraftingCPUSelectorContainer {
@@ -185,7 +186,8 @@ public class ContainerCraftConfirm extends AEBaseContainer implements ICraftingC
 
                         if (toExtract.getStackSize() > 0 && toCraft.getStackSize() <= 0
                                 && (missing == null || missing.getStackSize() <= 0)) {
-                            long available = items.getAvailableItem(toExtract).getStackSize();
+                            long available = items.getAvailableItem(toExtract, IterationCounter.fetchNewId())
+                                    .getStackSize();
                             toExtract.setUsedPercent(toExtract.getStackSize() / (available / 100f));
                         }
 

--- a/src/main/java/appeng/container/implementations/ContainerStorageBus.java
+++ b/src/main/java/appeng/container/implementations/ContainerStorageBus.java
@@ -31,6 +31,7 @@ import appeng.container.guisync.GuiSync;
 import appeng.container.slot.OptionalSlotFakeTypeOnly;
 import appeng.container.slot.SlotRestrictedInput;
 import appeng.parts.misc.PartStorageBus;
+import appeng.util.IterationCounter;
 import appeng.util.Platform;
 import appeng.util.iterators.NullIterator;
 
@@ -162,7 +163,8 @@ public class ContainerStorageBus extends ContainerUpgradeable {
 
         Iterator<IAEItemStack> i = new NullIterator<>();
         if (cellInv != null) {
-            final IItemList<IAEItemStack> list = cellInv.getAvailableItems(AEApi.instance().storage().createItemList());
+            final IItemList<IAEItemStack> list = cellInv
+                    .getAvailableItems(AEApi.instance().storage().createItemList(), IterationCounter.fetchNewId());
             i = list.iterator();
         }
 

--- a/src/main/java/appeng/crafting/MECraftingInventory.java
+++ b/src/main/java/appeng/crafting/MECraftingInventory.java
@@ -20,6 +20,7 @@ import appeng.api.storage.IMEMonitor;
 import appeng.api.storage.StorageChannel;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IItemList;
+import appeng.util.IterationCounter;
 
 public class MECraftingInventory implements IMEInventory<IAEItemStack> {
 
@@ -73,7 +74,8 @@ public class MECraftingInventory implements IMEInventory<IAEItemStack> {
             this.injectedCache = null;
         }
 
-        this.localCache = this.target.getAvailableItems(AEApi.instance().storage().createItemList());
+        this.localCache = this.target
+                .getAvailableItems(AEApi.instance().storage().createItemList(), IterationCounter.fetchNewId());
 
         this.par = parent;
     }
@@ -136,7 +138,8 @@ public class MECraftingInventory implements IMEInventory<IAEItemStack> {
             this.injectedCache = null;
         }
 
-        this.localCache = target.getAvailableItems(AEApi.instance().storage().createItemList());
+        this.localCache = target
+                .getAvailableItems(AEApi.instance().storage().createItemList(), IterationCounter.fetchNewId());
         this.par = null;
     }
 
@@ -192,7 +195,7 @@ public class MECraftingInventory implements IMEInventory<IAEItemStack> {
     }
 
     @Override
-    public IItemList<IAEItemStack> getAvailableItems(final IItemList<IAEItemStack> out) {
+    public IItemList<IAEItemStack> getAvailableItems(final IItemList<IAEItemStack> out, int iteration) {
         for (final IAEItemStack is : this.localCache) {
             out.add(is);
         }
@@ -201,7 +204,7 @@ public class MECraftingInventory implements IMEInventory<IAEItemStack> {
     }
 
     @Override
-    public IAEItemStack getAvailableItem(@Nonnull IAEItemStack request) {
+    public IAEItemStack getAvailableItem(@Nonnull IAEItemStack request, int iteration) {
         long count = 0;
         for (final IAEItemStack is : this.localCache) {
             if (is != null && is.getStackSize() > 0 && is.isSameType(request)) {

--- a/src/main/java/appeng/helpers/WirelessTerminalGuiObject.java
+++ b/src/main/java/appeng/helpers/WirelessTerminalGuiObject.java
@@ -129,17 +129,17 @@ public class WirelessTerminalGuiObject implements IPortableCell, IActionHost, II
     }
 
     @Override
-    public IItemList<IAEItemStack> getAvailableItems(final IItemList out) {
+    public IItemList<IAEItemStack> getAvailableItems(final IItemList out, int iteration) {
         if (this.itemStorage != null) {
-            return this.itemStorage.getAvailableItems(out);
+            return this.itemStorage.getAvailableItems(out, iteration);
         }
         return out;
     }
 
     @Override
-    public IAEItemStack getAvailableItem(@Nonnull IAEItemStack request) {
+    public IAEItemStack getAvailableItem(@Nonnull IAEItemStack request, int iteration) {
         if (this.itemStorage != null) {
-            return this.itemStorage.getAvailableItem(request);
+            return this.itemStorage.getAvailableItem(request, iteration);
         }
         return null;
     }

--- a/src/main/java/appeng/integration/modules/BCHelpers/BCPipeInventory.java
+++ b/src/main/java/appeng/integration/modules/BCHelpers/BCPipeInventory.java
@@ -62,12 +62,12 @@ public class BCPipeInventory implements IMEInventory<IAEItemStack> {
     }
 
     @Override
-    public IItemList<IAEItemStack> getAvailableItems(final IItemList<IAEItemStack> out) {
+    public IItemList<IAEItemStack> getAvailableItems(final IItemList<IAEItemStack> out, int iteration) {
         return out;
     }
 
     @Override
-    public IAEItemStack getAvailableItem(@Nonnull IAEItemStack request) {
+    public IAEItemStack getAvailableItem(@Nonnull IAEItemStack request, int iteration) {
         return null;
     }
 

--- a/src/main/java/appeng/integration/modules/helpers/BSCrate.java
+++ b/src/main/java/appeng/integration/modules/helpers/BSCrate.java
@@ -58,7 +58,7 @@ public class BSCrate implements IMEInventory<IAEItemStack> {
     }
 
     @Override
-    public IItemList getAvailableItems(final IItemList out) {
+    public IItemList getAvailableItems(final IItemList out, int iteration) {
         for (final ItemStack is : this.crateStorage.getContents()) {
             out.add(AEItemStack.create(is));
         }
@@ -66,7 +66,7 @@ public class BSCrate implements IMEInventory<IAEItemStack> {
     }
 
     @Override
-    public IAEItemStack getAvailableItem(@Nonnull IAEItemStack request) {
+    public IAEItemStack getAvailableItem(@Nonnull IAEItemStack request, int iteration) {
         long count = 0;
         for (final ItemStack is : this.crateStorage.getContents()) {
             if (is != null && is.stackSize > 0 && Platform.isSameItemPrecise(is, request.getItemStack())) {

--- a/src/main/java/appeng/integration/modules/helpers/FactorizationBarrel.java
+++ b/src/main/java/appeng/integration/modules/helpers/FactorizationBarrel.java
@@ -122,7 +122,7 @@ public class FactorizationBarrel implements IMEInventory<IAEItemStack> {
     }
 
     @Override
-    public IItemList<IAEItemStack> getAvailableItems(final IItemList out) {
+    public IItemList<IAEItemStack> getAvailableItems(final IItemList out, int iteration) {
         final ItemStack i = this.fProxy.barrelGetItem(this.te);
         if (i != null) {
             i.stackSize = this.fProxy.barrelGetItemCount(this.te);
@@ -133,7 +133,7 @@ public class FactorizationBarrel implements IMEInventory<IAEItemStack> {
     }
 
     @Override
-    public IAEItemStack getAvailableItem(@Nonnull IAEItemStack request) {
+    public IAEItemStack getAvailableItem(@Nonnull IAEItemStack request, int iteration) {
         if (!this.containsItemType(request, false)) {
             return null;
         }

--- a/src/main/java/appeng/integration/modules/helpers/JabbaBarrel.java
+++ b/src/main/java/appeng/integration/modules/helpers/JabbaBarrel.java
@@ -89,7 +89,7 @@ public class JabbaBarrel implements IMEInventory<IAEItemStack> {
     }
 
     @Override
-    public IItemList<IAEItemStack> getAvailableItems(final IItemList<IAEItemStack> out) {
+    public IItemList<IAEItemStack> getAvailableItems(final IItemList<IAEItemStack> out, int iteration) {
         final ItemStack is = this.barrel.getStoredItemType();
         if (is != null) {
             out.add(AEItemStack.create(is));

--- a/src/main/java/appeng/integration/modules/helpers/MinefactoryReloadedDeepStorageUnit.java
+++ b/src/main/java/appeng/integration/modules/helpers/MinefactoryReloadedDeepStorageUnit.java
@@ -91,7 +91,7 @@ public class MinefactoryReloadedDeepStorageUnit implements IMEInventory<IAEItemS
     }
 
     @Override
-    public IItemList<IAEItemStack> getAvailableItems(final IItemList<IAEItemStack> out) {
+    public IItemList<IAEItemStack> getAvailableItems(final IItemList<IAEItemStack> out, int iteration) {
         final ItemStack is = this.dsu.getStoredItemType();
         if (is != null) {
             out.add(AEItemStack.create(is));
@@ -100,7 +100,7 @@ public class MinefactoryReloadedDeepStorageUnit implements IMEInventory<IAEItemS
     }
 
     @Override
-    public IAEItemStack getAvailableItem(@Nonnull IAEItemStack request) {
+    public IAEItemStack getAvailableItem(@Nonnull IAEItemStack request, int iteration) {
         final ItemStack is = this.dsu.getStoredItemType();
         if (is != null && request.isSameType(is)) {
             return AEItemStack.create(is);

--- a/src/main/java/appeng/items/storage/ItemBasicStorageCell.java
+++ b/src/main/java/appeng/items/storage/ItemBasicStorageCell.java
@@ -48,6 +48,7 @@ import appeng.items.contents.CellConfig;
 import appeng.items.contents.CellUpgrades;
 import appeng.items.materials.MaterialType;
 import appeng.util.InventoryAdaptor;
+import appeng.util.IterationCounter;
 import appeng.util.Platform;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -257,7 +258,8 @@ public class ItemBasicStorageCell extends AEBaseItem implements IStorageCell, II
                     .getCellInventory(stack, null, StorageChannel.ITEMS);
             if (inv != null && playerInventory.getCurrentItem() == stack) {
                 final InventoryAdaptor ia = InventoryAdaptor.getAdaptor(player, ForgeDirection.UNKNOWN);
-                final IItemList<IAEItemStack> list = inv.getAvailableItems(StorageChannel.ITEMS.createList());
+                final IItemList<IAEItemStack> list = inv
+                        .getAvailableItems(StorageChannel.ITEMS.createList(), IterationCounter.fetchNewId());
                 if (list.isEmpty() && ia != null) {
                     playerInventory.setInventorySlotContents(playerInventory.currentItem, null);
 

--- a/src/main/java/appeng/items/storage/ItemExtremeStorageCell.java
+++ b/src/main/java/appeng/items/storage/ItemExtremeStorageCell.java
@@ -19,6 +19,7 @@ import appeng.api.storage.IMEInventoryHandler;
 import appeng.api.storage.StorageChannel;
 import appeng.core.features.AEFeature;
 import appeng.core.localization.GuiText;
+import appeng.util.IterationCounter;
 import appeng.util.item.ItemList;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -92,7 +93,8 @@ public class ItemExtremeStorageCell extends ItemBasicStorageCell {
                                 + GuiText.Types.getLocal());
 
                 if (cellInventory.getStoredItemTypes() != 0) {
-                    ItemStack itemStack = handler.getAvailableItems(new ItemList()).getFirstItem().getItemStack();
+                    ItemStack itemStack = handler.getAvailableItems(new ItemList(), IterationCounter.fetchNewId())
+                            .getFirstItem().getItemStack();
                     lines.add(GuiText.Contains.getLocal() + ": " + itemStack.getDisplayName());
                 }
 

--- a/src/main/java/appeng/items/tools/powered/ToolColorApplicator.java
+++ b/src/main/java/appeng/items/tools/powered/ToolColorApplicator.java
@@ -64,6 +64,7 @@ import appeng.items.tools.powered.powersink.AEBasePoweredItem;
 import appeng.me.storage.CellInventoryHandler;
 import appeng.tile.misc.TilePaint;
 import appeng.util.ItemSorters;
+import appeng.util.IterationCounter;
 import appeng.util.Platform;
 import appeng.util.item.AEItemStack;
 import cpw.mods.fml.relauncher.Side;
@@ -247,7 +248,8 @@ public class ToolColorApplicator extends AEBasePoweredItem
         final IMEInventory<IAEItemStack> inv = AEApi.instance().registries().cell()
                 .getCellInventory(is, null, StorageChannel.ITEMS);
         if (inv != null) {
-            final IItemList<IAEItemStack> itemList = inv.getAvailableItems(AEApi.instance().storage().createItemList());
+            final IItemList<IAEItemStack> itemList = inv
+                    .getAvailableItems(AEApi.instance().storage().createItemList(), IterationCounter.fetchNewId());
             if (anchor == null) {
                 final IAEItemStack firstItem = itemList.getFirstItem();
                 if (firstItem != null) {

--- a/src/main/java/appeng/items/tools/powered/ToolMassCannon.java
+++ b/src/main/java/appeng/items/tools/powered/ToolMassCannon.java
@@ -68,6 +68,7 @@ import appeng.items.misc.ItemPaintBall;
 import appeng.items.tools.powered.powersink.AEBasePoweredItem;
 import appeng.me.storage.CellInventoryHandler;
 import appeng.tile.misc.TilePaint;
+import appeng.util.IterationCounter;
 import appeng.util.Platform;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -128,7 +129,8 @@ public class ToolMassCannon extends AEBasePoweredItem implements IStorageCell {
             final IMEInventory inv = AEApi.instance().registries().cell()
                     .getCellInventory(item, null, StorageChannel.ITEMS);
             if (inv != null) {
-                final IItemList itemList = inv.getAvailableItems(AEApi.instance().storage().createItemList());
+                final IItemList itemList = inv
+                        .getAvailableItems(AEApi.instance().storage().createItemList(), IterationCounter.fetchNewId());
                 IAEStack aeAmmo = itemList.getFirstItem();
                 if (aeAmmo instanceof IAEItemStack) {
                     shots = Math.min(shots, (int) aeAmmo.getStackSize());

--- a/src/main/java/appeng/me/cache/CraftingGridCache.java
+++ b/src/main/java/appeng/me/cache/CraftingGridCache.java
@@ -412,7 +412,7 @@ public class CraftingGridCache
     }
 
     @Override
-    public IItemList<IAEStack> getAvailableItems(final IItemList<IAEStack> out) {
+    public IItemList<IAEStack> getAvailableItems(final IItemList<IAEStack> out, int iteration) {
         // add craftable items!
         for (final IAEItemStack stack : this.craftableItems.keySet()) {
             out.addCrafting(stack);
@@ -426,7 +426,7 @@ public class CraftingGridCache
     }
 
     @Override
-    public IAEStack getAvailableItem(@Nonnull IAEStack request) {
+    public IAEStack getAvailableItem(@Nonnull IAEStack request, int iteration) {
         return null;
     }
 

--- a/src/main/java/appeng/me/cache/GridStorageCache.java
+++ b/src/main/java/appeng/me/cache/GridStorageCache.java
@@ -49,6 +49,7 @@ import appeng.me.storage.MEInventoryHandler;
 import appeng.me.storage.NetworkInventoryHandler;
 import appeng.tile.storage.TileChest;
 import appeng.tile.storage.TileDrive;
+import appeng.util.IterationCounter;
 
 public class GridStorageCache implements IStorageGrid {
 
@@ -345,10 +346,10 @@ public class GridStorageCache implements IStorageGrid {
 
             if (channel == StorageChannel.ITEMS) {
                 this.list = ((IMEInventoryHandler<IAEItemStack>) h)
-                        .getAvailableItems(AEApi.instance().storage().createItemList());
+                        .getAvailableItems(AEApi.instance().storage().createItemList(), IterationCounter.fetchNewId());
             } else if (channel == StorageChannel.FLUIDS) {
                 this.list = ((IMEInventoryHandler<IAEFluidStack>) h)
-                        .getAvailableItems(AEApi.instance().storage().createFluidList());
+                        .getAvailableItems(AEApi.instance().storage().createFluidList(), IterationCounter.fetchNewId());
             } else {
                 this.list = null;
             }

--- a/src/main/java/appeng/me/cache/NetworkMonitor.java
+++ b/src/main/java/appeng/me/cache/NetworkMonitor.java
@@ -35,6 +35,7 @@ import appeng.api.storage.StorageChannel;
 import appeng.api.storage.data.IAEStack;
 import appeng.api.storage.data.IItemList;
 import appeng.me.storage.ItemWatcher;
+import appeng.util.IterationCounter;
 import appeng.util.item.LazyItemList;
 
 public class NetworkMonitor<T extends IAEStack<T>> implements IMEMonitor<T> {
@@ -100,8 +101,8 @@ public class NetworkMonitor<T extends IAEStack<T>> implements IMEMonitor<T> {
     }
 
     @Override
-    public IItemList<T> getAvailableItems(final IItemList out) {
-        return this.getHandler().getAvailableItems(out);
+    public IItemList<T> getAvailableItems(final IItemList out, int iteration) {
+        return this.getHandler().getAvailableItems(out, iteration);
     }
 
     @Override
@@ -125,7 +126,7 @@ public class NetworkMonitor<T extends IAEStack<T>> implements IMEMonitor<T> {
         if (this.hasChanged) {
             this.hasChanged = false;
             this.cachedList.resetStatus();
-            return this.getAvailableItems(this.cachedList);
+            return this.getAvailableItems(this.cachedList, IterationCounter.fetchNewId());
         }
 
         return this.cachedList;
@@ -246,7 +247,8 @@ public class NetworkMonitor<T extends IAEStack<T>> implements IMEMonitor<T> {
                 final Collection<ItemWatcher> list = this.myGridCache.getInterestManager().get(changedItem);
 
                 if (!list.isEmpty()) {
-                    IAEStack<T> fullStack = this.getHandler().getAvailableItem(changedItem);
+                    IAEStack<T> fullStack = this.getHandler()
+                            .getAvailableItem(changedItem, IterationCounter.fetchNewId());
 
                     if (fullStack == null) {
                         fullStack = changedItem.copy();

--- a/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
+++ b/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
@@ -85,6 +85,7 @@ import appeng.me.cluster.IAECluster;
 import appeng.tile.AEBaseTile;
 import appeng.tile.crafting.TileCraftingMonitorTile;
 import appeng.tile.crafting.TileCraftingTile;
+import appeng.util.IterationCounter;
 import appeng.util.Platform;
 import appeng.util.item.AEItemStack;
 import cpw.mods.fml.common.FMLCommonHandler;
@@ -970,9 +971,9 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
                     }
                 }
             }
-            case STORAGE -> this.inventory.getAvailableItems(list);
+            case STORAGE -> this.inventory.getAvailableItems(list, IterationCounter.fetchNewId());
             default -> {
-                this.inventory.getAvailableItems(list);
+                this.inventory.getAvailableItems(list, IterationCounter.fetchNewId());
                 for (final IAEItemStack ais : this.waitingFor) {
                     list.add(ais);
                 }

--- a/src/main/java/appeng/me/storage/CellInventory.java
+++ b/src/main/java/appeng/me/storage/CellInventory.java
@@ -35,6 +35,7 @@ import appeng.api.storage.ISaveProvider;
 import appeng.api.storage.StorageChannel;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IItemList;
+import appeng.util.IterationCounter;
 import appeng.util.Platform;
 import appeng.util.item.AEItemStack;
 
@@ -158,7 +159,8 @@ public class CellInventory implements ICellInventory {
     }
 
     private boolean isEmpty(final IMEInventory<IAEItemStack> meInventory) {
-        return meInventory.getAvailableItems(AEApi.instance().storage().createItemList()).isEmpty();
+        return meInventory.getAvailableItems(AEApi.instance().storage().createItemList(), IterationCounter.fetchNewId())
+                .isEmpty();
     }
 
     @Override
@@ -392,7 +394,7 @@ public class CellInventory implements ICellInventory {
     }
 
     @Override
-    public IItemList<IAEItemStack> getAvailableItems(final IItemList<IAEItemStack> out) {
+    public IItemList<IAEItemStack> getAvailableItems(final IItemList<IAEItemStack> out, int iteration) {
         for (final IAEItemStack i : this.getCellItems()) {
             out.add(i);
         }
@@ -401,7 +403,7 @@ public class CellInventory implements ICellInventory {
     }
 
     @Override
-    public IAEItemStack getAvailableItem(@Nonnull IAEItemStack request) {
+    public IAEItemStack getAvailableItem(@Nonnull IAEItemStack request, int iteration) {
         long count = 0;
         for (final IAEItemStack is : this.getCellItems()) {
             if (is != null && is.getStackSize() > 0 && is.isSameType(request)) {

--- a/src/main/java/appeng/me/storage/CreativeCellInventory.java
+++ b/src/main/java/appeng/me/storage/CreativeCellInventory.java
@@ -65,7 +65,7 @@ public class CreativeCellInventory implements IMEInventoryHandler<IAEItemStack> 
     }
 
     @Override
-    public IItemList<IAEItemStack> getAvailableItems(final IItemList out) {
+    public IItemList<IAEItemStack> getAvailableItems(final IItemList out, int iteration) {
         for (final IAEItemStack ais : this.itemListCache) {
             out.add(ais);
         }
@@ -73,7 +73,7 @@ public class CreativeCellInventory implements IMEInventoryHandler<IAEItemStack> 
     }
 
     @Override
-    public IAEItemStack getAvailableItem(@Nonnull IAEItemStack request) {
+    public IAEItemStack getAvailableItem(@Nonnull IAEItemStack request, int iteration) {
         final IAEItemStack local = this.itemListCache.findPrecise(request);
         if (local == null) {
             return null;

--- a/src/main/java/appeng/me/storage/MEIInventoryWrapper.java
+++ b/src/main/java/appeng/me/storage/MEIInventoryWrapper.java
@@ -168,7 +168,7 @@ public class MEIInventoryWrapper implements IMEInventory<IAEItemStack> {
     }
 
     @Override
-    public IItemList<IAEItemStack> getAvailableItems(final IItemList<IAEItemStack> out) {
+    public IItemList<IAEItemStack> getAvailableItems(final IItemList<IAEItemStack> out, int iteration) {
         for (int x = 0; x < this.target.getSizeInventory(); x++) {
             out.addStorage(AEItemStack.create(this.target.getStackInSlot(x)));
         }
@@ -177,7 +177,7 @@ public class MEIInventoryWrapper implements IMEInventory<IAEItemStack> {
     }
 
     @Override
-    public IAEItemStack getAvailableItem(@Nonnull IAEItemStack request) {
+    public IAEItemStack getAvailableItem(@Nonnull IAEItemStack request, int iteration) {
         long count = 0;
         for (int x = 0; x < this.target.getSizeInventory(); x++) {
             ItemStack stack = this.target.getStackInSlot(x);

--- a/src/main/java/appeng/me/storage/MEInventoryHandler.java
+++ b/src/main/java/appeng/me/storage/MEInventoryHandler.java
@@ -96,21 +96,21 @@ public class MEInventoryHandler<T extends IAEStack<T>> implements IMEInventoryHa
     }
 
     @Override
-    public IItemList<T> getAvailableItems(final IItemList<T> out) {
+    public IItemList<T> getAvailableItems(final IItemList<T> out, int iteration) {
         if (!this.hasReadAccess) {
             return out;
         }
 
-        return this.internal.getAvailableItems(out);
+        return this.internal.getAvailableItems(out, iteration);
     }
 
     @Override
-    public T getAvailableItem(@Nonnull T request) {
+    public T getAvailableItem(@Nonnull T request, int iteration) {
         if (!this.hasReadAccess) {
             return null;
         }
 
-        return this.internal.getAvailableItem(request);
+        return this.internal.getAvailableItem(request, iteration);
     }
 
     @Override

--- a/src/main/java/appeng/me/storage/MEMonitorIInventory.java
+++ b/src/main/java/appeng/me/storage/MEMonitorIInventory.java
@@ -250,7 +250,7 @@ public class MEMonitorIInventory implements IMEMonitor<IAEItemStack> {
     }
 
     @Override
-    public IItemList<IAEItemStack> getAvailableItems(final IItemList out) {
+    public IItemList<IAEItemStack> getAvailableItems(final IItemList out, int iteration) {
         for (final CachedItemStack is : this.memory.values()) {
             out.addStorage(is.aeStack);
         }
@@ -259,7 +259,7 @@ public class MEMonitorIInventory implements IMEMonitor<IAEItemStack> {
     }
 
     @Override
-    public IAEItemStack getAvailableItem(@Nonnull IAEItemStack request) {
+    public IAEItemStack getAvailableItem(@Nonnull IAEItemStack request, int iteration) {
         long count = 0;
         for (final CachedItemStack is : this.memory.values()) {
             if (is != null && is.aeStack != null && is.aeStack.getStackSize() > 0 && is.aeStack.isSameType(request)) {

--- a/src/main/java/appeng/me/storage/MEMonitorPassThrough.java
+++ b/src/main/java/appeng/me/storage/MEMonitorPassThrough.java
@@ -22,6 +22,7 @@ import appeng.api.storage.IMEMonitorHandlerReceiver;
 import appeng.api.storage.StorageChannel;
 import appeng.api.storage.data.IAEStack;
 import appeng.api.storage.data.IItemList;
+import appeng.util.IterationCounter;
 import appeng.util.Platform;
 import appeng.util.inv.ItemListIgnoreCrafting;
 
@@ -47,8 +48,9 @@ public class MEMonitorPassThrough<T extends IAEStack<T>> extends MEPassThrough<T
 
         this.monitor = null;
         final IItemList<T> before = this.getInternal() == null ? this.getWrappedChannel().createList()
-                : this.getInternal()
-                        .getAvailableItems(new ItemListIgnoreCrafting(this.getWrappedChannel().createList()));
+                : this.getInternal().getAvailableItems(
+                        new ItemListIgnoreCrafting(this.getWrappedChannel().createList()),
+                        IterationCounter.fetchNewId());
 
         super.setInternal(i);
         if (i instanceof IMEMonitor) {
@@ -56,8 +58,9 @@ public class MEMonitorPassThrough<T extends IAEStack<T>> extends MEPassThrough<T
         }
 
         final IItemList<T> after = this.getInternal() == null ? this.getWrappedChannel().createList()
-                : this.getInternal()
-                        .getAvailableItems(new ItemListIgnoreCrafting(this.getWrappedChannel().createList()));
+                : this.getInternal().getAvailableItems(
+                        new ItemListIgnoreCrafting(this.getWrappedChannel().createList()),
+                        IterationCounter.fetchNewId());
 
         if (this.monitor != null) {
             this.monitor.addListener(this, this.monitor);
@@ -67,8 +70,8 @@ public class MEMonitorPassThrough<T extends IAEStack<T>> extends MEPassThrough<T
     }
 
     @Override
-    public IItemList<T> getAvailableItems(final IItemList out) {
-        super.getAvailableItems(new ItemListIgnoreCrafting(out));
+    public IItemList<T> getAvailableItems(final IItemList out, int iterator) {
+        super.getAvailableItems(new ItemListIgnoreCrafting(out), iterator);
         return out;
     }
 
@@ -86,7 +89,7 @@ public class MEMonitorPassThrough<T extends IAEStack<T>> extends MEPassThrough<T
     public IItemList<T> getStorageList() {
         if (this.monitor == null) {
             final IItemList<T> out = this.getWrappedChannel().createList();
-            this.getInternal().getAvailableItems(new ItemListIgnoreCrafting(out));
+            this.getInternal().getAvailableItems(new ItemListIgnoreCrafting(out), IterationCounter.fetchNewId());
             return out;
         }
         return this.monitor.getStorageList();

--- a/src/main/java/appeng/me/storage/MEPassThrough.java
+++ b/src/main/java/appeng/me/storage/MEPassThrough.java
@@ -50,13 +50,13 @@ public class MEPassThrough<T extends IAEStack<T>> implements IMEInventoryHandler
     }
 
     @Override
-    public IItemList<T> getAvailableItems(final IItemList<T> out) {
-        return this.internal.getAvailableItems(out);
+    public IItemList<T> getAvailableItems(final IItemList<T> out, int iteration) {
+        return this.internal.getAvailableItems(out, iteration);
     }
 
     @Override
-    public T getAvailableItem(@Nonnull T request) {
-        return this.internal.getAvailableItem(request);
+    public T getAvailableItem(@Nonnull T request, int iteration) {
+        return this.internal.getAvailableItem(request, iteration);
     }
 
     @Override

--- a/src/main/java/appeng/me/storage/NullInventory.java
+++ b/src/main/java/appeng/me/storage/NullInventory.java
@@ -33,12 +33,12 @@ public class NullInventory<T extends IAEStack<T>> implements IMEInventoryHandler
     }
 
     @Override
-    public IItemList<T> getAvailableItems(final IItemList out) {
+    public IItemList<T> getAvailableItems(final IItemList out, int iteration) {
         return out;
     }
 
     @Override
-    public T getAvailableItem(@Nonnull T request) {
+    public T getAvailableItem(@Nonnull T request, int iteration) {
         return null;
     }
 

--- a/src/main/java/appeng/me/storage/SecurityInventory.java
+++ b/src/main/java/appeng/me/storage/SecurityInventory.java
@@ -87,7 +87,7 @@ public class SecurityInventory implements IMEInventoryHandler<IAEItemStack> {
     }
 
     @Override
-    public IItemList<IAEItemStack> getAvailableItems(final IItemList out) {
+    public IItemList<IAEItemStack> getAvailableItems(final IItemList out, int iteration) {
         for (final IAEItemStack ais : this.getStoredItems()) {
             out.add(ais);
         }
@@ -96,7 +96,7 @@ public class SecurityInventory implements IMEInventoryHandler<IAEItemStack> {
     }
 
     @Override
-    public IAEItemStack getAvailableItem(@Nonnull IAEItemStack request) {
+    public IAEItemStack getAvailableItem(@Nonnull IAEItemStack request, int iteration) {
         long count = 0;
         for (final IAEItemStack is : this.getStoredItems()) {
             if (is != null && is.getStackSize() > 0 && is.isSameType(request)) {

--- a/src/main/java/appeng/me/storage/VoidCellInventory.java
+++ b/src/main/java/appeng/me/storage/VoidCellInventory.java
@@ -101,12 +101,12 @@ public class VoidCellInventory extends MEInventoryHandler<IAEItemStack> {
     }
 
     @Override
-    public IItemList<IAEItemStack> getAvailableItems(IItemList<IAEItemStack> out) {
+    public IItemList<IAEItemStack> getAvailableItems(IItemList<IAEItemStack> out, int iteration) {
         return out;
     }
 
     @Override
-    public IAEItemStack getAvailableItem(@Nonnull IAEItemStack request) {
+    public IAEItemStack getAvailableItem(@Nonnull IAEItemStack request, int iteration) {
         return null;
     }
 

--- a/src/main/java/appeng/me/storage/VoidFluidInventory.java
+++ b/src/main/java/appeng/me/storage/VoidFluidInventory.java
@@ -47,12 +47,12 @@ public class VoidFluidInventory implements IMEInventoryHandler<IAEFluidStack> {
     }
 
     @Override
-    public IItemList<IAEFluidStack> getAvailableItems(final IItemList out) {
+    public IItemList<IAEFluidStack> getAvailableItems(final IItemList out, int iteration) {
         return out;
     }
 
     @Override
-    public IAEFluidStack getAvailableItem(@Nonnull IAEFluidStack request) {
+    public IAEFluidStack getAvailableItem(@Nonnull IAEFluidStack request, int iteration) {
         return null;
     }
 

--- a/src/main/java/appeng/me/storage/VoidItemInventory.java
+++ b/src/main/java/appeng/me/storage/VoidItemInventory.java
@@ -47,12 +47,12 @@ public class VoidItemInventory implements IMEInventoryHandler<IAEItemStack> {
     }
 
     @Override
-    public IItemList<IAEItemStack> getAvailableItems(final IItemList out) {
+    public IItemList<IAEItemStack> getAvailableItems(final IItemList out, int iteration) {
         return out;
     }
 
     @Override
-    public IAEItemStack getAvailableItem(@Nonnull IAEItemStack request) {
+    public IAEItemStack getAvailableItem(@Nonnull IAEItemStack request, int iteration) {
         return null;
     }
 

--- a/src/main/java/appeng/parts/automation/PartFormationPlane.java
+++ b/src/main/java/appeng/parts/automation/PartFormationPlane.java
@@ -626,12 +626,12 @@ public class PartFormationPlane extends PartUpgradeable
     }
 
     @Override
-    public IItemList<IAEItemStack> getAvailableItems(final IItemList<IAEItemStack> out) {
+    public IItemList<IAEItemStack> getAvailableItems(final IItemList<IAEItemStack> out, int iteration) {
         return out;
     }
 
     @Override
-    public IAEItemStack getAvailableItem(@Nonnull IAEItemStack request) {
+    public IAEItemStack getAvailableItem(@Nonnull IAEItemStack request, int iteration) {
         return null;
     }
 

--- a/src/main/java/appeng/parts/misc/PartStorageBus.java
+++ b/src/main/java/appeng/parts/misc/PartStorageBus.java
@@ -73,6 +73,7 @@ import appeng.tile.inventory.AppEngInternalAEInventory;
 import appeng.tile.inventory.InvOperation;
 import appeng.transformer.annotations.Integration.Interface;
 import appeng.transformer.annotations.Integration.Method;
+import appeng.util.IterationCounter;
 import appeng.util.Platform;
 import appeng.util.prioitylist.FuzzyPriorityList;
 import appeng.util.prioitylist.OreFilteredList;
@@ -351,7 +352,7 @@ public class PartStorageBus extends PartUpgradeable implements IGridTickable, IC
         final IMEInventory<IAEItemStack> in = this.getInternalHandler();
         IItemList<IAEItemStack> before = AEApi.instance().storage().createItemList();
         if (in != null) {
-            before = in.getAvailableItems(before);
+            before = in.getAvailableItems(before, IterationCounter.fetchNewId());
         }
 
         this.cached = false;
@@ -367,7 +368,7 @@ public class PartStorageBus extends PartUpgradeable implements IGridTickable, IC
 
         IItemList<IAEItemStack> after = AEApi.instance().storage().createItemList();
         if (out != null) {
-            after = out.getAvailableItems(after);
+            after = out.getAvailableItems(after, IterationCounter.fetchNewId());
         }
 
         Platform.postListChanges(before, after, this, this.mySrc);

--- a/src/main/java/appeng/recipes/game/DisassembleRecipe.java
+++ b/src/main/java/appeng/recipes/game/DisassembleRecipe.java
@@ -34,6 +34,7 @@ import appeng.api.storage.IMEInventory;
 import appeng.api.storage.StorageChannel;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IItemList;
+import appeng.util.IterationCounter;
 
 public final class DisassembleRecipe implements IRecipe {
 
@@ -97,7 +98,7 @@ public final class DisassembleRecipe implements IRecipe {
                             .getCellInventory(stackInSlot, null, StorageChannel.ITEMS);
                     if (cellInv != null) {
                         final IItemList<IAEItemStack> list = cellInv
-                                .getAvailableItems(StorageChannel.ITEMS.createList());
+                                .getAvailableItems(StorageChannel.ITEMS.createList(), IterationCounter.fetchNewId());
                         if (!list.isEmpty()) {
                             return null;
                         }

--- a/src/main/java/appeng/tile/crafting/TileCraftingTile.java
+++ b/src/main/java/appeng/tile/crafting/TileCraftingTile.java
@@ -45,6 +45,7 @@ import appeng.me.helpers.AENetworkProxyMultiblock;
 import appeng.tile.TileEvent;
 import appeng.tile.events.TileEventType;
 import appeng.tile.grid.AENetworkTile;
+import appeng.util.IterationCounter;
 import appeng.util.Platform;
 
 public class TileCraftingTile extends AENetworkTile implements IAEMultiBlock, IPowerChannelState {
@@ -270,7 +271,8 @@ public class TileCraftingTile extends AENetworkTile implements IAEMultiBlock, IP
                         this.cluster + " does not contain any kind of blocks, which were destroyed.");
             }
 
-            for (IAEItemStack ais : inv.getAvailableItems(AEApi.instance().storage().createItemList())) {
+            for (IAEItemStack ais : inv
+                    .getAvailableItems(AEApi.instance().storage().createItemList(), IterationCounter.fetchNewId())) {
                 ais = ais.copy();
                 ais.setStackSize(ais.getItemStack().getMaxStackSize());
                 while (!places.isEmpty()) {

--- a/src/main/java/appeng/tile/storage/TileDrive.java
+++ b/src/main/java/appeng/tile/storage/TileDrive.java
@@ -57,6 +57,7 @@ import appeng.tile.events.TileEventType;
 import appeng.tile.grid.AENetworkInvTile;
 import appeng.tile.inventory.AppEngInternalInventory;
 import appeng.tile.inventory.InvOperation;
+import appeng.util.IterationCounter;
 import appeng.util.Platform;
 import appeng.util.item.ItemList;
 import io.netty.buffer.ByteBuf;
@@ -344,7 +345,8 @@ public class TileDrive extends AENetworkInvTile implements IChestOrDrive, IPrior
         ICellInventory cellInventory = handler.getCellInv();
         if (cellInventory != null) {
             if (cellInventory.getStoredItemTypes() != 0) {
-                ItemStack partition = handler.getAvailableItems(new ItemList()).getFirstItem().getItemStack().copy();
+                ItemStack partition = handler.getAvailableItems(new ItemList(), IterationCounter.fetchNewId())
+                        .getFirstItem().getItemStack().copy();
                 partition.stackSize = 1;
                 cellInventory.getConfigInventory().setInventorySlotContents(0, partition);
             }

--- a/src/main/java/appeng/tile/storage/TileIOPort.java
+++ b/src/main/java/appeng/tile/storage/TileIOPort.java
@@ -59,6 +59,7 @@ import appeng.tile.inventory.InvOperation;
 import appeng.util.ConfigManager;
 import appeng.util.IConfigManagerHost;
 import appeng.util.InventoryAdaptor;
+import appeng.util.IterationCounter;
 import appeng.util.Platform;
 import appeng.util.inv.WrapperInventoryRange;
 
@@ -380,7 +381,7 @@ public class TileIOPort extends AENetworkInvTile implements IUpgradeableHost, IC
         if (src instanceof IMEMonitor) {
             myList = ((IMEMonitor) src).getStorageList();
         } else {
-            myList = src.getAvailableItems(src.getChannel().createList());
+            myList = src.getAvailableItems(src.getChannel().createList(), IterationCounter.fetchNewId());
         }
 
         boolean didStuff;
@@ -466,7 +467,7 @@ public class TileIOPort extends AENetworkInvTile implements IUpgradeableHost, IC
         if (src instanceof IMEMonitor) {
             myList = ((IMEMonitor) src).getStorageList();
         } else {
-            myList = src.getAvailableItems(src.getChannel().createList());
+            myList = src.getAvailableItems(src.getChannel().createList(), IterationCounter.fetchNewId());
         }
 
         if (fm == FullnessMode.EMPTY) {

--- a/src/main/java/appeng/util/IterationCounter.java
+++ b/src/main/java/appeng/util/IterationCounter.java
@@ -1,0 +1,12 @@
+package appeng.util;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public final class IterationCounter {
+
+    private static AtomicInteger counter = new AtomicInteger(0);
+
+    public static int fetchNewId() {
+        return counter.getAndIncrement();
+    }
+}

--- a/src/main/java/appeng/util/Platform.java
+++ b/src/main/java/appeng/util/Platform.java
@@ -1348,7 +1348,7 @@ public class Platform {
             myItems = AEApi.instance().registries().cell().getCellInventory(removed, null, StorageChannel.ITEMS);
 
             if (myItems != null) {
-                for (final IAEItemStack is : myItems.getAvailableItems(itemChanges)) {
+                for (final IAEItemStack is : myItems.getAvailableItems(itemChanges, IterationCounter.fetchNewId())) {
                     is.setStackSize(-is.getStackSize());
                 }
             }
@@ -1356,7 +1356,7 @@ public class Platform {
             myFluids = AEApi.instance().registries().cell().getCellInventory(removed, null, StorageChannel.FLUIDS);
 
             if (myFluids != null) {
-                for (final IAEFluidStack is : myFluids.getAvailableItems(fluidChanges)) {
+                for (final IAEFluidStack is : myFluids.getAvailableItems(fluidChanges, IterationCounter.fetchNewId())) {
                     is.setStackSize(-is.getStackSize());
                 }
             }
@@ -1366,13 +1366,13 @@ public class Platform {
             myItems = AEApi.instance().registries().cell().getCellInventory(added, null, StorageChannel.ITEMS);
 
             if (myItems != null) {
-                myItems.getAvailableItems(itemChanges);
+                myItems.getAvailableItems(itemChanges, IterationCounter.fetchNewId());
             }
 
             myFluids = AEApi.instance().registries().cell().getCellInventory(added, null, StorageChannel.FLUIDS);
 
             if (myFluids != null) {
-                myFluids.getAvailableItems(fluidChanges);
+                myFluids.getAvailableItems(fluidChanges, IterationCounter.fetchNewId());
             }
         }
         if (myItems == null) {

--- a/src/main/java/appeng/util/inv/IMEAdaptor.java
+++ b/src/main/java/appeng/util/inv/IMEAdaptor.java
@@ -24,6 +24,7 @@ import appeng.api.storage.IMEInventory;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IItemList;
 import appeng.util.InventoryAdaptor;
+import appeng.util.IterationCounter;
 import appeng.util.item.AEItemStack;
 
 public class IMEAdaptor extends InventoryAdaptor {
@@ -43,7 +44,8 @@ public class IMEAdaptor extends InventoryAdaptor {
     }
 
     private IItemList<IAEItemStack> getList() {
-        return this.target.getAvailableItems(AEApi.instance().storage().createItemList());
+        return this.target
+                .getAvailableItems(AEApi.instance().storage().createItemList(), IterationCounter.fetchNewId());
     }
 
     @Override


### PR DESCRIPTION
First an in-game scenario

![image](https://github.com/user-attachments/assets/0cf73bca-ed5b-4e3d-9ead-4c6a1739c377)

Let's call red network main network and green network subnetwork. They are connected by both storage bus and fluid storage bus. Both networks have a discretizer. The tank is there as a stub for a machine

In the main network storage there are liquids. Drops for liquids are visible through crafting terminals on both networks. On the subnetwork in the dual interface there is a crafting recipe which takes in a liquid. Use the crafting interface to start that craft. Now the drop items are only visible through the subnetwork terminal. (Not in the picture) If there is a recipe which takes in a fluid on the main network, trying to start it it will show

![image](https://github.com/user-attachments/assets/67a226ad-a448-4d7f-a116-ab549ed711aa)

This is because the droplet inventory of the fluid discretizer on the main network is in a wrong state. Specifically the `itemCache` is empty so `getAvailableItem` which skips the cache and creates the droplet on-demand doesn't match `getAvailableItems` which uses the cache.

The flow of the code is:
* craft issued
* items extracted
* caches invalidated on both networks
* crafting terminal in subnetwork fetches items to display them
  * iteration through subnetwork item inventories (A)
    * subnetwork discretizer droplet inventory is reached
       the cache is null, it fetches the liquid inventory
      * fluid inventory of the subnetwork is iterated through
      * fluid inventory of the main network is iterated through (B)
    * item inventory of the main network is reached
       * main network discretizer droplet inventory is reached
          the cache is null, it fetches the liquid inventory
          * fluid inventory of the main network is iterated through (C)
            this exits early immediately, so the droplet inventory is cached as empty

This happens because `diveIteration` uses static global state `currentPass` for current iteration number:

https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/blob/21739d54f0a8fe308037ed125f2374c40138affc/src/main/java/appeng/me/storage/NetworkInventoryHandler.java#L328-L343

Empty `getDepth` return indicates this is a beginning of a new iteration, so a new iteration ID is generated. If `getDepth` is not empty and iteration id of this object matches the global state it means this object was already a part of this iteration. Then in `getAvailableItems`:

https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/blob/21739d54f0a8fe308037ed125f2374c40138affc/src/main/java/appeng/me/storage/NetworkInventoryHandler.java#L284-L298

Iteration exits immediately instead of going through the related inventories. The assumption is that whatever this inventory and every inventory in it's list have is already added to `out`

But discretizer is a special case. When rebuilding cache it starts a separate iteration through inventories but on the `FLUIDS` channel. When there are two discretizers there are two separate iterations through `FLUIDS` (B and C) started, but the fluid `out` is not carried over between them, and since all of this is happening in the overall iteration of `ITEMS` (A) whichever iteration happens later will exit early as the fluid inventories have already been checked for the iteration number generated for A

So I've added `int iteration` to `getAvailableItem`/`s` that is passed through the call stack. `getStorageList` and other top-level entrypoints into the `getAvailableItems` stack generate their own non-conflicting iteration IDs with the use of a new helper `IterationCounter.fetchNewId()`

In the real-world scenario discretizer is needed on both networks because without it crafting recipes which output fluids never finish on networks with no discretizer... which I will probably look into later