### PR TITLE
Make GTNHLib dependency transitive for runtime

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,6 +2,7 @@
 
 dependencies {
     implementation('com.github.GTNewHorizons:NotEnoughItems:2.6.19-GTNH:dev')
+    implementation('com.github.GTNewHorizons:GTNHLib:0.3.3:dev')
     implementation('curse.maven:cofh-core-69162:2388751')
 
     compileOnlyApi('com.github.GTNewHorizons:Angelica:1.0.0-beta2:api')
@@ -40,7 +41,6 @@ dependencies {
 
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:DuraDisplay:1.3.2:dev")
     runtimeOnlyNonPublishable('com.github.GTNewHorizons:Baubles:1.0.4:dev')
-    runtimeOnlyNonPublishable('com.github.GTNewHorizons:GTNHLib:0.3.3:dev')
     runtimeOnlyNonPublishable('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev')
     runtimeOnlyNonPublishable('com.github.GTNewHorizons:ThaumicEnergistics:1.6.18-GTNH:dev') { transitive = false }
     runtimeOnlyNonPublishable('com.github.GTNewHorizons:AE2FluidCraft-Rework:1.3.18-gtnh:dev') { transitive = false }

--- a/src/main/java/appeng/core/AppEng.java
+++ b/src/main/java/appeng/core/AppEng.java
@@ -74,7 +74,8 @@ public final class AppEng {
                     + net.minecraftforge.common.ForgeVersion.revisionVersion
                     + '.' // revisionVersion
                     + net.minecraftforge.common.ForgeVersion.buildVersion
-                    + ",)"; // buildVersion
+                    + ",);"
+                    + "required-after:gtnhlib@[0.3.3,)"; // require gtnhlib
 
     @Nonnull
     private static final AppEng INSTANCE = new AppEng();

--- a/src/main/java/appeng/core/AppEng.java
+++ b/src/main/java/appeng/core/AppEng.java
@@ -74,7 +74,7 @@ public final class AppEng {
                     + net.minecraftforge.common.ForgeVersion.revisionVersion
                     + '.' // revisionVersion
                     + net.minecraftforge.common.ForgeVersion.buildVersion
-                    + ",);"
+                    + ",);" // buildVersion
                     + "required-after:gtnhlib@[0.3.3,)"; // require gtnhlib
 
     @Nonnull


### PR DESCRIPTION
AE2 is loading `it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap` class from GTNHLib on startup causing dependents to [crash during server startup](https://github.com/GTNewHorizons/ExtraCells2/pull/83/checks?check_run_id=28168347855)