### PR TITLE
Fix weird gap in cpu table

### DIFF
--- a/src/main/java/appeng/client/gui/widgets/GuiCraftingCPUTable.java
+++ b/src/main/java/appeng/client/gui/widgets/GuiCraftingCPUTable.java
@@ -247,7 +247,7 @@ public class GuiCraftingCPUTable {
                 parent.drawTexturedModalRect(offsetX - CPU_TABLE_WIDTH, offsetY + y, 0, 41, CPU_TABLE_WIDTH, 23);
                 y += 23;
             }
-            parent.drawTexturedModalRect(offsetX - CPU_TABLE_WIDTH, offsetY + y, 0, 132, CPU_TABLE_WIDTH, 31);
+            parent.drawTexturedModalRect(offsetX - CPU_TABLE_WIDTH, offsetY + y, 0, 133, CPU_TABLE_WIDTH, 31);
         } else {
             parent.drawTexturedModalRect(offsetX - CPU_TABLE_WIDTH, offsetY, 0, 0, CPU_TABLE_WIDTH, CPU_TABLE_HEIGHT);
         }


### PR DESCRIPTION
There had a little white gap between last and penultimate cpu, cause by worng texture bias
Now fix

| before | after fix |
| :-: | :-: |
| ![43efe8c15a260137c2ad43ed4bf92fe7](https://github.com/user-attachments/assets/50147041-7c01-4c4f-a6d2-b24c65a3dc72) | ![007e1b3f644f3540c0c8c64f204fa0e9](https://github.com/user-attachments/assets/6221d994-7969-4505-8ce7-3120c29b12cc) |
