### PR TITLE
Add blue light for drive and ME chest

### DIFF
--- a/src/main/java/appeng/client/render/blocks/RenderDrive.java
+++ b/src/main/java/appeng/client/render/blocks/RenderDrive.java
@@ -334,9 +334,12 @@ public class RenderDrive extends BaseBlockRender<BlockDrive, TileDrive> {
                         Tessellator.instance.setColorOpaque_I(0x00ff00);
                     }
                     if (stat == 2) {
-                        Tessellator.instance.setColorOpaque_I(0xffaa00);
+                        Tessellator.instance.setColorOpaque_I(0x00aaff);
                     }
                     if (stat == 3) {
+                        Tessellator.instance.setColorOpaque_I(0xffaa00);
+                    }
+                    if (stat == 4) {
                         Tessellator.instance.setColorOpaque_I(0xff0000);
                     }
 

--- a/src/main/java/appeng/client/render/blocks/RenderMEChest.java
+++ b/src/main/java/appeng/client/render/blocks/RenderMEChest.java
@@ -118,9 +118,12 @@ public class RenderMEChest extends BaseBlockRender<BlockChest, TileChest> {
                 Tessellator.instance.setColorOpaque_I(0x00ff00);
             }
             if (stat == 2) {
-                Tessellator.instance.setColorOpaque_I(0xffaa00);
+                Tessellator.instance.setColorOpaque_I(0x00aaff);
             }
             if (stat == 3) {
+                Tessellator.instance.setColorOpaque_I(0xffaa00);
+            }
+            if (stat == 4) {
                 Tessellator.instance.setColorOpaque_I(0xff0000);
             }
             this.selectFace(renderer, west, up, forward, 9, 10, 11, 12);

