### PR TITLE
Change Craft Ordering Quantity to Allow Longs

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiAmount.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiAmount.java
@@ -129,23 +129,23 @@ public abstract class GuiAmount extends AEBaseGui {
                 || btn == this.minus1000;
 
         if (isPlus || isMinus) {
-            int resultI = addOrderAmount(this.getQty(btn));
-            this.amountTextField.setText(Integer.toString(resultI));
+            long resultI = addOrderAmount(this.getQty(btn));
+            this.amountTextField.setText(Long.toString(resultI));
         }
     }
 
-    protected int addOrderAmount(final int i) {
-        int resultI = getAmount();
+    protected long addOrderAmount(final int i) {
+        long resultL = getAmountLong();
 
-        if (resultI == 1 && i > 1) {
-            resultI = 0;
+        if (resultL == 1 && i > 1) {
+            resultL = 0;
         }
 
-        resultI += i;
-        if (resultI < 1) {
-            resultI = 1;
+        resultL += i;
+        if (resultL < 1) {
+            resultL = 1;
         }
-        return resultI;
+        return resultL;
     }
 
     protected int getAmount() {
@@ -156,6 +156,17 @@ public abstract class GuiAmount extends AEBaseGui {
             return 0;
         } else {
             return (int) ArithHelper.round(resultD, 0);
+        }
+    }
+
+    protected long getAmountLong() {
+        String out = this.amountTextField.getText();
+        double resultD = Calculator.conversion(out);
+
+        if (resultD <= 0 || Double.isNaN(resultD)) {
+            return 0;
+        } else {
+            return (long) ArithHelper.round(resultD, 0);
         }
     }
 

--- a/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
@@ -403,7 +403,9 @@ public class GuiCraftConfirm extends AEBaseGui implements ICraftingCPUTableHolde
         final String byteUsed = Platform.formatByteDouble(BytesUsed);
         final String bannerText;
         if (jobTree != null && !jobTree.getErrorMessage().isEmpty()) {
-            bannerText = StatCollector.translateToLocal(jobTree.getErrorMessage());
+            if (jobTree.getErrorMessage().equals("java.lang.ArithmeticException: long overflow")) {
+                bannerText = GuiText.CraftingSizeLimitExceeded.getLocal();
+            } else bannerText = StatCollector.translateToLocal(jobTree.getErrorMessage());
         } else if (BytesUsed > 0) {
             bannerText = byteUsed;
         } else {

--- a/src/main/java/appeng/client/gui/implementations/GuiPatternMulti.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiPatternMulti.java
@@ -128,7 +128,7 @@ public class GuiPatternMulti extends GuiAmount {
     }
 
     @Override
-    protected int addOrderAmount(final int i) {
+    protected long addOrderAmount(final int i) {
         return i + getAmount();
     }
 

--- a/src/main/java/appeng/container/implementations/ContainerCraftConfirm.java
+++ b/src/main/java/appeng/container/implementations/ContainerCraftConfirm.java
@@ -270,6 +270,7 @@ public class ContainerCraftConfirm extends AEBaseContainer implements ICraftingC
     }
 
     public boolean cpuMatches(final CraftingCPUStatus c) {
+        if (this.getUsedBytes() <= 0) return false;
         if (c.isBusy() && this.cpuCraftingSameItem(c)) {
             return c.getStorage() >= this.getUsedBytes() + c.getUsedStorage();
         }

--- a/src/main/java/appeng/core/localization/GuiText.java
+++ b/src/main/java/appeng/core/localization/GuiText.java
@@ -169,6 +169,7 @@ public enum GuiText {
     Simulation,
     Missing,
     CraftingStepLimitExceeded,
+    CraftingSizeLimitExceeded,
     NoCraftingTreeReceived,
     RequestedItem,
     SimulationIncomplete,

--- a/src/main/java/appeng/core/sync/packets/PacketCraftRequest.java
+++ b/src/main/java/appeng/core/sync/packets/PacketCraftRequest.java
@@ -50,7 +50,7 @@ public class PacketCraftRequest extends AppEngPacket {
         this(craftAmt, shift, CraftingMode.STANDARD);
     }
 
-    public PacketCraftRequest(final int craftAmt, final boolean shift, final CraftingMode craftingMode) {
+    public PacketCraftRequest(final long craftAmt, final boolean shift, final CraftingMode craftingMode) {
         this.amount = craftAmt;
         this.heldShift = shift;
         this.craftingMode = craftingMode;

--- a/src/main/resources/assets/appliedenergistics2/lang/en_US.lang
+++ b/src/main/resources/assets/appliedenergistics2/lang/en_US.lang
@@ -279,6 +279,7 @@ gui.appliedenergistics2.Merge=Merge
 gui.appliedenergistics2.Missing=Missing
 gui.appliedenergistics2.NoCraftingTreeReceived=No crafting tree received
 gui.appliedenergistics2.CraftingStepLimitExceeded=Crafting step limit exceeded
+gui.appliedenergistics2.CraftingSizeLimitExceeded=Crafting size limit exceeded
 gui.appliedenergistics2.RequestedItem=Requested item
 gui.appliedenergistics2.SimulationIncomplete=Simulation incomplete
 gui.appliedenergistics2.Bytes=Storage


### PR DESCRIPTION
Some crafts get pretty big. I wanted to order many billions of plasma once. Why require using a dummy pattern when we can just order the full amount? The vast majority of crafting logic already supported long amounts (as it needed to), it was just the ordering GUI was capped to int (which most must remain due to vanilla minecraft). Pattern item sizes remain ints because they are ItemStacks - refactoring things to enable them to store longs would be _a lot_ of work.

The change to ContainerCraftConfirm covers a small edge case where somehow, I guess, I could overflow a long without it realizing a long overflowed, causing a negative craft size that could be placed on any size of CPU (or a size of 0).

Tested briefly in a test world to ensure:
- Could order a one-step 4^30 item craft
- Could order a 1:1 multi-step 4^30 item craft
- Could order a N:1 multi-step 4^30 item craft up to long max craft size

Added a new GUI string for if the craft size overflows - the log still captures the proper overflow error.