### PR TITLE
fix overlap of "craft" and "0" in ME Terminals

### DIFF
--- a/src/main/java/appeng/client/render/AppEngRenderItem.java
+++ b/src/main/java/appeng/client/render/AppEngRenderItem.java
@@ -102,7 +102,7 @@ public class AppEngRenderItem extends AERenderItem {
 
             // Display stack quantity
             final long amount = this.aeStack != null ? this.aeStack.getStackSize() : is.stackSize;
-            if (amount > 0 && showStackSize || (!this.aeStack.isCraftable() && amount == 0)) {
+            if (showStackSize && (amount > 0 || !this.aeStack.isCraftable())) {
                 GL11.glDisable(GL11.GL_LIGHTING);
                 GL11.glPushMatrix();
                 this.drawStackSize(par4, par5, amount, fontRenderer, fontSize);

--- a/src/main/java/appeng/client/render/AppEngRenderItem.java
+++ b/src/main/java/appeng/client/render/AppEngRenderItem.java
@@ -102,7 +102,7 @@ public class AppEngRenderItem extends AERenderItem {
 
             // Display stack quantity
             final long amount = this.aeStack != null ? this.aeStack.getStackSize() : is.stackSize;
-            if (showStackSize) {
+            if (amount > 0 && showStackSize || (!this.aeStack.isCraftable() && amount == 0)) {
                 GL11.glDisable(GL11.GL_LIGHTING);
                 GL11.glPushMatrix();
                 this.drawStackSize(par4, par5, amount, fontRenderer, fontSize);


### PR DESCRIPTION
only displays the itemstack as 0, when item is not craftable
(middle 2 were taken out)
![image](https://github.com/user-attachments/assets/6801cff6-ebce-4cde-9416-13ab6801ba62)
![image](https://github.com/user-attachments/assets/a67035d0-b4bf-43e9-9bd2-bdaf298cd1f4)
Tested in normal, wireless and ae2fc terminals

closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18744