--- a/src/main/java/appeng/me/storage/CellInventory.java
+++ b/src/main/java/appeng/me/storage/CellInventory.java
@@ -540,12 +540,15 @@ public class CellInventory implements ICellInventory {
 
     @Override
     public int getStatusForCell() {
-        if (this.canHoldNewItem()) {
+        if (this.getStoredItemCount() == 0) {
             return 1;
         }
-        if (this.getRemainingItemCount() > 0) {
+        if (this.canHoldNewItem()) {
             return 2;
         }
-        return 3;
+        if (this.getRemainingItemCount() > 0) {
+            return 3;
+        }
+        return 4;
     }
 }

--- a/src/main/java/appeng/me/storage/CellInventoryHandler.java
+++ b/src/main/java/appeng/me/storage/CellInventoryHandler.java
@@ -118,8 +118,8 @@ public class CellInventoryHandler extends MEInventoryHandler<IAEItemStack>
     public int getStatusForCell() {
         int val = this.getCellInv().getStatusForCell();
 
-        if (val == 1 && this.isPreformatted()) {
-            val = 2;
+        if ((val == 1 || val == 2) && this.isPreformatted()) {
+            val = 3;
         }
 
         return val;

--- a/src/main/java/appeng/tile/storage/TileChest.java
+++ b/src/main/java/appeng/tile/storage/TileChest.java
@@ -144,11 +144,11 @@ public class TileChest extends AENetworkPowerTile implements IMEChest, IFluidHan
         int newState = 0;
 
         for (int x = 0; x < this.getCellCount(); x++) {
-            newState |= (this.getCellStatus(x) << (2 * x));
+            newState |= (this.getCellStatus(x) << (3 * x));
         }
 
         if (this.isPowered()) {
-            newState |= 0b100;
+            newState |= 0b1000;
         }
 
         final boolean currentActive = this.getProxy().isActive();
@@ -258,7 +258,7 @@ public class TileChest extends AENetworkPowerTile implements IMEChest, IFluidHan
     @Override
     public int getCellStatus(final int slot) {
         if (Platform.isClient()) {
-            return (this.state >> (slot * 2)) & 0b11;
+            return (this.state >> (slot * 3)) & 0b111;
         }
 
         final ItemStack cell = this.inv.getStackInSlot(1);
@@ -286,7 +286,7 @@ public class TileChest extends AENetworkPowerTile implements IMEChest, IFluidHan
     @Override
     public boolean isPowered() {
         if (Platform.isClient()) {
-            return (this.state & 0b100) == 0b100;
+            return (this.state & 0b1000) == 0b1000;
         }
 
         boolean gridPowered = this.getAECurrentPower() > 64;
@@ -329,14 +329,14 @@ public class TileChest extends AENetworkPowerTile implements IMEChest, IFluidHan
         try {
             if (!this.getProxy().getEnergy().isNetworkPowered()) {
                 final double powerUsed = this.extractAEPower(idleUsage, Actionable.MODULATE, PowerMultiplier.CONFIG); // drain
-                if (powerUsed + 0.1 >= idleUsage != (this.state & 0b100) > 0) {
+                if (powerUsed + 0.1 >= idleUsage != (this.state & 0b1000) > 0) {
                     this.recalculateDisplay();
                 }
             }
         } catch (final GridAccessException e) {
             final double powerUsed = this
                     .extractAEPower(this.getProxy().getIdlePowerUsage(), Actionable.MODULATE, PowerMultiplier.CONFIG); // drain
-            if (powerUsed + 0.1 >= idleUsage != (this.state & 0b100) > 0) {
+            if (powerUsed + 0.1 >= idleUsage != (this.state & 0b1000) > 0) {
                 this.recalculateDisplay();
             }
         }
@@ -365,7 +365,7 @@ public class TileChest extends AENetworkPowerTile implements IMEChest, IFluidHan
         final int oldState = this.state;
         final ItemStack oldType = this.storageType;
 
-        this.state = data.readByte() & 0b111;
+        this.state = data.readByte() & 0b1111;
         final AEColor oldPaintedColor = this.paintedColor;
         this.paintedColor = AEColor.values()[data.readByte()];
 

--- a/src/main/java/appeng/tile/storage/TileDrive.java
+++ b/src/main/java/appeng/tile/storage/TileDrive.java
@@ -68,8 +68,8 @@ public class TileDrive extends AENetworkInvTile implements IChestOrDrive, IPrior
     /**
      * Masks the part of {@link #state} that contains information
      */
-    private static final int STATE_MASK = 0b111111111111111111111;
-    private static final int STATE_ACTIVE_MASK = 1 << 20;
+    private static final int STATE_MASK = 0b1111111111111111111111111111111;
+    private static final int STATE_ACTIVE_MASK = 1 << 30;
 
     private final int[] sides = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
     private final AppEngInternalInventory inv = new AppEngInternalInventory(this, INV_SIZE);
@@ -106,7 +106,7 @@ public class TileDrive extends AENetworkInvTile implements IChestOrDrive, IPrior
     @Override
     public int getCellStatus(final int slot) {
         if (Platform.isClient()) {
-            return (this.state >> (slot * 2)) & 0b11;
+            return (this.state >> (slot * 3)) & 0b111;
         }
 
         final ItemStack cell = this.inv.getStackInSlot(2);
@@ -192,7 +192,7 @@ public class TileDrive extends AENetworkInvTile implements IChestOrDrive, IPrior
         }
 
         for (int x = 0; x < this.getCellCount(); x++) {
-            newState |= ((this.getCellStatus(x) & 0b11) << (2 * x));
+            newState |= ((this.getCellStatus(x) & 0b111) << (3 * x));
         }
 
         if (this.state != newState) {


### PR DESCRIPTION
![3R@ ALY521K}O`XW)I5UJEM](https://github.com/user-attachments/assets/e31dc501-6357-4e65-945c-aa54113826bf)

Previously only had three light:
- GREEN for cell which can insert item and new type
- ORANGE for type is full
- RED for bytes  if full

After this will have four light:
- GREEN for total empty cell
- BLUE for cell which can insert item and new type
- ORANGE for type is full
- RED for bytes  if full

this function in higher version AE look like
![Cache_-27fadf77b837c5e5](https://github.com/user-attachments/assets/3c28fc46-c2c5-4e97-867e-e0b6fa33bfb1)
