### PR TITLE
Fix sticky storages break autocrafting

### DIFF
--- a/src/main/java/appeng/api/storage/IMEInventoryHandler.java
+++ b/src/main/java/appeng/api/storage/IMEInventoryHandler.java
@@ -84,4 +84,13 @@ public interface IMEInventoryHandler<StackType extends IAEStack> extends IMEInve
         return false;
     }
 
+    /**
+     * Gets whether an inventory stores items for crafting. For example the {@link appeng.me.cache.CraftingGridCache}
+     *
+     * @return true if this inventory stores items for crafting
+     */
+    default boolean getCraftingInventory() {
+        return false;
+    }
+
 }

--- a/src/main/java/appeng/api/storage/IMEInventoryHandler.java
+++ b/src/main/java/appeng/api/storage/IMEInventoryHandler.java
@@ -85,11 +85,12 @@ public interface IMEInventoryHandler<StackType extends IAEStack> extends IMEInve
     }
 
     /**
-     * Gets whether an inventory stores items for crafting. For example the {@link appeng.me.cache.CraftingGridCache}
+     * Gets whether an inventory stores items for auto crafting. For example the
+     * {@link appeng.me.cache.CraftingGridCache}
      *
-     * @return true if this inventory stores items for crafting
+     * @return true if this inventory stores items for auto crafting
      */
-    default boolean getCraftingInventory() {
+    default boolean isAutoCraftingInventory() {
         return false;
     }
 

--- a/src/main/java/appeng/api/storage/MEMonitorHandler.java
+++ b/src/main/java/appeng/api/storage/MEMonitorHandler.java
@@ -181,4 +181,9 @@ public class MEMonitorHandler<StackType extends IAEStack> implements IMEMonitor<
     public boolean getSticky() {
         return this.internalHandler.getSticky();
     }
+
+    @Override
+    public boolean getCraftingInventory() {
+        return this.internalHandler.getCraftingInventory();
+    }
 }

--- a/src/main/java/appeng/api/storage/MEMonitorHandler.java
+++ b/src/main/java/appeng/api/storage/MEMonitorHandler.java
@@ -181,9 +181,4 @@ public class MEMonitorHandler<StackType extends IAEStack> implements IMEMonitor<
     public boolean getSticky() {
         return this.internalHandler.getSticky();
     }
-
-    @Override
-    public boolean isAutoCraftingInventory() {
-        return this.internalHandler.isAutoCraftingInventory();
-    }
 }

--- a/src/main/java/appeng/api/storage/MEMonitorHandler.java
+++ b/src/main/java/appeng/api/storage/MEMonitorHandler.java
@@ -183,7 +183,7 @@ public class MEMonitorHandler<StackType extends IAEStack> implements IMEMonitor<
     }
 
     @Override
-    public boolean getCraftingInventory() {
-        return this.internalHandler.getCraftingInventory();
+    public boolean isAutoCraftingInventory() {
+        return this.internalHandler.isAutoCraftingInventory();
     }
 }

--- a/src/main/java/appeng/me/cache/CraftingGridCache.java
+++ b/src/main/java/appeng/me/cache/CraftingGridCache.java
@@ -398,6 +398,11 @@ public class CraftingGridCache
     }
 
     @Override
