### PR TITLE
Remove GridFlags.ULTRA_DENSE_CAPACITY

### DIFF
--- a/src/main/java/appeng/api/networking/GridFlags.java
+++ b/src/main/java/appeng/api/networking/GridFlags.java
@@ -54,9 +54,4 @@ public enum GridFlags {
      * the order they are processed in.
      */
     PREFERRED,
-
-    /**
-     * This node can transmit 128 signals, this should only apply to Tier3 Cables only.
-     */
-    ULTRA_DENSE_CAPACITY
 }

--- a/src/main/java/appeng/me/GridNode.java
+++ b/src/main/java/appeng/me/GridNode.java
@@ -186,7 +186,6 @@ public class GridNode implements IGridNode, IPathItem {
 
     private int getCompressedChannelsIndex(final EnumSet<GridFlags> set) {
         if (set.contains(GridFlags.CANNOT_CARRY)) return 0;
-        else if (set.contains(GridFlags.ULTRA_DENSE_CAPACITY)) return 3;
         else if (set.contains(GridFlags.DENSE_CAPACITY)) return 2;
         return 1;
     }
@@ -427,13 +426,6 @@ public class GridNode implements IGridNode, IPathItem {
         if (!this.isValidDirection(dir)) {
             return false;
         }
-
-        // only connect ultra dense cable to dense cables
-        if (hasFlag(GridFlags.ULTRA_DENSE_CAPACITY) && !hasFlag(GridFlags.DENSE_CAPACITY)
-                && !(from.hasFlag(GridFlags.ULTRA_DENSE_CAPACITY)
-                        || (from.hasFlag(GridFlags.DENSE_CAPACITY) && !from.hasFlag(GridFlags.CANNOT_CARRY))))
-            return false;
-
         return from.getColor().matches(this.getColor());
     }
 

--- a/src/main/java/appeng/me/pathfinding/PathSegment.java
+++ b/src/main/java/appeng/me/pathfinding/PathSegment.java
@@ -47,13 +47,6 @@ public class PathSegment {
             for (final IPathItem pi : i.getPossibleOptions()) {
                 final EnumSet<GridFlags> flags = pi.getFlags();
                 if (!this.closed.contains(pi)) {
-                    boolean stopHere = false;
-                    if (flags.contains(GridFlags.ULTRA_DENSE_CAPACITY)
-                            && stage == TopologyStage.CONTROLLER_TO_BACKBONE) {
-                        backbone.computeIfAbsent(pi, k -> new BackbonePathSegment(pi, pgc, semiOpen, closed))
-                                .addControllerRoute(i);
-                        stopHere = true;
-                    }
                     pi.setControllerRoute(i, true);
 
                     if (flags.contains(GridFlags.REQUIRE_CHANNEL) && stage != TopologyStage.BACKBONE) {
@@ -77,10 +70,8 @@ public class PathSegment {
                         }
                     }
 
-                    if (!stopHere) {
-                        this.closed.add(pi);
-                        this.open.add(pi);
-                    }
+                    this.closed.add(pi);
+                    this.open.add(pi);
                 } else if (stage == TopologyStage.BACKBONE) {
                     BackbonePathSegment bb = backbone.get(pi);
                     if (bb != null && bb != this) {

--- a/src/main/java/appeng/parts/networking/PartCable.java
+++ b/src/main/java/appeng/parts/networking/PartCable.java
@@ -355,15 +355,12 @@ public class PartCable extends AEBasePart implements IPartCable {
                     if (part.getGridNode() != null) {
                         final IReadOnlyCollection<IGridConnection> set = part.getGridNode().getConnections();
                         for (final IGridConnection gc : set) {
-                            if (this.getProxy().getNode().hasFlag(GridFlags.ULTRA_DENSE_CAPACITY) && gc
-                                    .getOtherSide(this.getProxy().getNode()).hasFlag(GridFlags.ULTRA_DENSE_CAPACITY)) {
-                                sideOut |= (gc.getUsedChannels() / 16) << (4 * thisSide.ordinal());
-                            } else if (this.getProxy().getNode().hasFlag(GridFlags.DENSE_CAPACITY)
+                            if (this.getProxy().getNode().hasFlag(GridFlags.DENSE_CAPACITY)
                                     && gc.getOtherSide(this.getProxy().getNode()).hasFlag(GridFlags.DENSE_CAPACITY)) {
-                                        sideOut |= (gc.getUsedChannels() / 4) << (4 * thisSide.ordinal());
-                                    } else {
-                                        sideOut |= (gc.getUsedChannels()) << (4 * thisSide.ordinal());
-                                    }
+                                sideOut |= (gc.getUsedChannels() / 4) << (4 * thisSide.ordinal());
+                            } else {
+                                sideOut |= (gc.getUsedChannels()) << (4 * thisSide.ordinal());
+                            }
                         }
                     }
                 }
@@ -372,17 +369,11 @@ public class PartCable extends AEBasePart implements IPartCable {
             for (final IGridConnection gc : n.getConnections()) {
                 final ForgeDirection side = gc.getDirection(n);
                 if (side != ForgeDirection.UNKNOWN) {
-                    final boolean isTier3a = this.getProxy().getNode().hasFlag(GridFlags.ULTRA_DENSE_CAPACITY);
-                    final boolean isTier3b = gc.getOtherSide(this.getProxy().getNode())
-                            .hasFlag(GridFlags.ULTRA_DENSE_CAPACITY);
-
                     final boolean isTier2a = this.getProxy().getNode().hasFlag(GridFlags.DENSE_CAPACITY);
                     final boolean isTier2b = gc.getOtherSide(this.getProxy().getNode())
                             .hasFlag(GridFlags.DENSE_CAPACITY);
 
-                    if (isTier3a && isTier3b) {
-                        sideOut |= (gc.getUsedChannels() / 16) << (4 * side.ordinal());
-                    } else if ((isTier3a || isTier2a) && (isTier2b || isTier3b)) {
+                    if (isTier2a && isTier2b) {
                         sideOut |= (gc.getUsedChannels() / 4) << (4 * side.ordinal());
                     } else {
                         sideOut |= gc.getUsedChannels() << (4 * side.ordinal());


### PR DESCRIPTION
Part of #550.

This PR only removes "first-order" code. That is, only `if` branches that are always `false` with the non-existence of `ULTRA_DENSE_CAPACITY`. Code like the `BackbonePathSegment` or potential `TopologyState`s will be removed separately.

**Caution for GTNH**: This PR will break EnderIO versions prior to GTNewHorizons/EnderIO#182.