### PR TITLE
Remove Unnecessary `IllegalStateException` for Shared Input/Output Patterns

### DIFF
--- a/src/main/java/appeng/crafting/v2/resolvers/CraftableItemResolver.java
+++ b/src/main/java/appeng/crafting/v2/resolvers/CraftableItemResolver.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 
+import appeng.crafting.v2.resolvers.CraftingTask.State;
 import net.minecraft.world.World;
 
 import org.apache.logging.log4j.Level;
@@ -131,12 +132,12 @@ public class CraftableItemResolver implements CraftingRequestResolver<IAEItemSta
                     break;
                 }
             }
-            if (matchingOutput == null) {
-                state = State.FAILURE;
-                throw new IllegalStateException("Invalid pattern crafting step for " + request);
-            }
 
             this.matchingOutput = matchingOutput;
+
+            if (matchingOutput == null) {
+                state = State.FAILURE;
+            }
         }
 
         @SuppressWarnings("unused")
@@ -658,10 +659,16 @@ public class CraftableItemResolver implements CraftingRequestResolver<IAEItemSta
             if (context.isPatternComplex(pattern)) {
                 logComplexPattrn(pattern, request.remainingToProcess);
                 for (int i = 0; i < request.remainingToProcess; i++) {
-                    tasks.add(new CraftFromPatternTask(request, pattern, priority, false, true));
+                    CraftFromPatternTask task = new CraftFromPatternTask(request, pattern, priority, false, true);
+                    if (task.getState() != State.FAILURE) {
+                        tasks.add(task);
+                    }
                 }
             } else {
-                tasks.add(new CraftFromPatternTask(request, pattern, priority, false, false));
+                CraftFromPatternTask task = new CraftFromPatternTask(request, pattern, priority, false, false);
+                if (task.getState() != State.FAILURE) {
+                    tasks.add(task);
+                }
             }
             priority--;
         }
@@ -670,11 +677,16 @@ public class CraftableItemResolver implements CraftingRequestResolver<IAEItemSta
             ICraftingPatternDetails pattern = patterns.get(0);
             if (context.isPatternComplex(pattern)) {
                 for (int i = 0; i < request.remainingToProcess; i++) {
-                    tasks.add(new CraftFromPatternTask(request, pattern, priority, true, true));
+                    CraftFromPatternTask task = new CraftFromPatternTask(request, pattern, priority, true, true);
+                    if (task.getState() != State.FAILURE) {
+                        tasks.add(task);
+                    }
                 }
             } else {
-                tasks.add(
-                        new CraftFromPatternTask(request, pattern, CraftingTask.PRIORITY_SIMULATE_CRAFT, true, false));
+                CraftFromPatternTask task = new CraftFromPatternTask(request, pattern, CraftingTask.PRIORITY_SIMULATE_CRAFT, true, false);
+                if (task.getState() != State.FAILURE) {
+                    tasks.add(task);
+                }
             }
         }
 

--- a/src/main/java/appeng/crafting/v2/resolvers/CraftableItemResolver.java
+++ b/src/main/java/appeng/crafting/v2/resolvers/CraftableItemResolver.java
@@ -15,7 +15,6 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 
-import appeng.crafting.v2.resolvers.CraftingTask.State;
 import net.minecraft.world.World;
 
 import org.apache.logging.log4j.Level;
@@ -35,6 +34,7 @@ import appeng.crafting.v2.CraftingRequest;
 import appeng.crafting.v2.CraftingRequest.SubstitutionMode;
 import appeng.crafting.v2.CraftingTreeSerializer;
 import appeng.crafting.v2.ITreeSerializable;
+import appeng.crafting.v2.resolvers.CraftingTask.State;
 import appeng.me.cluster.implementations.CraftingCPUCluster;
 import appeng.util.Platform;
 import appeng.util.item.AEItemStack;
@@ -683,7 +683,12 @@ public class CraftableItemResolver implements CraftingRequestResolver<IAEItemSta
                     }
                 }
             } else {
-                CraftFromPatternTask task = new CraftFromPatternTask(request, pattern, CraftingTask.PRIORITY_SIMULATE_CRAFT, true, false);
+                CraftFromPatternTask task = new CraftFromPatternTask(
+                        request,
+                        pattern,
+                        CraftingTask.PRIORITY_SIMULATE_CRAFT,
+                        true,
+                        false);
                 if (task.getState() != State.FAILURE) {
                     tasks.add(task);
                 }


### PR DESCRIPTION
Patterns with shared input and output items could cause excessive log bloat due to repeated `IllegalStateException` errors. This change maintains the behavior of `CraftingItemResolver` while preventing unnecessary exceptions.