### PR TITLE
Fix scroll bar drag click

### DIFF
--- a/src/main/java/appeng/client/gui/AEBaseGui.java
+++ b/src/main/java/appeng/client/gui/AEBaseGui.java
@@ -384,7 +384,7 @@ public abstract class AEBaseGui extends GuiContainer {
         final ItemStack itemstack = this.mc.thePlayer.inventory.getItemStack();
 
         if (this.getScrollBar() != null) {
-            this.getScrollBar().click(this, x - this.guiLeft, y - this.guiTop);
+            this.getScrollBar().clickMove(y - this.guiTop);
         }
 
         if (slot instanceof SlotFake && itemstack != null) {

--- a/src/main/java/appeng/client/gui/implementations/GuiPatternTermEx.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiPatternTermEx.java
@@ -232,7 +232,7 @@ public class GuiPatternTermEx extends GuiMEMonitorable {
     @Override
     protected void mouseClickMove(final int x, final int y, final int c, final long d) {
         final int currentScroll = this.processingScrollBar.getCurrentScroll();
-        this.processingScrollBar.click(this, x - this.guiLeft, y - this.guiTop);
+        this.processingScrollBar.clickMove(y - this.guiTop);
         super.mouseClickMove(x, y, c, d);
 
         if (currentScroll != this.processingScrollBar.getCurrentScroll()) {

--- a/src/main/java/appeng/client/gui/widgets/GuiCraftingCPUTable.java
+++ b/src/main/java/appeng/client/gui/widgets/GuiCraftingCPUTable.java
@@ -294,7 +294,7 @@ public class GuiCraftingCPUTable {
      */
     public void mouseClickMove(int xCoord, int yCoord) {
         if (cpuScrollbar != null) {
-            cpuScrollbar.click(parent, xCoord, yCoord);
+            cpuScrollbar.clickMove(yCoord);
         }
     }
 

--- a/src/main/java/appeng/client/gui/widgets/GuiScrollbar.java
+++ b/src/main/java/appeng/client/gui/widgets/GuiScrollbar.java
@@ -31,6 +31,7 @@ public class GuiScrollbar implements IScrollSource {
     private int minScroll = 0;
     private int currentScroll = 0;
     private boolean visible = true;
+    private boolean isLatestClickOnScrollbar;
 
     public void setTexture(final String base, final String file, final int shiftX, final int shiftY) {
         txtBase = base;
@@ -133,8 +134,22 @@ public class GuiScrollbar implements IScrollSource {
         if (this.getRange() == 0) {
             return;
         }
-
         if (this.contains(x, y)) {
+            this.currentScroll = (y - this.displayY);
+            this.currentScroll = this.minScroll + ((this.currentScroll * 2 * this.getRange() / this.height));
+            this.currentScroll = (this.currentScroll + 1) >> 1;
+            this.applyRange();
+            isLatestClickOnScrollbar = true;
+        } else {
+            isLatestClickOnScrollbar = false;
+        }
+    }
+
+    public void clickMove(final int y) {
+        if (this.getRange() == 0 || !isLatestClickOnScrollbar) {
+            return;
+        }
+        if (y >= this.displayY && y <= this.displayY + this.height) {
             this.currentScroll = (y - this.displayY);
             this.currentScroll = this.minScroll + ((this.currentScroll * 2 * this.getRange() / this.height));
             this.currentScroll = (this.currentScroll + 1) >> 1;


### PR DESCRIPTION
This PR fixes the following bug :

In any AE2 gui if you click on the scrollbar and keep the mouse pressed and then you move the mouse up and down to scroll the menu, it will check if your mouse on the X axis is within the width of the scrool bar which makes scrolling stop as soon as your mouse leaves the width of the scrollbar even if your mouse button is still pressed.