+    public boolean getCraftingInventory() {
+        return true;
+    }
+
+    @Override
     public IAEStack injectItems(IAEStack input, final Actionable type, final BaseActionSource src) {
         for (final CraftingCPUCluster cpu : this.craftingCPUClusters) {
             input = cpu.injectItems(input, type, src);

--- a/src/main/java/appeng/me/cache/CraftingGridCache.java
+++ b/src/main/java/appeng/me/cache/CraftingGridCache.java
@@ -398,7 +398,7 @@ public class CraftingGridCache
     }
 
     @Override
-    public boolean getCraftingInventory() {
+    public boolean isAutoCraftingInventory() {
         return true;
     }
 

--- a/src/main/java/appeng/me/storage/MEInventoryHandler.java
+++ b/src/main/java/appeng/me/storage/MEInventoryHandler.java
@@ -36,6 +36,7 @@ public class MEInventoryHandler<T extends IAEStack<T>> implements IMEInventoryHa
     private boolean hasReadAccess;
     protected boolean hasWriteAccess;
     protected boolean isSticky;
+    protected boolean isCraftingInventory;
 
     public MEInventoryHandler(final IMEInventory<T> i, final StorageChannel channel) {
         if (i instanceof IMEInventoryHandler) {
@@ -168,6 +169,15 @@ public class MEInventoryHandler<T extends IAEStack<T>> implements IMEInventoryHa
     @Override
     public boolean getSticky() {
         return isSticky || this.internal.getSticky();
+    }
+
+    @Override
+    public boolean getCraftingInventory() {
+        return isCraftingInventory || this.internal.getCraftingInventory();
+    }
+
+    public void setCraftingInventory(final boolean isCraftingInventory) {
+        this.isCraftingInventory = isCraftingInventory;
     }
 
     public IMEInventory<T> getInternal() {

--- a/src/main/java/appeng/me/storage/MEInventoryHandler.java
+++ b/src/main/java/appeng/me/storage/MEInventoryHandler.java
@@ -36,7 +36,6 @@ public class MEInventoryHandler<T extends IAEStack<T>> implements IMEInventoryHa
     private boolean hasReadAccess;
     protected boolean hasWriteAccess;
     protected boolean isSticky;
-    protected boolean isAutoCraftingInventory;
 
     public MEInventoryHandler(final IMEInventory<T> i, final StorageChannel channel) {
         if (i instanceof IMEInventoryHandler) {
@@ -169,15 +168,6 @@ public class MEInventoryHandler<T extends IAEStack<T>> implements IMEInventoryHa
     @Override
     public boolean getSticky() {
         return isSticky || this.internal.getSticky();
-    }
-
-    @Override
-    public boolean isAutoCraftingInventory() {
-        return isAutoCraftingInventory || this.internal.isAutoCraftingInventory();
-    }
-
-    public void setIsAutoCraftingInventory(final boolean isCraftingInventory) {
-        this.isAutoCraftingInventory = isCraftingInventory;
     }
 
     public IMEInventory<T> getInternal() {

--- a/src/main/java/appeng/me/storage/MEInventoryHandler.java
+++ b/src/main/java/appeng/me/storage/MEInventoryHandler.java
@@ -36,7 +36,7 @@ public class MEInventoryHandler<T extends IAEStack<T>> implements IMEInventoryHa
     private boolean hasReadAccess;
     protected boolean hasWriteAccess;
     protected boolean isSticky;
-    protected boolean isCraftingInventory;
+    protected boolean isAutoCraftingInventory;
 
     public MEInventoryHandler(final IMEInventory<T> i, final StorageChannel channel) {
         if (i instanceof IMEInventoryHandler) {
@@ -172,12 +172,12 @@ public class MEInventoryHandler<T extends IAEStack<T>> implements IMEInventoryHa
     }
 
     @Override
-    public boolean getCraftingInventory() {
-        return isCraftingInventory || this.internal.getCraftingInventory();
+    public boolean isAutoCraftingInventory() {
+        return isAutoCraftingInventory || this.internal.isAutoCraftingInventory();
     }
 
-    public void setCraftingInventory(final boolean isCraftingInventory) {
-        this.isCraftingInventory = isCraftingInventory;
+    public void setIsAutoCraftingInventory(final boolean isCraftingInventory) {
+        this.isAutoCraftingInventory = isCraftingInventory;
     }
 
     public IMEInventory<T> getInternal() {

--- a/src/main/java/appeng/me/storage/NetworkInventoryHandler.java
+++ b/src/main/java/appeng/me/storage/NetworkInventoryHandler.java
@@ -38,13 +38,13 @@ public class NetworkInventoryHandler<T extends IAEStack<T>> implements IMEInvent
     private static final ThreadLocal<LinkedList> DEPTH_SIM = new ThreadLocal<>();
 
     /**
-     * Sorter for the {@link #priorityInventory} list. Crafting inventories are first followed by Sticky inventories.
-     * The inventories are then sorted by priority (highest first), and then by placement pass (1 first, 1&2 second, 2
-     * last).
+     * Sorter for the {@link #priorityInventory} list. AutoCrafting inventories are first followed by Sticky
+     * inventories. The inventories are then sorted by priority (highest first), and then by placement pass (1 first,
+     * 1&2 second, 2 last).
      */
     private static final Comparator<IMEInventoryHandler<?>> CRAFTING_STICKY_PRIORITY_PLACEMENT_PASS_SORTER = (o1,
             o2) -> {
-        int result = Boolean.compare(o2.getCraftingInventory(), o1.getCraftingInventory());
+        int result = Boolean.compare(o2.isAutoCraftingInventory(), o1.isAutoCraftingInventory());
         if (result != 0) {
             return result;
         }


### PR DESCRIPTION
Fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16152

The current implementation always tries to store into sticky inventories first. If there is any sticky inventory that can store the item, it will not attempt to insert into any non-sticky inventories. 
This breaks autocrafting since the item will never be injected into the CraftingGridCache.


https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/221 is related to this PR. The ae2fc PR will allow sticky inventory autocrafting to work with fluids too.
