### PR TITLE
[Feature] Shift to pause terminal view movement

### DIFF
--- a/src/main/java/appeng/api/storage/data/IDisplayRepo.java
+++ b/src/main/java/appeng/api/storage/data/IDisplayRepo.java
@@ -34,4 +34,8 @@ public interface IDisplayRepo {
     String getSearchString();
 
     void setSearchString(@Nonnull final String searchString);
+
+    boolean isPaused();
+
+    void setPaused(boolean paused);
 }

--- a/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
@@ -143,7 +143,7 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
             public void onTextChange(final String oldText) {
                 final String text = getText();
                 repo.setSearchString(text);
-                this.repo.updateView();
+                repo.updateView();
                 setScrollBar();
             }
         };

--- a/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
@@ -143,7 +143,7 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
             public void onTextChange(final String oldText) {
                 final String text = getText();
                 repo.setSearchString(text);
-                updateView();
+                this.repo.updateView();
                 setScrollBar();
             }
         };
@@ -156,7 +156,7 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
             this.repo.postUpdate(is);
         }
 
-        updateView();
+        this.repo.updateView();
         this.setScrollBar();
     }
 
@@ -555,7 +555,7 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
             this.typeFilter.set(this.configSrc.getSetting(Settings.TYPE_FILTER));
         }
 
-        updateView();
+        this.repo.updateView();
     }
 
     @SuppressWarnings("SameParameterValue")
@@ -617,6 +617,14 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
         super.handleMouseClick(p_146984_1_, p_146984_2_, p_146984_3_, p_146984_4_);
     }
 
+    @Override
+    public void handleKeyboardInput() {
+        super.handleKeyboardInput();
+
+        // Pause the terminal when holding shift
+        this.repo.setPaused(hasShiftDown());
+    }
+
     public boolean hideItemPanelSlot(int tx, int ty, int tw, int th) {
 
         if (this.viewCell) {
@@ -645,13 +653,5 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
 
     private boolean hasShiftDown() {
         return Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT);
-    }
-
-    /**
-     * Apply pre-update logic, then updates the DisplayRepo.
-     */
-    private void updateView() {
-        this.repo.setPaused(hasShiftDown());
-        this.repo.updateView();
     }
 }

--- a/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
@@ -143,7 +143,7 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
             public void onTextChange(final String oldText) {
                 final String text = getText();
                 repo.setSearchString(text);
-                repo.updateView();
+                updateView();
                 setScrollBar();
             }
         };
@@ -156,7 +156,7 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
             this.repo.postUpdate(is);
         }
 
-        this.repo.updateView();
+        updateView();
         this.setScrollBar();
     }
 
@@ -555,7 +555,7 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
             this.typeFilter.set(this.configSrc.getSetting(Settings.TYPE_FILTER));
         }
 
-        this.repo.updateView();
+        updateView();
     }
 
     @SuppressWarnings("SameParameterValue")
@@ -641,5 +641,17 @@ public class GuiMEMonitorable extends AEBaseMEGui implements ISortSource, IConfi
         }
 
         return false;
+    }
+
+    private boolean hasShiftDown() {
+        return Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT);
+    }
+
+    /**
+     * Apply pre-update logic, then updates the DisplayRepo.
+     */
+    private void updateView() {
+        this.repo.setPaused(hasShiftDown());
+        this.repo.updateView();
     }
 }

--- a/src/main/java/appeng/client/me/ItemRepo.java
+++ b/src/main/java/appeng/client/me/ItemRepo.java
@@ -37,7 +37,6 @@ import appeng.api.storage.data.IItemList;
 import appeng.client.gui.widgets.IScrollSource;
 import appeng.client.gui.widgets.ISortSource;
 import appeng.core.AEConfig;
-import appeng.core.AELog;
 import appeng.integration.modules.NEI;
 import appeng.items.storage.ItemViewCell;
 import appeng.util.ItemSorters;
