### PR TITLE
Remove internal packet size limit

### DIFF
--- a/src/main/java/appeng/core/sync/AppEngPacket.java
+++ b/src/main/java/appeng/core/sync/AppEngPacket.java
@@ -49,12 +49,6 @@ public abstract class AppEngPacket {
     }
 
     public FMLProxyPacket getProxy() {
-        if (this.p.array().length > 0x1FFF90) // Use the maximum MC S3FPacketCustomPayload size with space for FML
-        {
-            throw new IllegalArgumentException(
-                    "Sorry AE2 made a " + this.p.array().length + " byte packet by accident!");
-        }
-
         final FMLProxyPacket pp = new FMLProxyPacket(this.p, NetworkHandler.instance.getChannel());
 
         if (AEConfig.instance.isFeatureEnabled(AEFeature.PacketLogging)) {


### PR DESCRIPTION
With the Hodgepodge packet size limit there is no need to check the packet size here, and even if the max packet size is exceeded the FML network layer will throw a very similar exception anyway.