### PR TITLE
Feature/sort interfaces alphanum order

### DIFF
--- a/src/main/java/appeng/api/config/Settings.java
+++ b/src/main/java/appeng/api/config/Settings.java
@@ -80,7 +80,9 @@ public enum Settings {
 
     PRIORITY_CARD_MODE(EnumSet.allOf(PriorityCardMode.class)),
 
-    TERMINAL_FONT_SIZE(EnumSet.allOf(TerminalFontSize.class));
+    TERMINAL_FONT_SIZE(EnumSet.allOf(TerminalFontSize.class)),
+
+    INTERFACE_TERMINAL_SECTION_ORDER(EnumSet.allOf(StringOrder.class));
 
     private final EnumSet<? extends Enum<?>> values;
 

--- a/src/main/java/appeng/api/config/StringOrder.java
+++ b/src/main/java/appeng/api/config/StringOrder.java
@@ -8,7 +8,7 @@ public enum StringOrder {
 
     NATURAL(Comparator.naturalOrder()),
 
-    ALPHANUM(new AlphanumComparator());
+    ALPHANUM(AlphanumComparator.INSTANCE);
 
     public final Comparator<String> comparator;
 

--- a/src/main/java/appeng/api/config/StringOrder.java
+++ b/src/main/java/appeng/api/config/StringOrder.java
@@ -1,0 +1,18 @@
+package appeng.api.config;
+
+import java.util.Comparator;
+
+import appeng.util.AlphanumComparator;
+
+public enum StringOrder {
+
+    NATURAL(Comparator.naturalOrder()),
+
+    ALPHANUM(new AlphanumComparator());
+
+    public final Comparator<String> comparator;
+
+    StringOrder(Comparator<String> comparator) {
+        this.comparator = comparator;
+    }
+}

--- a/src/main/java/appeng/client/gui/widgets/GuiImgButton.java
+++ b/src/main/java/appeng/client/gui/widgets/GuiImgButton.java
@@ -48,6 +48,7 @@ import appeng.api.config.SidelessMode;
 import appeng.api.config.SortDir;
 import appeng.api.config.SortOrder;
 import appeng.api.config.StorageFilter;
+import appeng.api.config.StringOrder;
 import appeng.api.config.TerminalStyle;
 import appeng.api.config.TypeFilter;
 import appeng.api.config.ViewItems;
@@ -767,6 +768,19 @@ public class GuiImgButton extends GuiButton implements ITooltip {
                     PriorityCardMode.DEC,
                     ButtonToolTips.PriorityCardMode,
                     ButtonToolTips.PriorityCardMode_Dec);
+
+            this.registerApp(
+                    64,
+                    Settings.INTERFACE_TERMINAL_SECTION_ORDER,
+                    StringOrder.NATURAL,
+                    ButtonToolTips.StringOrder,
+                    ButtonToolTips.StringOrderNatural);
+            this.registerApp(
+                    65,
+                    Settings.INTERFACE_TERMINAL_SECTION_ORDER,
+                    StringOrder.ALPHANUM,
+                    ButtonToolTips.StringOrder,
+                    ButtonToolTips.StringOrderAlphanum);
 
         }
     }

