### PR TITLE
Fix memory leak with WAILA

### DIFF
--- a/src/main/java/appeng/integration/modules/waila/tile/PowerStorageWailaDataProvider.java
+++ b/src/main/java/appeng/integration/modules/waila/tile/PowerStorageWailaDataProvider.java
@@ -11,6 +11,7 @@
 package appeng.integration.modules.waila.tile;
 
 import java.util.List;
+import java.util.WeakHashMap;
 
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
@@ -22,8 +23,6 @@ import appeng.api.networking.energy.IAEPowerStorage;
 import appeng.core.localization.WailaText;
 import appeng.integration.modules.waila.BaseWailaDataProvider;
 import appeng.util.Platform;
-import gnu.trove.map.TObjectLongMap;
-import gnu.trove.map.hash.TObjectLongHashMap;
 import mcp.mobius.waila.api.ITaggedList;
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
@@ -50,7 +49,7 @@ public final class PowerStorageWailaDataProvider extends BaseWailaDataProvider {
      * <p/>
      * The cache will be updated from the server.
      */
-    private final TObjectLongMap<TileEntity> cache = new TObjectLongHashMap<>();
+    private final WeakHashMap<TileEntity, Long> cache = new WeakHashMap<>();
 
     /**
      * Adds the current and max power to the tool tip Will ignore if the tile has an energy buffer ( &gt; 0 )


### PR DESCRIPTION
Since the cache for power storage blocks is never cleared, the TileEntity instances stored in the cache would be kept in memory forever. This is especially bad when frequently changing dimensions, as the temporary World instance will never be pruned from memory.