### PR TITLE
Use escaping drop item name algorithm from NEI

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiInterfaceTerminal.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiInterfaceTerminal.java
@@ -948,9 +948,9 @@ public class GuiInterfaceTerminal extends AEBaseGui
 
     public void setTextFieldValue(final String displayName, final int mousex, final int mousey, final ItemStack stack) {
         if (searchFieldInputs.isMouseIn(mousex, mousey)) {
-            searchFieldInputs.setText(displayName);
+            searchFieldInputs.setText(NEI.searchField.getEscapedSearchText(displayName));
         } else if (searchFieldOutputs.isMouseIn(mousex, mousey)) {
-            searchFieldOutputs.setText(displayName);
+            searchFieldOutputs.setText(NEI.searchField.getEscapedSearchText(displayName));
         } else if (searchFieldNames.isMouseIn(mousex, mousey)) {
             searchFieldNames.setText(displayName);
         }

--- a/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
@@ -602,7 +602,7 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
     }
 
     public void setTextFieldValue(final String displayName, final int mousex, final int mousey, final ItemStack stack) {
-        searchField.setText(displayName);
+        searchField.setText(NEI.searchField.getEscapedSearchText(displayName));
     }
 
     @Override

--- a/src/main/java/appeng/client/gui/implementations/GuiOreFilter.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiOreFilter.java
@@ -53,8 +53,6 @@ public class GuiOreFilter extends AEBaseGui implements IDropToFillTextField {
             }
         };
 
-        this.textField.setMaxStringLength(120);
-
         if (NEI.searchField.existsSearchField()) {
             this.textField.setFormatter(new OreFilterTextFormatter());
         }

--- a/src/main/java/appeng/client/gui/implementations/GuiQuartzKnife.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiQuartzKnife.java
@@ -47,7 +47,6 @@ public class GuiQuartzKnife extends AEBaseGui implements IDropToFillTextField {
                 }
             }
         };
-        this.textField.setMaxStringLength(32);
     }
 
     @Override

--- a/src/main/java/appeng/client/gui/implementations/GuiRenamer.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiRenamer.java
@@ -11,7 +11,6 @@ import appeng.client.gui.AEBaseGui;
 import appeng.client.gui.widgets.IDropToFillTextField;
 import appeng.client.gui.widgets.MEGuiTextField;
 import appeng.container.implementations.ContainerRenamer;
-import appeng.core.AEConfig;
 import appeng.core.AELog;
 import appeng.core.localization.GuiColors;
 import appeng.core.localization.GuiText;
@@ -38,7 +37,6 @@ public class GuiRenamer extends AEBaseGui implements IDropToFillTextField {
                 }
             }
         };
-        this.textField.setMaxStringLength(AEConfig.instance.quartzKnifeInputLength);
     }
 
     @Override

--- a/src/main/java/appeng/client/gui/widgets/MEGuiTextField.java
+++ b/src/main/java/appeng/client/gui/widgets/MEGuiTextField.java
@@ -19,7 +19,6 @@ import net.minecraft.client.gui.GuiTextField;
 
 import org.lwjgl.input.Keyboard;
 
-import appeng.core.AEConfig;
 import appeng.core.localization.GuiColors;
 import codechicken.nei.FormattedTextField.TextFormatter;
 
