### PR TITLE
Allow crafting notifications to be sent on next player login

### DIFF
--- a/src/main/java/appeng/me/cluster/MBCalculator.java
+++ b/src/main/java/appeng/me/cluster/MBCalculator.java
@@ -17,6 +17,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 import appeng.api.util.WorldCoord;
 import appeng.core.AELog;
 import appeng.util.Platform;
+import cpw.mods.fml.common.FMLCommonHandler;
 
 public abstract class MBCalculator {
 
@@ -72,6 +73,7 @@ public abstract class MBCalculator {
                     boolean updateGrid = false;
                     final IAECluster cluster = this.target.getCluster();
                     if (cluster == null) {
+                        FMLCommonHandler.instance().bus().register(c);
                         this.updateTiles(c, world, min, max);
 
                         updateGrid = true;

--- a/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
+++ b/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
@@ -1518,4 +1518,51 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
 
         private long value;
     }
+
+    private static class CraftNotification {
+
+        private ItemStack finalOutput;
+        private long outputsCount;
+        private long elapsedTime;
+
+        public CraftNotification() {
+            this.finalOutput = null;
+            this.outputsCount = 0L;
+            this.elapsedTime = 0L;
+        }
+
+        public CraftNotification(ItemStack finalOutput, long outputsCount, long elapsedTime) {
+            this.finalOutput = finalOutput;
+            this.outputsCount = outputsCount;
+            this.elapsedTime = elapsedTime;
+        }
+
+        public IChatComponent createMessage() {
+            final String elapsedTimeText = DurationFormatUtils.formatDuration(
+                    TimeUnit.MILLISECONDS.convert(this.elapsedTime, TimeUnit.NANOSECONDS),
+                    GuiText.ETAFormat.getLocal());
+            return PlayerMessages.FinishCraftingRemind.get(
+                    new ChatComponentText(EnumChatFormatting.GREEN + String.valueOf(this.outputsCount)),
+                    this.finalOutput.func_151000_E(),
+                    new ChatComponentText(EnumChatFormatting.GREEN + elapsedTimeText));
+        }
+
+        public void readFromNBT(NBTTagCompound tag) {
+            if (tag.hasKey("finalOutput")) {
+                this.finalOutput = ItemStack.loadItemStackFromNBT(tag.getCompoundTag("finalOutput"));
+            }
+            this.outputsCount = tag.getLong("outputsCount");
+            this.elapsedTime = tag.getLong("elapsedTime");
+        }
+
+        public void writeToNBT(NBTTagCompound tag) {
+            if (this.finalOutput != null) {
+                NBTTagCompound finalOutputTag = new NBTTagCompound();
+                this.finalOutput.writeToNBT(finalOutputTag);
+                tag.setTag("finalOutput", finalOutputTag);
+            }
+            tag.setLong("outputsCount", this.outputsCount);
+            tag.setLong("elapsedTime", this.elapsedTime);
+        }
+    }
 }


### PR DESCRIPTION
Currently crafting notifications are only sent to players that are online. If the player starts a long craft, follows it and leaves server then one will not be notified if craft finishes while the player is offline. This PR introduces logic for storing such notifications and sending ones when the player logs in next time.

### Question

This feature requires that the instance of `CraftingCPUCluster` is registered as event handler. This should happen on server start and when multiblock is (re-)assembled. The instance should also be properly unregistered to prevent flooding event bus with dead instances.
Is there better place in code to register and unregister event handler?
