### PR TITLE
add different function for left and right key in ore dictionary filter gui

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiOreFilter.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiOreFilter.java
@@ -166,9 +166,17 @@ public class GuiOreFilter extends AEBaseGui implements IDropToFillTextField {
 
         if (ores.length > 0) {
 
+            // left click
             if (Mouse.isButtonDown(0)) {
-                // left click
-                textField.setText(textField.getText() + OreDictionary.getOreName(ores[0]));
+                // If had something in text field before
+                // add a ` | ` automatically
+                String oldText = textField.getText();
+                if (oldText.length() != 0) {
+                    oldText = oldText + " | ";
+                }
+
+                textField.setText(oldText + OreDictionary.getOreName(ores[0]));
+
             } else if (Mouse.isButtonDown(1)) {
                 // right click
                 textField.setText(OreDictionary.getOreName(ores[0]));

--- a/src/main/java/appeng/client/gui/implementations/GuiOreFilter.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiOreFilter.java
@@ -171,7 +171,7 @@ public class GuiOreFilter extends AEBaseGui implements IDropToFillTextField {
                 // If had something in text field before
                 // add a ` | ` automatically
                 String oldText = textField.getText();
-                if (oldText.length() != 0) {
+                if (!oldText.isEmpty()) {
                     oldText = oldText + " | ";
                 }
 

--- a/src/main/java/appeng/client/gui/implementations/GuiOreFilter.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiOreFilter.java
@@ -7,6 +7,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
 
 import org.lwjgl.input.Keyboard;
+import org.lwjgl.input.Mouse;
 
 import appeng.client.gui.AEBaseGui;
 import appeng.client.gui.widgets.IDropToFillTextField;
@@ -164,9 +165,19 @@ public class GuiOreFilter extends AEBaseGui implements IDropToFillTextField {
         final int[] ores = OreDictionary.getOreIDs(stack);
 
         if (ores.length > 0) {
-            textField.setText(OreDictionary.getOreName(ores[0]));
+
+            if (Mouse.isButtonDown(0)) {
+                // left click
+                textField.setText(textField.getText() + OreDictionary.getOreName(ores[0]));
+            } else if (Mouse.isButtonDown(1)) {
+                // right click
+                textField.setText(OreDictionary.getOreName(ores[0]));
+            }
+
         } else {
             textField.setText(displayName);
         }
+        // Move the cursor to end
+        textField.setCursorPositionEnd();
     }
 }

--- a/src/main/java/appeng/client/gui/implementations/GuiOreFilter.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiOreFilter.java
@@ -174,10 +174,8 @@ public class GuiOreFilter extends AEBaseGui implements IDropToFillTextField {
                 textField.setText(OreDictionary.getOreName(ores[0]));
             }
 
-        } else {
-            textField.setText(displayName);
+            // Move the cursor to end
+            textField.setCursorPositionEnd();
         }
-        // Move the cursor to end
-        textField.setCursorPositionEnd();
     }
 }


### PR DESCRIPTION

https://github.com/user-attachments/assets/076711c5-ef98-4292-97ac-f39260ddca1f

If drag some ore and click the text field before will clear it and insert new ore dict of what you hold.

Now if use left click will not clear it but append new ore dict at the end of the text field.
Right click will clear it like used to be.