### PR TITLE
Fix crafting notifications work only in single dimension

### DIFF
--- a/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
+++ b/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
@@ -26,12 +26,14 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.nbt.NBTTagString;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.ChatComponentTranslation;
@@ -416,8 +418,6 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
         }
 
         if (!this.playersFollowingCurrentCraft.isEmpty()) {
-
-            final World clusterWorld = this.getWorld();
             final String elapsedTimeText = DurationFormatUtils.formatDuration(
                     TimeUnit.MILLISECONDS.convert(this.getElapsedTime(), TimeUnit.NANOSECONDS),
                     GuiText.ETAFormat.getLocal());
@@ -429,11 +429,11 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
 
             for (String playerName : this.playersFollowingCurrentCraft) {
                 // Get each EntityPlayer
-                EntityPlayer pl = clusterWorld.getPlayerEntityByName(playerName);
-                if (pl != null) {
+                EntityPlayer player = getPlayerByName(playerName);
+                if (player != null) {
                     // Send message to player
-                    pl.addChatMessage(messageWaitToSend);
-                    clusterWorld.playSoundAtEntity(pl, "random.levelup", 1f, 1f);
+                    player.addChatMessage(messageWaitToSend);
+                    player.worldObj.playSoundAtEntity(player, "random.levelup", 1f, 1f);
                 }
             }
         }
@@ -446,6 +446,10 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
         this.numsOfOutput = 0;
         this.isComplete = true;
         this.playersFollowingCurrentCraft.clear();
+    }
+
+    private EntityPlayerMP getPlayerByName(String playerName) {
+        return MinecraftServer.getServer().getConfigurationManager().func_152612_a(playerName);
     }
 
     private void updateCPU() {


### PR DESCRIPTION
Previously, crafting notifications were bound to the dimension where the CPU cluster was working. This PR allows players to be notified regardless of their dimension.