### PR TITLE
Sound/Music P2P Tunnels, fix DimensionalCoord equals and prevent World GC leaks

### DIFF
--- a/src/main/java/appeng/api/config/TunnelType.java
+++ b/src/main/java/appeng/api/config/TunnelType.java
@@ -21,6 +21,7 @@ public enum TunnelType {
     FLUID, // Fluid Tunnel
     ITEM, // Item Tunnel
     LIGHT, // Light Tunnel
+    SOUND,
     BUNDLED_REDSTONE, // Bundled Redstone Tunnel
     COMPUTER_MESSAGE, // Computer Message Tunnel
     PRESSURE, // PneumaticCraft Tunnel

--- a/src/main/java/appeng/api/definitions/IParts.java
+++ b/src/main/java/appeng/api/definitions/IParts.java
@@ -78,6 +78,10 @@ public interface IParts {
 
     IItemDefinition p2PTunnelLight();
 
+    default IItemDefinition p2PTunnelSound() {
+        return null;
+    }
+
     IItemDefinition p2PTunnelOpenComputers();
 
     IItemDefinition p2PTunnelPneumaticCraft();

--- a/src/main/java/appeng/api/implementations/tiles/ISoundP2PHandler.java
+++ b/src/main/java/appeng/api/implementations/tiles/ISoundP2PHandler.java
@@ -1,0 +1,27 @@
+package appeng.api.implementations.tiles;
+
+import appeng.parts.p2p.PartP2PSound;
+
+/**
+ * Allows registering custom behaviour for handling P2P sound events.
+ */
+public interface ISoundP2PHandler {
+
+    /**
+     * @param p2p The tunnel asking just before proxying a sound event
+     * @return True if the sound should be proxied, false to suppress proxying via this tunnel.
+     */
+    default boolean allowSoundProxying(PartP2PSound p2p) {
+        return true;
+    }
+
+    /**
+     * Invoked when a Sound P2P tunnel is attached to this block.
+     */
+    default void onSoundP2PAttach(PartP2PSound p2p) {}
+
+    /**
+     * Invoked when a Sound P2P tunnel is detached from this block (e.g. unloaded or removed).
+     */
+    default void onSoundP2PDetach(PartP2PSound p2p) {}
+}

--- a/src/main/java/appeng/api/util/DimensionalCoord.java
+++ b/src/main/java/appeng/api/util/DimensionalCoord.java
@@ -13,6 +13,7 @@
 
 package appeng.api.util;
 
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,7 +26,8 @@ import net.minecraft.world.World;
  */
 public class DimensionalCoord extends WorldCoord {
 
-    private final World w;
+    private static final WeakReference<World> NULL_WORLD = new WeakReference<>(null);
+    private final WeakReference<World> w;
     private final int dimId;
 
     public DimensionalCoord(final DimensionalCoord s) {
@@ -36,19 +38,19 @@ public class DimensionalCoord extends WorldCoord {
 
     public DimensionalCoord(final TileEntity s) {
         super(s);
-        this.w = s.getWorldObj();
-        this.dimId = this.w.provider.dimensionId;
+        this.w = new WeakReference<>(s.getWorldObj());
+        this.dimId = s.getWorldObj().provider.dimensionId;
     }
 
     public DimensionalCoord(final World _w, final int _x, final int _y, final int _z) {
         super(_x, _y, _z);
-        this.w = _w;
+        this.w = new WeakReference<>(_w);
         this.dimId = _w.provider.dimensionId;
     }
 
     public DimensionalCoord(final int _x, final int _y, final int _z, final int _dim) {
         super(_x, _y, _z);
-        this.w = null;
+        this.w = NULL_WORLD;
         this.dimId = _dim;
     }
 
@@ -117,11 +119,11 @@ public class DimensionalCoord extends WorldCoord {
     }
 
     public boolean isInWorld(final World world) {
-        return this.w == world;
+        return this.w.get() == world;
     }
 
     public World getWorld() {
-        return this.w;
+        return this.w.get();
     }
 
     public int getDimension() {

--- a/src/main/java/appeng/api/util/DimensionalCoord.java
+++ b/src/main/java/appeng/api/util/DimensionalCoord.java
@@ -68,7 +68,7 @@ public class DimensionalCoord extends WorldCoord {
     }
 
     public boolean isEqual(final DimensionalCoord c) {
-        return this.x == c.x && this.y == c.y && this.z == c.z && c.w == this.w;
+        return this.x == c.x && this.y == c.y && this.z == c.z && c.dimId == this.dimId;
     }
 
     private static void writeToNBT(final NBTTagCompound data, int x, int y, int z, int dimId) {

--- a/src/main/java/appeng/core/Registration.java
+++ b/src/main/java/appeng/core/Registration.java
@@ -67,6 +67,7 @@ import appeng.core.localization.PlayerMessages;
 import appeng.core.stats.PlayerStatsRegistration;
 import appeng.helpers.BlockingModeIgnoreList;
 import appeng.hooks.AETrading;
+import appeng.hooks.SoundEventHandler;
 import appeng.hooks.TickHandler;
 import appeng.items.materials.ItemMultiMaterial;
 import appeng.me.cache.CraftingGridCache;
@@ -522,6 +523,8 @@ public final class Registration {
 
         FMLCommonHandler.instance().bus().register(TickHandler.INSTANCE);
         MinecraftForge.EVENT_BUS.register(TickHandler.INSTANCE);
+
+        MinecraftForge.EVENT_BUS.register(SoundEventHandler.INSTANCE);
 
         final PartPlacement pp = new PartPlacement();
         MinecraftForge.EVENT_BUS.register(pp);

--- a/src/main/java/appeng/core/api/definitions/ApiParts.java
+++ b/src/main/java/appeng/core/api/definitions/ApiParts.java
@@ -53,6 +53,7 @@ public final class ApiParts implements IParts {
     private final IItemDefinition p2PTunnelEU;
     private final IItemDefinition p2PTunnelRF;
     private final IItemDefinition p2PTunnelLight;
+    private final IItemDefinition p2PTunnelSound;
     private final IItemDefinition p2PTunnelOpenComputers;
     private final IItemDefinition p2PTunnelPneumaticCraft;
     private final IItemDefinition p2PTunnelGregtech;
@@ -105,6 +106,7 @@ public final class ApiParts implements IParts {
         this.p2PTunnelEU = new DamagedItemDefinition(itemMultiPart.createPart(PartType.P2PTunnelEU));
         this.p2PTunnelRF = new DamagedItemDefinition(itemMultiPart.createPart(PartType.P2PTunnelRF));
         this.p2PTunnelLight = new DamagedItemDefinition(itemMultiPart.createPart(PartType.P2PTunnelLight));
+        this.p2PTunnelSound = new DamagedItemDefinition(itemMultiPart.createPart(PartType.P2PTunnelSound));
         this.p2PTunnelOpenComputers = new DamagedItemDefinition(
                 itemMultiPart.createPart(PartType.P2PTunnelOpenComputers));
         this.p2PTunnelPneumaticCraft = new DamagedItemDefinition(itemMultiPart.createPart(PartType.P2PTunnelPressure));
@@ -270,6 +272,11 @@ public final class ApiParts implements IParts {
     @Override
     public IItemDefinition p2PTunnelLight() {
         return this.p2PTunnelLight;
+    }
+
+    @Override
+    public IItemDefinition p2PTunnelSound() {
+        return this.p2PTunnelSound;
     }
 
     @Override

--- a/src/main/java/appeng/core/features/AEFeature.java
+++ b/src/main/java/appeng/core/features/AEFeature.java
@@ -94,6 +94,7 @@ public enum AEFeature {
     P2PTunnelEU(Constants.CATEGORY_P2P_TUNNELS),
     P2PTunnelLiquids(Constants.CATEGORY_P2P_TUNNELS),
     P2PTunnelLight(Constants.CATEGORY_P2P_TUNNELS),
+    P2PTunnelSound(Constants.CATEGORY_P2P_TUNNELS),
     P2PTunnelOpenComputers(Constants.CATEGORY_P2P_TUNNELS),
     P2PTunnelPressure(Constants.CATEGORY_P2P_TUNNELS),
     P2PTunnelGregtech(Constants.CATEGORY_P2P_TUNNELS),

--- a/src/main/java/appeng/core/features/registries/P2PTunnelRegistry.java
+++ b/src/main/java/appeng/core/features/registries/P2PTunnelRegistry.java
@@ -44,6 +44,23 @@ public final class P2PTunnelRegistry implements IP2PTunnelRegistry {
          */
         this.addNewAttunement(new ItemStack(Blocks.torch), TunnelType.LIGHT);
         this.addNewAttunement(new ItemStack(Blocks.glowstone), TunnelType.LIGHT);
+        this.addNewAttunement(new ItemStack(Items.glowstone_dust), TunnelType.LIGHT);
+
+        // Sound
+        this.addNewAttunement(new ItemStack(Blocks.noteblock), TunnelType.SOUND);
+        this.addNewAttunement(new ItemStack(Blocks.jukebox), TunnelType.SOUND);
+        this.addNewAttunement(new ItemStack(Items.record_11), TunnelType.SOUND);
+        this.addNewAttunement(new ItemStack(Items.record_13), TunnelType.SOUND);
+        this.addNewAttunement(new ItemStack(Items.record_blocks), TunnelType.SOUND);
+        this.addNewAttunement(new ItemStack(Items.record_cat), TunnelType.SOUND);
+        this.addNewAttunement(new ItemStack(Items.record_chirp), TunnelType.SOUND);
+        this.addNewAttunement(new ItemStack(Items.record_far), TunnelType.SOUND);
+        this.addNewAttunement(new ItemStack(Items.record_mall), TunnelType.SOUND);
+        this.addNewAttunement(new ItemStack(Items.record_mellohi), TunnelType.SOUND);
+        this.addNewAttunement(new ItemStack(Items.record_stal), TunnelType.SOUND);
+        this.addNewAttunement(new ItemStack(Items.record_strad), TunnelType.SOUND);
+        this.addNewAttunement(new ItemStack(Items.record_wait), TunnelType.SOUND);
+        this.addNewAttunement(new ItemStack(Items.record_ward), TunnelType.SOUND);
 
         /**
          * attune based on most redstone base items.

--- a/src/main/java/appeng/core/localization/GuiText.java
+++ b/src/main/java/appeng/core/localization/GuiText.java
@@ -90,6 +90,7 @@ public enum GuiText {
     FluidTunnel,
     OCTunnel,
     LightTunnel,
+    SoundTunnel,
     RFTunnel,
     PressureTunnel,
     GTTunnel,

--- a/src/main/java/appeng/core/settings/TickRates.java
+++ b/src/main/java/appeng/core/settings/TickRates.java
@@ -36,6 +36,8 @@ public enum TickRates {
 
     LightTunnel(5, 120),
 
+    SoundTunnel(20, 120),
+
     OpenComputersTunnel(1, 5),
 
     PressureTunnel(1, 120);

--- a/src/main/java/appeng/hooks/SoundEventHandler.java
+++ b/src/main/java/appeng/hooks/SoundEventHandler.java
@@ -1,0 +1,197 @@
+package appeng.hooks;
+
+import java.lang.ref.WeakReference;
+import java.util.Collection;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.world.IWorldAccess;
+import net.minecraft.world.World;
+import net.minecraftforge.event.world.WorldEvent;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+
+import appeng.api.util.DimensionalCoord;
+import appeng.me.helpers.AENetworkProxy;
+import appeng.parts.p2p.PartP2PSound;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+
+public final class SoundEventHandler {
+
+    public static final SoundEventHandler INSTANCE = new SoundEventHandler();
+
+    private final Multimap<DimensionalCoord, PartP2PSound> loadedP2Ps = HashMultimap.create(32, 1);
+
+    private SoundEventHandler() {}
+
+    public void activateP2P(PartP2PSound p2p) {
+        final AENetworkProxy proxy = p2p.getProxy();
+        if (proxy == null) {
+            return;
+        }
+        final DimensionalCoord coord = proxy.getLocation();
+        coord.add(p2p.getSide(), 1);
+        loadedP2Ps.put(coord, p2p);
+    }
+
+    public void deactivateP2P(PartP2PSound p2p) {
+        final AENetworkProxy proxy = p2p.getProxy();
+        if (proxy == null) {
+            return;
+        }
+        final DimensionalCoord coord = proxy.getLocation();
+        coord.add(p2p.getSide(), 1);
+        loadedP2Ps.remove(coord, p2p);
+    }
+
+    /**
+     * @return Sound tunnels that point at the given block coordinate.
+     */
+    public Collection<PartP2PSound> getTunnelsAround(DimensionalCoord soundPosition) {
+        return loadedP2Ps.get(soundPosition);
+    }
+
+    @SubscribeEvent
+    public void onWorldLoad(final WorldEvent.Load event) {
+        if (event.world.isRemote) {
+            // ignore clients
+            return;
+        }
+        event.world.addWorldAccess(new SoundProxyAccess(event.world));
+    }
+
+    private boolean inSoundEvent = false;
+
+    public class SoundProxyAccess implements IWorldAccess {
+
+        private final WeakReference<World> world;
+
+        public SoundProxyAccess(World world) {
+            this.world = new WeakReference<>(world);
+        }
+
+        @Override
+        public void playRecord(String recordName, int x, int y, int z) {
+            if (inSoundEvent) {
+                return;
+            }
+            inSoundEvent = true;
+            try {
+                final World w = world.get();
+                if (w == null) {
+                    return;
+                }
+                final DimensionalCoord position = new DimensionalCoord(w, x, y, z);
+                final Collection<PartP2PSound> p2ps = loadedP2Ps.get(position);
+                p2ps.forEach(
+                        p2p -> p2p.proxyCall(
+                                (outPos, outWorld) -> outWorld.playRecord(recordName, outPos.x, outPos.y, outPos.z)));
+            } finally {
+                inSoundEvent = false;
+            }
+        }
+
+        @Override
+        public void broadcastSound(int soundId, int x, int y, int z, int extraData) {
+            // ignored, this is for boss death server-wide sounds
+        }
+
+        @Override
+        public void playAuxSFX(EntityPlayer optionalPlayer, int soundId, int x, int y, int z, int extraData) {
+            if (inSoundEvent) {
+                return;
+            }
+            inSoundEvent = true;
+            try {
+                final World w = world.get();
+                if (w == null) {
+                    return;
+                }
+                final DimensionalCoord position = new DimensionalCoord(w, x, y, z);
+                final Collection<PartP2PSound> p2ps = loadedP2Ps.get(position);
+                p2ps.forEach(
+                        p2p -> p2p.proxyCall(
+                                (outPos, outWorld) -> outWorld
+                                        .playAuxSFX(soundId, outPos.x, outPos.y, outPos.z, extraData)));
+            } finally {
+                inSoundEvent = false;
+            }
+        }
+
+        @Override
+        public void playSound(String soundName, double dx, double dy, double dz, float volume, float pitch) {
+            if (inSoundEvent) {
+                return;
+            }
+            inSoundEvent = true;
+            try {
+                final int x = (int) Math.floor(dx), y = (int) Math.floor(dy), z = (int) Math.floor(dz);
+                final World w = world.get();
+                if (w == null) {
+                    return;
+                }
+                final DimensionalCoord position = new DimensionalCoord(w, x, y, z);
+                final Collection<PartP2PSound> p2ps = loadedP2Ps.get(position);
+                p2ps.forEach(
+                        p2p -> p2p.proxyCall(
+                                (outPos, outWorld) -> outWorld
+                                        .playSoundEffect(outPos.x, outPos.y, outPos.z, soundName, volume, pitch)));
+            } finally {
+                inSoundEvent = false;
+            }
+        }
+
+        @Override
+        public void playSoundToNearExcept(EntityPlayer srcPlayer, String soundName, double dx, double dy, double dz,
+                float volume, float pitch) {
+            if (inSoundEvent) {
+                return;
+            }
+            inSoundEvent = true;
+            try {
+                final int x = (int) Math.floor(dx), y = (int) Math.floor(dy), z = (int) Math.floor(dz);
+                final World w = world.get();
+                if (w == null) {
+                    return;
+                }
+                final DimensionalCoord position = new DimensionalCoord(w, x, y, z);
+                final Collection<PartP2PSound> p2ps = loadedP2Ps.get(position);
+                // Because this sound is proxied, it must be played to srcPlayer too
+                p2ps.forEach(
+                        p2p -> p2p.proxyCall(
+                                (outPos, outWorld) -> outWorld
+                                        .playSoundEffect(outPos.x, outPos.y, outPos.z, soundName, volume, pitch)));
+            } finally {
+                inSoundEvent = false;
+            }
+        }
+
+        @Override
+        public void markBlockForUpdate(int p_147586_1_, int p_147586_2_, int p_147586_3_) {}
+
+        @Override
+        public void markBlockForRenderUpdate(int p_147588_1_, int p_147588_2_, int p_147588_3_) {}
+
+        @Override
+        public void markBlockRangeForRenderUpdate(int p_147585_1_, int p_147585_2_, int p_147585_3_, int p_147585_4_,
+                int p_147585_5_, int p_147585_6_) {}
+
+        @Override
+        public void spawnParticle(String p_72708_1_, double p_72708_2_, double p_72708_4_, double p_72708_6_,
+                double p_72708_8_, double p_72708_10_, double p_72708_12_) {}
+
+        @Override
+        public void onEntityCreate(Entity p_72703_1_) {}
+
+        @Override
+        public void onEntityDestroy(Entity p_72709_1_) {}
+
+        @Override
+        public void destroyBlockPartially(int p_147587_1_, int p_147587_2_, int p_147587_3_, int p_147587_4_,
+                int p_147587_5_) {}
+
+        @Override
+        public void onStaticEntitiesChanged() {}
+    }
+}

--- a/src/main/java/appeng/items/parts/PartType.java
+++ b/src/main/java/appeng/items/parts/PartType.java
@@ -48,6 +48,7 @@ import appeng.parts.p2p.PartP2POpenComputers;
 import appeng.parts.p2p.PartP2PPressure;
 import appeng.parts.p2p.PartP2PRFPower;
 import appeng.parts.p2p.PartP2PRedstone;
+import appeng.parts.p2p.PartP2PSound;
 import appeng.parts.p2p.PartP2PTunnelME;
 import appeng.parts.reporting.PartConversionMonitor;
 import appeng.parts.reporting.PartCraftingTerminal;
@@ -203,6 +204,9 @@ public enum PartType {
 
     P2PTunnelInterface(471, EnumSet.of(AEFeature.P2PTunnel), EnumSet.noneOf(IntegrationType.class),
             PartP2PInterface.class, GuiText.IFACETunnel),
+
+    P2PTunnelSound(472, EnumSet.of(AEFeature.P2PTunnel, AEFeature.P2PTunnelSound),
+            EnumSet.noneOf(IntegrationType.class), PartP2PSound.class, GuiText.SoundTunnel),
 
     InterfaceTerminal(480, EnumSet.of(AEFeature.InterfaceTerminal), EnumSet.noneOf(IntegrationType.class),
             PartInterfaceTerminal.class),

--- a/src/main/java/appeng/parts/p2p/PartP2PSound.java
+++ b/src/main/java/appeng/parts/p2p/PartP2PSound.java
@@ -1,0 +1,150 @@
+/*
+ * This file is part of Applied Energistics 2. Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved. Applied
+ * Energistics 2 is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version. Applied Energistics 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+ * Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+ * Applied Energistics 2. If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.parts.p2p;
+
+import java.util.function.BiConsumer;
+
+import javax.annotation.Nullable;
+
+import net.minecraft.init.Blocks;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.IIcon;
+import net.minecraft.world.World;
+
+import appeng.api.implementations.tiles.ISoundP2PHandler;
+import appeng.api.networking.IGridNode;
+import appeng.api.networking.events.MENetworkChannelsChanged;
+import appeng.api.networking.events.MENetworkPowerStatusChange;
+import appeng.api.networking.ticking.IGridTickable;
+import appeng.api.networking.ticking.TickRateModulation;
+import appeng.api.networking.ticking.TickingRequest;
+import appeng.api.util.DimensionalCoord;
+import appeng.core.settings.TickRates;
+import appeng.hooks.SoundEventHandler;
+import appeng.me.GridAccessException;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+public class PartP2PSound extends PartP2PTunnelNormal<PartP2PSound> implements IGridTickable {
+
+    private boolean alive = false;
+    private ISoundP2PHandler customHandler;
+
+    public PartP2PSound(final ItemStack is) {
+        super(is);
+    }
+
+    @Override
+    public void chanRender(final MENetworkChannelsChanged c) {
+        this.onTunnelNetworkChange();
+        super.chanRender(c);
+    }
+
+    @Override
+    public void powerRender(final MENetworkPowerStatusChange c) {
+        this.onTunnelNetworkChange();
+        super.powerRender(c);
+    }
+
+    @Override
+    public void onNeighborChanged() {
+        final TileEntity te = this.getTile();
+        final World w = te.getWorldObj();
+        final TileEntity neighbor = w.getTileEntity(
+                te.xCoord + this.getSide().offsetX,
+                te.yCoord + this.getSide().offsetY,
+                te.zCoord + this.getSide().offsetZ);
+        if (alive && !isOutput()) {
+            SoundEventHandler.INSTANCE.activateP2P(this);
+        }
+        if (neighbor instanceof ISoundP2PHandler handler) {
+            if (this.customHandler != handler) {
+                this.customHandler = handler;
+                handler.onSoundP2PAttach(this);
+            }
+        } else {
+            this.customHandler = null;
+        }
+    }
+
+    @Override
+    public void addToWorld() {
+        super.addToWorld();
+        alive = true;
+        onNeighborChanged();
+    }
+
+    @Override
+    public void removeFromWorld() {
+        if (customHandler != null) {
+            customHandler.onSoundP2PDetach(this);
+        }
+        super.removeFromWorld();
+        alive = false;
+        SoundEventHandler.INSTANCE.deactivateP2P(this);
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public IIcon getTypeTexture() {
+        return Blocks.noteblock.getBlockTextureFromSide(0);
+    }
+
+    @Override
+    public void onTunnelConfigChange() {
+        this.onTunnelNetworkChange();
+    }
+
+    @Override
+    public void onTunnelNetworkChange() {
+        this.onNeighborChanged();
+    }
+
+    @Override
+    public TickingRequest getTickingRequest(final IGridNode node) {
+        return new TickingRequest(TickRates.SoundTunnel.getMin(), TickRates.SoundTunnel.getMax(), false, false);
+    }
+
+    @Override
+    public TickRateModulation tickingRequest(final IGridNode node, final int ticksSinceLastCall) {
+        this.onNeighborChanged(); // periodically, but rarely, check the neighbor
+        return TickRateModulation.SLOWER;
+    }
+
+    public @Nullable ISoundP2PHandler getCustomHandler() {
+        return this.customHandler;
+    }
+
+    /**
+     * Invokes the given function for each active output linked to this P2P.
+     */
+    public void proxyCall(BiConsumer<DimensionalCoord, World> runAtOutput) {
+        if (this.getProxy() == null || !this.getProxy().isActive() || this.isOutput()) {
+            return;
+        }
+        if (this.customHandler != null && !this.customHandler.allowSoundProxying(this)) {
+            return;
+        }
+        try {
+            this.getOutputs().forEach(output -> {
+                if (output.getTile() == null || output.getProxy() == null || !output.getProxy().isActive()) {
+                    return;
+                }
+                final DimensionalCoord outputPos = output.getLocation();
+                outputPos.add(output.getSide(), 1);
+                runAtOutput.accept(outputPos, output.getTile().getWorldObj());
+            });
+        } catch (GridAccessException e) {
+            // skip
+        }
+    }
+}

--- a/src/main/java/appeng/parts/p2p/PartP2PTunnelNormal.java
+++ b/src/main/java/appeng/parts/p2p/PartP2PTunnelNormal.java
@@ -85,6 +85,11 @@ public class PartP2PTunnelNormal<T extends PartP2PTunnelNormal> extends PartP2PT
                         newType = stack;
                     }
                 }
+                case SOUND -> {
+                    for (final ItemStack stack : parts.p2PTunnelSound().maybeStack(1).asSet()) {
+                        newType = stack;
+                    }
+                }
                 case RF_POWER -> {
                     for (final ItemStack stack : parts.p2PTunnelRF().maybeStack(1).asSet()) {
                         newType = stack;

--- a/src/main/resources/assets/appliedenergistics2/lang/en_US.lang
+++ b/src/main/resources/assets/appliedenergistics2/lang/en_US.lang
@@ -125,6 +125,7 @@ gui.appliedenergistics2.RedstoneTunnel=Redstone
 gui.appliedenergistics2.EUTunnel=EU
 gui.appliedenergistics2.RFTunnel=RF
 gui.appliedenergistics2.LightTunnel=Light
+gui.appliedenergistics2.SoundTunnel=Sound
 gui.appliedenergistics2.OCTunnel=OpenComputers
 gui.appliedenergistics2.PressureTunnel=Pressure
 gui.appliedenergistics2.GTTunnel=GT EU


### PR DESCRIPTION
Adds a Sound P2P tunnel type that can proxy sounds generated in the block space it's pointing at to all connected output sound P2Ps. 
Tested and works with:
 - Note blocks (place the p2p on the note block)
 - Jukeboxes (same as above, place the p2p directly on the jukebox)
 - Pistons (when pointing at the piston base, piston movement sounds are played from all outputs)
 - Block place/break sounds (funnily this also shows the block break particles at all outputs as Minecraft handles that in sound code for some reason)

Does not work with:

 - Any sounds that only get played on the client without the server's involvement.

Also adds an API to tweak the behaviour from other mods - I plan to use this for improved electric jukeboxes in GT5u.

Example at work:

https://github.com/user-attachments/assets/b7e4646a-7659-464f-887f-4b0edeb01eb3