--- a/src/main/java/appeng/client/gui/widgets/GuiImgButton.java
+++ b/src/main/java/appeng/client/gui/widgets/GuiImgButton.java
@@ -777,7 +777,7 @@ public class GuiImgButton extends GuiButton implements ITooltip {
                     ButtonToolTips.StringOrder,
                     ButtonToolTips.StringOrderNatural);
             this.registerApp(
-                    65,
+                    16,
                     Settings.INTERFACE_TERMINAL_SECTION_ORDER,
                     StringOrder.ALPHANUM,
                     ButtonToolTips.StringOrder,

--- a/src/main/java/appeng/core/AEConfig.java
+++ b/src/main/java/appeng/core/AEConfig.java
@@ -27,6 +27,7 @@ import appeng.api.config.PowerUnits;
 import appeng.api.config.SearchBoxMode;
 import appeng.api.config.Settings;
 import appeng.api.config.SortDir;
+import appeng.api.config.StringOrder;
 import appeng.api.config.TerminalFontSize;
 import appeng.api.config.TerminalStyle;
 import appeng.api.config.YesNo;
@@ -158,6 +159,7 @@ public final class AEConfig extends Configuration implements IConfigurableObject
         this.settings.registerSetting(Settings.CRAFTING_SORT_BY, CraftingSortOrder.NAME);
         this.settings.registerSetting(Settings.SORT_DIRECTION, SortDir.ASCENDING);
         this.settings.registerSetting(Settings.TERMINAL_FONT_SIZE, TerminalFontSize.SMALL);
+        this.settings.registerSetting(Settings.INTERFACE_TERMINAL_SECTION_ORDER, StringOrder.NATURAL);
 
         this.spawnChargedChance = (float) (1.0
                 - this.get("worldGen", "spawnChargedChance", 1.0 - this.spawnChargedChance)

--- a/src/main/java/appeng/core/localization/ButtonToolTips.java
+++ b/src/main/java/appeng/core/localization/ButtonToolTips.java
@@ -214,7 +214,11 @@ public enum ButtonToolTips {
     PriorityCardMode_Inc,
     PriorityCardMode_Dec,
     ToFollow,
-    ToUnfollow;
+    ToUnfollow,
+
+    StringOrder,
+    StringOrderNatural,
+    StringOrderAlphanum;
 
     private final String root;
 

--- a/src/main/java/appeng/util/AlphanumComparator.java
+++ b/src/main/java/appeng/util/AlphanumComparator.java
@@ -27,22 +27,12 @@ package appeng.util;
 
 import java.util.Comparator;
 
-// spotless:off
 /**
- * This is an updated version with enhancements made by Daniel Migowski,
- * Andre Bogus, and David Koelle
- * <p/>
- * To convert to use Templates (Java 1.5+):
- * - Change "implements Comparator" to "implements Comparator<String>"
- * - Change "compare(Object o1, Object o2)" to "compare(String s1, String s2)"
- * - Remove the type checking and casting in compare().
- * <p/>
- * To use this class:
- * Use the static "sort" method from the java.util.Collections class:
- * Collections.sort(your list, new AlphanumComparator());
+ * This is an updated version with enhancements made by Daniel Migowski, Andre Bogus, and David Koelle
  */
-// spotless:on
 public class AlphanumComparator implements Comparator<String> {
+
+    public final static AlphanumComparator INSTANCE = new AlphanumComparator();
 
     private final boolean isDigit(char ch) {
         return ch >= 48 && ch <= 57;

--- a/src/main/java/appeng/util/AlphanumComparator.java
+++ b/src/main/java/appeng/util/AlphanumComparator.java
@@ -1,0 +1,118 @@
+package appeng.util;
+// spotless:off
+/*
+ * The Alphanum Algorithm is an improved sorting algorithm for strings
+ * containing numbers.  Instead of sorting numbers in ASCII order like
+ * a standard sort, this algorithm sorts numbers in numeric order.
+ *
+ * The Alphanum Algorithm is discussed at http://www.DaveKoelle.com
+ *
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+// spotless:on
+
+import java.util.Comparator;
+
+// spotless:off
+/**
+ * This is an updated version with enhancements made by Daniel Migowski,
+ * Andre Bogus, and David Koelle
+ * <p/>
+ * To convert to use Templates (Java 1.5+):
+ * - Change "implements Comparator" to "implements Comparator<String>"
+ * - Change "compare(Object o1, Object o2)" to "compare(String s1, String s2)"
+ * - Remove the type checking and casting in compare().
+ * <p/>
+ * To use this class:
+ * Use the static "sort" method from the java.util.Collections class:
+ * Collections.sort(your list, new AlphanumComparator());
+ */
+// spotless:on
+public class AlphanumComparator implements Comparator<String> {
+
+    private final boolean isDigit(char ch) {
+        return ch >= 48 && ch <= 57;
+    }
+
+    /**
+     * Length of string is passed in for improved efficiency (only need to calculate it once) *
+     */
+    private final String getChunk(String s, int slength, int marker) {
+        StringBuilder chunk = new StringBuilder();
+        char c = s.charAt(marker);
+        chunk.append(c);
+        marker++;
+        if (isDigit(c)) {
+            while (marker < slength) {
+                c = s.charAt(marker);
+                if (!isDigit(c)) break;
+                chunk.append(c);
+                marker++;
+            }
+        } else {
+            while (marker < slength) {
+                c = s.charAt(marker);
+                if (isDigit(c)) break;
+                chunk.append(c);
+                marker++;
+            }
+        }
+        return chunk.toString();
+    }
+
+    public int compare(String s1, String s2) {
+        if (s1 == null || s2 == null) {
+            return 0;
+        }
+
+        int thisMarker = 0;
+        int thatMarker = 0;
+        int s1Length = s1.length();
+        int s2Length = s2.length();
+
+        while (thisMarker < s1Length && thatMarker < s2Length) {
+            String thisChunk = getChunk(s1, s1Length, thisMarker);
+            thisMarker += thisChunk.length();
+
+            String thatChunk = getChunk(s2, s2Length, thatMarker);
+            thatMarker += thatChunk.length();
+
+            // If both chunks contain numeric characters, sort them numerically
+            int result = 0;
+            if (isDigit(thisChunk.charAt(0)) && isDigit(thatChunk.charAt(0))) {
+                // Simple chunk comparison by length.
+                int thisChunkLength = thisChunk.length();
+                result = thisChunkLength - thatChunk.length();
+                // If equal, the first different number counts
+                if (result == 0) {
+                    for (int i = 0; i < thisChunkLength; i++) {
+                        result = thisChunk.charAt(i) - thatChunk.charAt(i);
+                        if (result != 0) {
+                            return result;
+                        }
+                    }
+                }
+            } else {
+                result = thisChunk.compareTo(thatChunk);
+            }
+
+            if (result != 0) return result;
+        }
+
+        return s1Length - s2Length;
+    }
+}

--- a/src/main/java/appeng/util/AlphanumComparator.java
+++ b/src/main/java/appeng/util/AlphanumComparator.java
@@ -1,4 +1,5 @@
 package appeng.util;
+// This code is copied from the library https://github.com/metamx/alphanum
 // spotless:off
 /*
  * The Alphanum Algorithm is an improved sorting algorithm for strings

--- a/src/main/resources/assets/appliedenergistics2/lang/en_US.lang
+++ b/src/main/resources/assets/appliedenergistics2/lang/en_US.lang
@@ -527,6 +527,10 @@ gui.tooltips.appliedenergistics2.MultiplyOrDividePatternHint=If it's positive, i
 gui.tooltips.appliedenergistics2.ToFollow=Click to follow this craft and receive message when it is complete\nYou are not following this crafting job right now
 gui.tooltips.appliedenergistics2.ToUnfollow=Click to stop following this craft\nYou are following this crafting job and will receive chat message when it's complete
 
+gui.tooltips.appliedenergistics2.StringOrder=Sorting
+gui.tooltips.appliedenergistics2.StringOrderNatural=Default
+gui.tooltips.appliedenergistics2.StringOrderAlphanum=Natural Order
+
 # Units
 gui.appliedenergistics2.units.appliedenergstics=AE
 gui.appliedenergistics2.units.ic2=Energy Units

--- a/src/main/resources/assets/appliedenergistics2/lang/zh_CN.lang
+++ b/src/main/resources/assets/appliedenergistics2/lang/zh_CN.lang
@@ -527,6 +527,10 @@ gui.tooltips.appliedenergistics2.MultiplyOrDividePatternHint=如果是正数,就
 gui.tooltips.appliedenergistics2.ToFollow=当前并未订阅该合成的消息\n当该合成完成时将不会接收到消息提示\n点击即可订阅
 gui.tooltips.appliedenergistics2.ToUnfollow=当前已经订阅该合成的消息\n当该合成完成时将会接收到消息提示\n点击即可取消
 
+gui.tooltips.appliedenergistics2.StringOrder=排序方式
+gui.tooltips.appliedenergistics2.StringOrderNatural=默认排序
+gui.tooltips.appliedenergistics2.StringOrderAlphanum=自然数序
+
 # Units
 gui.appliedenergistics2.units.appliedenergstics=AE
 gui.appliedenergistics2.units.ic2=EU


### PR DESCRIPTION
Allows sorting the interface terminal by natural order instead of alphabetical.
Reuses existing textures, for distinction new textures may be better but i can't do art.

| Default order | Natural order |
|----|----|
|![image](https://github.com/user-attachments/assets/ffab3048-d73f-4c4c-8bd8-5940d397eb01)|![image](https://github.com/user-attachments/assets/58ceaeac-5459-4ae2-8bcb-75c18f9f3e10)|

