### PR TITLE
Set EntityFloatingItem delayBeforeCanPickup negative so it is detectable externally

### DIFF
--- a/src/main/java/appeng/entity/EntityFloatingItem.java
+++ b/src/main/java/appeng/entity/EntityFloatingItem.java
@@ -25,7 +25,7 @@ public final class EntityFloatingItem extends EntityItem {
     public EntityFloatingItem(final Entity parent, final World world, final double x, final double y, final double z,
             final ItemStack stack) {
         super(world, x, y, z, stack);
-        this.delayBeforeCanPickup = -100;
+        this.delayBeforeCanPickup = -1;
         this.motionX = this.motionY = this.motionZ = 0.0d;
         this.hoverStart = 0.5f;
         this.rotationYaw = 0;

--- a/src/main/java/appeng/entity/EntityFloatingItem.java
+++ b/src/main/java/appeng/entity/EntityFloatingItem.java
@@ -25,6 +25,7 @@ public final class EntityFloatingItem extends EntityItem {
     public EntityFloatingItem(final Entity parent, final World world, final double x, final double y, final double z,
             final ItemStack stack) {
         super(world, x, y, z, stack);
+        this.delayBeforeCanPickup = -100;
         this.motionX = this.motionY = this.motionZ = 0.0d;
         this.hoverStart = 0.5f;
         this.rotationYaw = 0;


### PR DESCRIPTION
So that stuff like the Draconic Evolution dislocator can discriminate without having to dep AE.

These items are never intended to be picked up, so there should be no issue.