### PR TITLE
Fix AEFluidStack.loadFluidStackFromNBT not properly implemented

### DIFF
--- a/src/main/java/appeng/util/item/AEFluidStack.java
+++ b/src/main/java/appeng/util/item/AEFluidStack.java
@@ -72,11 +72,11 @@ public final class AEFluidStack extends AEStack<IAEFluidStack> implements IAEFlu
     }
 
     public static IAEFluidStack loadFluidStackFromNBT(final NBTTagCompound i) {
-        final ItemStack itemstack = ItemStack.loadItemStackFromNBT(i);
-        if (itemstack == null) {
+        final FluidStack fluidstack = FluidStack.loadFluidStackFromNBT(i);
+        if (fluidstack == null) {
             return null;
         }
-        final AEFluidStack fluid = AEFluidStack.create(itemstack);
+        final AEFluidStack fluid = AEFluidStack.create(fluidstack);
         // fluid.priority = i.getInteger( "Priority" );
         fluid.setStackSize(i.getLong("Cnt"));
         fluid.setCountRequestable(i.getLong("Req"));

--- a/src/main/java/appeng/util/item/AEFluidStack.java
+++ b/src/main/java/appeng/util/item/AEFluidStack.java
@@ -19,7 +19,6 @@ import java.nio.charset.StandardCharsets;
 
 import javax.annotation.Nonnull;
 
-import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompressedStreamTools;
 import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;


### PR DESCRIPTION
Before fix, this method always returns null.
By the way, it seems that no one uses this method currently.