@@ -70,7 +69,7 @@ public class MEGuiTextField implements ITooltip {
         h = height;
 
         field.setEnableBackgroundDrawing(false);
-        field.setMaxStringLength(AEConfig.instance.quartzKnifeInputLength);
+        field.setMaxStringLength(256);
         field.setTextColor(GuiColors.SearchboxText.getColor());
         field.setCursorPositionZero();
 

--- a/src/main/java/appeng/core/AEConfig.java
+++ b/src/main/java/appeng/core/AEConfig.java
@@ -64,6 +64,7 @@ public final class AEConfig extends Configuration implements IConfigurableObject
     public int quartzOresPerCluster = 4;
     public int quartzOresClusterAmount = 15;
     public final int chargedChange = 4;
+    @Deprecated
     public int quartzKnifeInputLength = 32;
     public int minMeteoriteDistance = 707;
     public int minMeteoriteDistanceSq = this.minMeteoriteDistance * this.minMeteoriteDistance;
@@ -310,8 +311,6 @@ public final class AEConfig extends Configuration implements IConfigurableObject
         this.preserveSearchBar = this.get("Client", "preserveSearchBar", true).getBoolean(true);
         this.showOnlyInterfacesWithFreeSlotsInInterfaceTerminal = this
                 .get("Client", "showOnlyInterfacesWithFreeSlotsInInterfaceTerminal", false).getBoolean(false);
-        this.quartzKnifeInputLength = this.get("Client", "quartzKnifeInputLength", this.quartzKnifeInputLength)
-                .getInt(this.quartzKnifeInputLength);
         this.MEMonitorableSmallSize = this.get("Client", "MEMonitorableSmallSize", 6).getInt(6);
         this.InterfaceTerminalSmallSize = this.get("Client", "InterfaceTerminalSmallSize", 6).getInt(6);
         // load buttons..

--- a/src/main/java/appeng/integration/modules/NEIHelpers/NEIGuiHandler.java
+++ b/src/main/java/appeng/integration/modules/NEIHelpers/NEIGuiHandler.java
@@ -1,34 +1,28 @@
 package appeng.integration.modules.NEIHelpers;
 
-import java.util.regex.Pattern;
-
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
+import net.minecraftforge.fluids.FluidStack;
 
 import appeng.client.gui.implementations.GuiCraftConfirm;
 import appeng.client.gui.implementations.GuiCraftingStatus;
 import appeng.client.gui.implementations.GuiMEMonitorable;
 import appeng.client.gui.widgets.IDropToFillTextField;
 import codechicken.nei.api.INEIGuiAdapter;
+import codechicken.nei.recipe.StackInfo;
 
 public class NEIGuiHandler extends INEIGuiAdapter {
-
-    protected static final Pattern SPECIAL_REGEX_CHARS = Pattern.compile("[{}()\\[\\].+*?^$\\\\|]");
 
     @Override
     public boolean handleDragNDrop(GuiContainer gui, int mousex, int mousey, ItemStack draggedStack, int button) {
 
-        if (draggedStack != null && draggedStack.getItem() != null && gui instanceof IDropToFillTextField gmm) {
+        if (draggedStack != null && draggedStack.getItem() != null
+                && (gui instanceof IDropToFillTextField gmm)
+                && gmm.isOverTextField(mousex, mousey)) {
+            gmm.setTextFieldValue(getItemStackText(draggedStack), mousex, mousey, draggedStack.copy());
 
-            if (gmm.isOverTextField(mousex, mousey)) {
-                gmm.setTextFieldValue(
-                        formattingText(draggedStack.getDisplayName()),
-                        mousex,
-                        mousey,
-                        draggedStack.copy());
-                return true;
-            }
+            return true;
         }
 
         return super.handleDragNDrop(gui, mousex, mousey, draggedStack, button);
@@ -47,8 +41,16 @@ public class NEIGuiHandler extends INEIGuiAdapter {
         return false;
     }
 
-    protected String formattingText(final String displayName) {
-        return SPECIAL_REGEX_CHARS.matcher(EnumChatFormatting.getTextWithoutFormattingCodes(displayName))
-                .replaceAll("\\\\$0");
+    protected static String getItemStackText(ItemStack stack) {
+        final FluidStack fluidStack = StackInfo.isFluidContainer(stack) ? null : StackInfo.getFluid(stack);
+        String displayName;
+
+        if (fluidStack != null) {
+            displayName = fluidStack.getLocalizedName();
+        } else {
+            displayName = stack.getDisplayName();
+        }
+
+        return EnumChatFormatting.getTextWithoutFormattingCodes(displayName);
     }
 }

--- a/src/main/java/appeng/integration/modules/NEIHelpers/NEISearchField.java
+++ b/src/main/java/appeng/integration/modules/NEIHelpers/NEISearchField.java
@@ -38,6 +38,16 @@ public class NEISearchField {
         return getSearchField() != null;
     }
 
+    public String getEscapedSearchText(String text) {
+        final SearchField searchField = getSearchField();
+
+        if (searchField != null) {
+            return SearchField.getEscapedSearchText(text);
+        }
+
+        return text;
+    }
+
     public void putFormatter(MEGuiTextField field) {
         final SearchField searchField = getSearchField();
 


### PR DESCRIPTION
1. Use Escaping settings from NEI
2. Change `MEGuiTextField.setMaxStringLength`. 256 is used because 32 is too small and the name of the dragNdrop element is longer