### PR TITLE
Feature/Blood Magic Compat

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -44,4 +44,5 @@ dependencies {
     runtimeOnlyNonPublishable('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev')
     runtimeOnlyNonPublishable('com.github.GTNewHorizons:ThaumicEnergistics:1.6.22-GTNH:dev') { transitive = false }
     runtimeOnlyNonPublishable('com.github.GTNewHorizons:AE2FluidCraft-Rework:1.3.29-gtnh:dev') { transitive = false }
+    runtimeOnlyNonPublishable("com.github.GTNewHorizons:BloodMagic:1.6.2")
 }

--- a/src/main/java/appeng/helpers/BlockingModeIgnoreList.java
+++ b/src/main/java/appeng/helpers/BlockingModeIgnoreList.java
@@ -165,6 +165,23 @@ public class BlockingModeIgnoreList {
             IgnoredItems.add(GameRegistry.findItem("dreamcraft", "item.ChromaticLens"));
             IgnoredItems.add(GameRegistry.findItem("bartworks", "gt.bwMetaGeneratedlens"));
         }
+
+        if (Loader.isModLoaded("AWWayofTime")) { // blood magic
+            IgnoredItems.add(GameRegistry.findItem("AWWayofTime", "weakBloodOrb"));
+            IgnoredItems.add(GameRegistry.findItem("AWWayofTime", "apprenticeBloodOrb"));
+            IgnoredItems.add(GameRegistry.findItem("AWWayofTime", "magicianBloodOrb"));
+            IgnoredItems.add(GameRegistry.findItem("AWWayofTime", "masterBloodOrb"));
+            IgnoredItems.add(GameRegistry.findItem("AWWayofTime", "archmageBloodOrb"));
+            IgnoredItems.add(GameRegistry.findItem("AWWayofTime", "transcendentBloodOrb"));
+
+            if (Loader.isModLoaded("Avaritia")) {
+                IgnoredItems.add(GameRegistry.findItem("Avaritia", "Orb_Armok"));
+            }
+
+            if (Loader.isModLoaded("ForbiddenMagic")) {
+                IgnoredItems.add(GameRegistry.findItem("ForbiddenMagic", "EldritchOrb"));
+            }
+        }
     }
 
     public static boolean isIgnored(ItemStack is) {

--- a/src/main/java/appeng/helpers/DualityInterface.java
+++ b/src/main/java/appeng/helpers/DualityInterface.java
@@ -870,8 +870,8 @@ public class DualityInterface implements IGridTickable, IStorageMonitorable, IIn
 
     private boolean inventoryCountsAsEmpty(TileEntity te, InventoryAdaptor ad, ForgeDirection side) {
         String name = te.getBlockType().getUnlocalizedName();
-        boolean isEmpty = (name.equals("gt.blockmachines") || name.equals("tile.interface") || name.equals("tile.blockWritingTable"))
-                && tileHasOnlyIgnoredItems(ad);
+        boolean isEmpty = (name.equals("gt.blockmachines") || name.equals("tile.interface")
+                || name.equals("tile.blockWritingTable")) && tileHasOnlyIgnoredItems(ad);
         if (shouldCheckFluid()) {
             isEmpty = name.equals("tile.interface");
         }

--- a/src/main/java/appeng/helpers/DualityInterface.java
+++ b/src/main/java/appeng/helpers/DualityInterface.java
@@ -854,10 +854,10 @@ public class DualityInterface implements IGridTickable, IStorageMonitorable, IIn
         };
     }
 
-    private boolean gtMachineHasOnlyCircuit(InventoryAdaptor ad) {
+    private boolean tileHasOnlyIgnoredItems(InventoryAdaptor ad) {
         for (ItemSlot i : ad) {
             ItemStack is = i.getItemStack();
-            if (BlockingModeIgnoreList.isIgnored(is)) continue;
+            if (BlockingModeIgnoreList.isIgnored(is) || is == null) continue;
             return false;
         }
         return true;
@@ -870,8 +870,8 @@ public class DualityInterface implements IGridTickable, IStorageMonitorable, IIn
 
     private boolean inventoryCountsAsEmpty(TileEntity te, InventoryAdaptor ad, ForgeDirection side) {
         String name = te.getBlockType().getUnlocalizedName();
-        boolean isEmpty = (name.equals("gt.blockmachines") || name.equals("tile.interface"))
-                && gtMachineHasOnlyCircuit(ad);
+        boolean isEmpty = (name.equals("gt.blockmachines") || name.equals("tile.interface") || name.equals("tile.blockWritingTable"))
+                && tileHasOnlyIgnoredItems(ad);
         if (shouldCheckFluid()) {
             isEmpty = name.equals("tile.interface");
         }


### PR DESCRIPTION
This PR adds the **Blood Orbs** to the **Ignore List of Interface Blocking Mode** like virtual circuits in the GT machines, to make it better and easier to automate the alchemic chemistry sets.