### PR TITLE
cleanup: Deprecate and remove usages of GridCacheWrapper

### DIFF
--- a/src/main/java/appeng/me/Grid.java
+++ b/src/main/java/appeng/me/Grid.java
@@ -36,7 +36,7 @@ public class Grid implements IGrid {
 
     private final NetworkEventBus eventBus = new NetworkEventBus();
     private final Map<Class<? extends IGridHost>, MachineSet> machines = new HashMap<>();
-    private final Map<Class<? extends IGridCache>, GridCacheWrapper> caches = new HashMap<>();
+    private final Map<Class<? extends IGridCache>, IGridCache> caches = new HashMap<>();
     private GridNode pivot;
     private int priority; // how import is this network?
     private GridStorage myStorage;
@@ -56,7 +56,7 @@ public class Grid implements IGrid {
             final Class<? extends IGridCache> valueClass = value.getClass();
 
             this.eventBus.readClass(key, valueClass);
-            this.caches.put(key, new GridCacheWrapper(value));
+            this.caches.put(key, value);
         }
 
         this.postEvent(new MENetworkPostCacheConstruction());
@@ -73,7 +73,7 @@ public class Grid implements IGrid {
         return this.myStorage;
     }
 
-    Map<Class<? extends IGridCache>, GridCacheWrapper> getCaches() {
+    Map<Class<? extends IGridCache>, IGridCache> getCaches() {
         return this.caches;
     }
 
@@ -179,7 +179,7 @@ public class Grid implements IGrid {
     @Override
     @SuppressWarnings("unchecked")
     public <C extends IGridCache> C getCache(final Class<? extends IGridCache> iface) {
-        return (C) this.caches.get(iface).getCache();
+        return (C) this.caches.get(iface);
     }
 
     @Override

--- a/src/main/java/appeng/me/GridCacheWrapper.java
+++ b/src/main/java/appeng/me/GridCacheWrapper.java
@@ -15,6 +15,7 @@ import appeng.api.networking.IGridHost;
 import appeng.api.networking.IGridNode;
 import appeng.api.networking.IGridStorage;
 
+/** @deprecated Use `.getClass().getName()` on IGridCache instances directly instead of `getName` */
 public class GridCacheWrapper implements IGridCache {
 
     private final IGridCache myCache;

--- a/src/main/java/appeng/me/NetworkEventBus.java
+++ b/src/main/java/appeng/me/NetworkEventBus.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import appeng.api.networking.IGridCache;
 import appeng.api.networking.IGridNode;
 import appeng.api.networking.events.MENetworkEvent;
 import appeng.api.networking.events.MENetworkEventSubscribe;
@@ -79,10 +80,10 @@ public class NetworkEventBus {
             if (subscribers != null) {
                 for (final Entry<Class, MENetworkEventInfo> subscriber : subscribers.entrySet()) {
                     final MENetworkEventInfo target = subscriber.getValue();
-                    final GridCacheWrapper cache = g.getCaches().get(subscriber.getKey());
+                    final IGridCache cache = g.getCaches().get(subscriber.getKey());
                     if (cache != null) {
                         x++;
-                        target.invoke(cache.getCache(), e);
+                        target.invoke(cache, e);
                     }
 
                     for (final IGridNode obj : g.getMachines(subscriber.getKey())) {


### PR DESCRIPTION
The `GridCacheWrapper` is a simple wrapper around an arbitrary `IGridCache` plus storing the name of the `IGridCache`. Since the name is actually unused, we can get rid of the wrapper altogether and just use the `IGridCache` directly.