@@ -319,7 +318,6 @@ public class ItemRepo implements IDisplayRepo {
     public void setPaused(boolean paused) {
         if (this.paused != paused) {
             this.paused = paused;
-            AELog.debug("Pause toggled!");
 
             // Update view when un-paused
             if (!paused) {

--- a/src/main/java/appeng/client/me/ItemRepo.java
+++ b/src/main/java/appeng/client/me/ItemRepo.java
@@ -107,20 +107,26 @@ public class ItemRepo implements IDisplayRepo {
 
     @Override
     public void updateView() {
-        // If paused, special update handling.
         if (this.paused) {
-            // Build view set for fast existence check
-            Set<IAEItemStack> viewSet = new HashSet<>(this.view);
-
-            // If the list entry is already in the view, do not add it.
-            // Otherwise, append to the end of the view.
-            ArrayList<IAEItemStack> entriesToAdd = new ArrayList<>();
-            for (IAEItemStack listEntry : this.list) {
-                if (!viewSet.contains(listEntry)) {
-                    entriesToAdd.add(listEntry);
+            // Update existing view with new data
+            for (int i = 0; i < this.view.size(); i++) {
+                IAEItemStack entry = this.view.get(i);
+                IAEItemStack serverEntry = this.list.findPrecise(entry);
+                if (serverEntry == null) {
+                    entry.setStackSize(0);
+                } else {
+                    this.view.set(i, serverEntry);
                 }
             }
 
+            // Append newly added item stacks to the end of the view
+            Set<IAEItemStack> viewSet = new HashSet<>(this.view);
+            ArrayList<IAEItemStack> entriesToAdd = new ArrayList<>();
+            for (IAEItemStack serverEntry : this.list) {
+                if (!viewSet.contains(serverEntry)) {
+                    entriesToAdd.add(serverEntry);
+                }
+            }
             addEntriesToView(entriesToAdd);
         } else {
             this.view.clear();

--- a/src/main/java/appeng/client/me/ItemRepo.java
+++ b/src/main/java/appeng/client/me/ItemRepo.java
@@ -288,14 +288,13 @@ public class ItemRepo implements IDisplayRepo {
     @Override
     public void setPaused(boolean paused) {
         if (this.paused != paused) {
+            this.paused = paused;
             AELog.debug("Pause toggled!");
-        }
 
-        this.paused = paused;
-
-        // Update view when un-paused
-        if (!paused) {
-            updateView();
+            // Update view when un-paused
+            if (!paused) {
+                updateView();
+            }
         }
     }
 }

--- a/src/main/java/appeng/client/me/ItemRepo.java
+++ b/src/main/java/appeng/client/me/ItemRepo.java
@@ -35,6 +35,7 @@ import appeng.api.storage.data.IItemList;
 import appeng.client.gui.widgets.IScrollSource;
 import appeng.client.gui.widgets.ISortSource;
 import appeng.core.AEConfig;
+import appeng.core.AELog;
 import appeng.integration.modules.NEI;
 import appeng.items.storage.ItemViewCell;
 import appeng.util.ItemSorters;
@@ -57,6 +58,7 @@ public class ItemRepo implements IDisplayRepo {
     private Map<IAEItemStack, Boolean> searchCache = new WeakHashMap<>();
     private IPartitionList<IAEItemStack> myPartitionList;
     private boolean hasPower;
+    private boolean paused = false;
 
     public ItemRepo(final IScrollSource src, final ISortSource sortSrc) {
         this.src = src;
@@ -276,5 +278,24 @@ public class ItemRepo implements IDisplayRepo {
             }
         }
 
+    }
+
+    @Override
+    public boolean isPaused() {
+        return this.paused;
+    }
+
+    @Override
+    public void setPaused(boolean paused) {
+        if (this.paused != paused) {
+            AELog.debug("Pause toggled!");
+        }
+
+        this.paused = paused;
+
+        // Update view when un-paused
+        if (!paused) {
+            updateView();
+        }
     }
 }

--- a/src/main/java/appeng/client/render/AppEngRenderItem.java
+++ b/src/main/java/appeng/client/render/AppEngRenderItem.java
@@ -88,7 +88,8 @@ public class AppEngRenderItem extends AERenderItem {
                 GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
             }
 
-            if (is.stackSize == 0 && showCraftLabelText) {
+            // Display "craftable" text
+            if (is.stackSize == 0 && showCraftLabelText && this.aeStack != null && this.aeStack.isCraftable()) {
                 final String craftLabelText = fontSize == TerminalFontSize.SMALL ? GuiText.SmallFontCraft.getLocal()
                         : GuiText.LargeFontCraft.getLocal();
 
@@ -99,10 +100,9 @@ public class AppEngRenderItem extends AERenderItem {
                 GL11.glEnable(GL11.GL_LIGHTING);
             }
 
+            // Display stack quantity
             final long amount = this.aeStack != null ? this.aeStack.getStackSize() : is.stackSize;
-
-            if (amount != 0 && showStackSize) {
-
+            if (showStackSize) {
                 GL11.glDisable(GL11.GL_LIGHTING);
                 GL11.glPushMatrix();
                 this.drawStackSize(par4, par5, amount, fontRenderer, fontSize);


### PR DESCRIPTION
https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18420

This is my attempt to reimplement #449, which was reverted in #513.

While the player is holding shift, the ItemRepo enters a paused state. When paused, instead of clearing the view and display buffers entirely and filling them from the server entries, the existing view buffer is maintained and the existing view items are updated from the server entries. Any items that were not previously in the view are appended to the end of the view. Sorting is disabled while paused. 

Changes were made to the AppEngRenderingItem class to prevent non-craftable, 0 quantity IAEItemStacks from displaying the "craft" text, and instead show "0" as their quantity.

I have tested this on the world provided in the original reversion, but I would love some massively updating AE2 systems to test performance on, as well as any advice on how to go about testing ae2 performance outside of monitoring MSPT. I haven't run into any noticeable FPS TPS issues in my testing, but since the previous attempt had to be reverted I would love addition eyes.