### PR TITLE
Feature/item storage bus export filter

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,17 +1,17 @@
 // Add your dependencies here
 
 dependencies {
-    implementation('com.github.GTNewHorizons:NotEnoughItems:2.6.22-GTNH:dev')
-    implementation('com.github.GTNewHorizons:GTNHLib:0.4.2:dev')
+    implementation('com.github.GTNewHorizons:NotEnoughItems:2.6.25-GTNH:dev')
+    implementation('com.github.GTNewHorizons:GTNHLib:0.4.3:dev')
     implementation('curse.maven:cofh-core-69162:2388751')
 
     compileOnlyApi('com.github.GTNewHorizons:Angelica:1.0.0-beta4:api')
-    compileOnly("com.github.GTNewHorizons:GTNHLib:0.4.2:dev") {transitive = false}
+    compileOnly("com.github.GTNewHorizons:GTNHLib:0.4.3:dev") {transitive = false}
     compileOnly('com.github.GTNewHorizons:ThaumicTinkerer:2.10.1:dev') {transitive = false}
     compileOnly('com.github.GTNewHorizons:BuildCraft:7.1.39:dev') {transitive = false}
     compileOnly('com.github.GTNewHorizons:ForestryMC:4.9.7:dev') {transitive = false} // required to compile CraftingV2Tests.java now
     compileOnly('com.github.GTNewHorizons:ForgeMultipart:1.5.0:dev') {transitive = false}
-    compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.48.148:dev') {transitive = false}
+    compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.49.03:dev') {transitive = false}
     compileOnly('com.github.GTNewHorizons:Jabba:1.4.6:dev') {transitive = false}
     compileOnly('com.github.GTNewHorizons:inventory-tweaks:1.6.2:api') {transitive = false}
     compileOnly('com.github.GTNewHorizons:OpenComputers:1.10.19-GTNH:api') {transitive = false}
@@ -35,7 +35,7 @@ dependencies {
     functionalTestImplementation('org.junit.platform:junit-platform-engine')
     functionalTestImplementation('org.junit.platform:junit-platform-launcher')
     functionalTestImplementation('org.junit.platform:junit-platform-reporting')
-    functionalTestImplementation('com.github.GTNewHorizons:GT5-Unofficial:5.09.48.148:dev') {
+    functionalTestImplementation('com.github.GTNewHorizons:GT5-Unofficial:5.09.49.03:dev') {
         exclude module: "Applied-Energistics-2-Unofficial"
     }
 

--- a/src/main/java/appeng/me/storage/MEInventoryHandler.java
+++ b/src/main/java/appeng/me/storage/MEInventoryHandler.java
@@ -101,7 +101,7 @@ public class MEInventoryHandler<T extends IAEStack<T>> implements IMEInventoryHa
         if (!this.hasReadAccess) {
             return null;
         }
-        if (!myExtractPartitionList.isEmpty() && !myExtractPartitionList.isListed(request)) {
+        if (this.isExtractFilter() && !myExtractPartitionList.isEmpty() && !myExtractPartitionList.isListed(request)) {
             return null;
         }
 
@@ -141,7 +141,7 @@ public class MEInventoryHandler<T extends IAEStack<T>> implements IMEInventoryHa
         return this.internal.getAvailableItem(request, iteration);
     }
 
-    private boolean isExtractFilter() {
+    public boolean isExtractFilter() {
         // only READ since READ_WRITE would break compat of existing storage buses
         // could use a new setting that is applied via button or a card too
         return this.cachedAccessRestriction == AccessRestriction.READ;

--- a/src/main/java/appeng/parts/misc/PartStorageBus.java
+++ b/src/main/java/appeng/parts/misc/PartStorageBus.java
@@ -141,7 +141,7 @@ public class PartStorageBus extends PartUpgradeable implements IGridTickable, IC
 
     @Override
     public void updateSetting(final IConfigManager manager, final Enum settingName, final Enum newValue) {
-        if(settingName == Settings.ACCESS && newValue == AccessRestriction.READ) {
+        if (settingName == Settings.ACCESS && newValue == AccessRestriction.READ) {
             postUnfilteredChangesOnce = true;
         }
         this.resetCache(true);
@@ -235,11 +235,12 @@ public class PartStorageBus extends PartUpgradeable implements IGridTickable, IC
      * Filters the changes to only include items that pass the handlers extract filter.
      */
     private Iterable<IAEItemStack> filterChanges(Iterable<IAEItemStack> change) {
-        if(this.postUnfilteredChangesOnce) {
+        if (this.postUnfilteredChangesOnce) {
             return change;
         }
 
-        if (this.handler != null && this.handler.isExtractFilter() && !this.handler.getExtractPartitionList().isEmpty()) {
+        if (this.handler != null && this.handler.isExtractFilter()
+                && !this.handler.getExtractPartitionList().isEmpty()) {
             List<IAEItemStack> filteredChanges = new ArrayList<>();
             for (final IAEItemStack changedItem : change) {
                 if (this.handler.getExtractPartitionList().isListed(changedItem)) {

--- a/src/main/java/appeng/parts/misc/PartStorageBus.java
+++ b/src/main/java/appeng/parts/misc/PartStorageBus.java
@@ -231,10 +231,12 @@ public class PartStorageBus extends PartUpgradeable implements IGridTickable, IC
                         }
                     }
 
-                    this.getProxy().getStorage().postAlterationOfStoredItems(
-                            StorageChannel.ITEMS,
-                            Collections.unmodifiableList(partitionedChanges),
-                            this.mySrc);
+                    if(!partitionedChanges.isEmpty()) {
+                        this.getProxy().getStorage().postAlterationOfStoredItems(
+                                StorageChannel.ITEMS,
+                                Collections.unmodifiableList(partitionedChanges),
+                                this.mySrc);
+                    }
                 } else {
                     this.getProxy().getStorage().postAlterationOfStoredItems(StorageChannel.ITEMS, change, this.mySrc);
                 }


### PR DESCRIPTION
Enables an item storage bus to only show filtered items and only allow the extraction of the filtered items.

Right now it uses the existing input partition list to determine the filtered items. 
To keep existing behavior the extraction filter is only active when access is set to read. This trigger could be replaced with a new setting or a new card.