### PR TITLE
Restore api backwards compatibility

### DIFF
--- a/src/main/java/appeng/api/storage/IMEMonitor.java
+++ b/src/main/java/appeng/api/storage/IMEMonitor.java
@@ -21,10 +21,14 @@ public interface IMEMonitor<T extends IAEStack> extends IMEInventoryHandler<T>, 
 
     /**
      * This method is discouraged when accessing data via a IMEMonitor
+     * 
+     * @deprecated use/override {@link #getAvailableItems(IItemList,int)} instead
      */
     @Override
     @Deprecated
-    IItemList<T> getAvailableItems(IItemList out, int iteration);
+    default IItemList<T> getAvailableItems(IItemList out) {
+        return IMEInventoryHandler.super.getAvailableItems(out);
+    }
 
     /**
      * Get access to the full item list of the network, preferred over {@link IMEInventory} .getAvailableItems(...)

--- a/src/main/java/appeng/util/IterationCounter.java
+++ b/src/main/java/appeng/util/IterationCounter.java
@@ -2,41 +2,60 @@ package appeng.util;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.google.common.annotations.VisibleForTesting;
+
 public final class IterationCounter {
 
     private static AtomicInteger counter = new AtomicInteger(0);
-    private static int globalDepth = 0;
-    private static int globalCounter = 0;
+    private static final ThreadLocal<Integer> globalDepth = ThreadLocal.withInitial(() -> 0);
+    private static final ThreadLocal<Integer> globalCounter = ThreadLocal.withInitial(() -> 0);
 
     public static int fetchNewId() {
         return counter.getAndIncrement();
     }
 
     /**
-     * Increment the global iteration depth
+     * Increment the global iteration depth for this thread
      * 
      * @return Iteration number currently used for global iteration
      */
-    public static synchronized int incrementGlobalDepth() {
-        if (globalDepth == 0) {
-            globalCounter++;
+    public static int incrementGlobalDepth() {
+        var depth = globalDepth.get();
+        if (depth == 0) {
+            globalCounter.set(fetchNewId());
         }
-        globalDepth++;
-        return globalCounter;
+        globalDepth.set(depth + 1);
+        return globalCounter.get();
     }
 
     /**
-     * Initialize global iteration number and increment global depth This unconditionally overrides current global
-     * iteration number!
+     * Initialize global iteration number and increment global depth for this thread
+     *
+     * This unconditionally overrides current global iteration number!
      *
      * @param iteration Iteration number to set global one to
      */
-    public static synchronized void incrementGlobalDepthWith(int iteration) {
-        globalCounter = iteration;
-        globalDepth++;
+    public static void incrementGlobalDepthWith(int iteration) {
+        globalCounter.set(iteration);
+        globalDepth.set(globalDepth.get() + 1);
     }
 
-    public static synchronized void decrementGlobalDepth() {
-        globalDepth--;
+    public static void decrementGlobalDepth() {
+        globalDepth.set(globalDepth.get() - 1);
+    }
+
+    public static int getCurrentDepth() {
+        return globalDepth.get();
+    }
+
+    public static int getCurrentIteration() {
+        return globalCounter.get();
+    }
+
+    @VisibleForTesting
+    static void clear() {
+        counter = new AtomicInteger(0);
+        globalDepth.set(0);
+        globalCounter.set(0);
     }
 }

--- a/src/main/java/appeng/util/IterationCounter.java
+++ b/src/main/java/appeng/util/IterationCounter.java
@@ -5,8 +5,38 @@ import java.util.concurrent.atomic.AtomicInteger;
 public final class IterationCounter {
 
     private static AtomicInteger counter = new AtomicInteger(0);
+    private static int globalDepth = 0;
+    private static int globalCounter = 0;
 
     public static int fetchNewId() {
         return counter.getAndIncrement();
+    }
+
+    /**
+     * Increment the global iteration depth
+     * 
+     * @return Iteration number currently used for global iteration
+     */
+    public static synchronized int incrementGlobalDepth() {
+        if (globalDepth == 0) {
+            globalCounter++;
+        }
+        globalDepth++;
+        return globalCounter;
+    }
+
+    /**
+     * Initialize global iteration number and increment global depth This unconditionally overrides current global
+     * iteration number!
+     *
+     * @param iteration Iteration number to set global one to
+     */
+    public static synchronized void incrementGlobalDepthWith(int iteration) {
+        globalCounter = iteration;
+        globalDepth++;
+    }
+
+    public static synchronized void decrementGlobalDepth() {
+        globalDepth--;
     }
 }

--- a/src/test/java/appeng/util/IterationCounterGlobalTest.java
+++ b/src/test/java/appeng/util/IterationCounterGlobalTest.java
@@ -1,0 +1,50 @@
+package appeng.util;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Test for {@link IterationCounter}
+ */
+public class IterationCounterGlobalTest {
+
+    @After
+    public void cleanup() {
+        IterationCounter.clear();
+    }
+
+    @Test
+    public void incrementGlobalDepthIterationTest() {
+        var prev = IterationCounter.fetchNewId();
+        IterationCounter.incrementGlobalDepthWith(prev);
+        IterationCounter.decrementGlobalDepth();
+        assertEquals(IterationCounter.incrementGlobalDepth(), prev + 1);
+    }
+
+    @Test
+    public void incrementGlobalDepthDepthTest() {
+        IterationCounter.incrementGlobalDepth();
+        assertEquals(IterationCounter.getCurrentDepth(), 1);
+    }
+
+    @Test
+    public void incrementGlobalDepthWithIterationTest() {
+        IterationCounter.incrementGlobalDepthWith(1234);
+        assertEquals(1234, IterationCounter.getCurrentIteration());
+    }
+
+    @Test
+    public void incrementGlobalDepthWithDepthTest() {
+        IterationCounter.incrementGlobalDepthWith(4567);
+        assertEquals(1, IterationCounter.getCurrentDepth());
+    }
+
+    @Test
+    public void decrementGlobalDepthDepth() {
+        IterationCounter.incrementGlobalDepth();
+        IterationCounter.decrementGlobalDepth();
+        assertEquals(IterationCounter.getCurrentDepth(), 0);
+    }
+}


### PR DESCRIPTION
#536 broke backwards compatibility with non-GTNH mods by changing a signature of a function in the api which I was informed shouldn't be done for mods classified as public.

This re-adds removed functions and provides default implementations for both old and new versions to allow interweaving between them depending on which version is overridden.