### PR TITLE
Add Search Cache to Terminal

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiInterfaceTerminal.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiInterfaceTerminal.java
@@ -909,11 +909,13 @@ public class GuiInterfaceTerminal extends AEBaseGui
 
         final NBTTagList tags = encodedValue.getTagList(in ? "in" : "out", NBT.TAG_COMPOUND);
         final boolean containsInvalidDisplayName = GuiText.UnknownItem.getLocal().toLowerCase().contains(searchTerm);
-        Predicate<ItemStack> itemFilter = (is) -> Platform
-                .getItemDisplayName(AEApi.instance().storage().createItemStack(is)).toLowerCase().contains(searchTerm);
+        Predicate<ItemStack> itemFilter;
 
         if (NEI.searchField.existsSearchField()) {
             itemFilter = NEI.searchField.getFilter(searchTerm);
+        } else {
+            itemFilter = is -> Platform.getItemDisplayName(AEApi.instance().storage().createItemStack(is)).toLowerCase()
+                    .contains(searchTerm);
         }
 
         for (int i = 0; i < tags.tagCount(); i++) {

--- a/src/main/java/appeng/integration/modules/NEIHelpers/NEISearchField.java
+++ b/src/main/java/appeng/integration/modules/NEIHelpers/NEISearchField.java
@@ -76,7 +76,7 @@ public class NEISearchField {
 
         if (searchField != null) {
             final ItemFilter filter = searchField.getFilter(filterText);
-            return stack -> filter.matches(stack);
+            return filter::matches;
         }
 
         return null;


### PR DESCRIPTION
It fixed low fps in big ME networks where added/removed items constantly.

With this PR it works better: https://github.com/GTNewHorizons/NotEnoughItems/pull/569

P.S. If NEI sync is enabled, search may have low fps before items in NEI are rendered for the first time. reason - render not search algorithm

P.S.2. I tested it in 2 worlds in 3 PC where it fixed problem