### PR TITLE
Remove stack capture from GridAccessException

### DIFF
--- a/src/main/java/appeng/core/AEConfig.java
+++ b/src/main/java/appeng/core/AEConfig.java
@@ -90,6 +90,7 @@ public final class AEConfig extends Configuration implements IConfigurableObject
 
     public boolean debugLogTiming = false;
     public boolean debugPathFinding = false;
+    public boolean captureGAEStacks = false;
     public int wirelessTerminalBattery = 1600000;
     public int entropyManipulatorBattery = 200000;
     public int matterCannonBattery = 200000;
@@ -233,6 +234,7 @@ public final class AEConfig extends Configuration implements IConfigurableObject
         this.craftingCalculatorVersion = this.get("debug", "CraftingCalculatorVersion", this.craftingCalculatorVersion)
                 .getInt(this.craftingCalculatorVersion);
         this.craftingCalculatorVersion = Math.max(1, Math.min(this.craftingCalculatorVersion, 2));
+        this.captureGAEStacks = this.get("debug", "CaptureGridAccessExceptionStacks", false).getBoolean();
         this.maxCraftingSteps = this.get("misc", "MaxCraftingSteps", this.maxCraftingSteps)
                 .getInt(this.maxCraftingSteps);
         this.maxCraftingTreeVisualizationSize = this

--- a/src/main/java/appeng/me/GridAccessException.java
+++ b/src/main/java/appeng/me/GridAccessException.java
@@ -13,4 +13,10 @@ package appeng.me;
 public class GridAccessException extends Exception {
 
     private static final long serialVersionUID = 3914554394866375300L;
+
+    public GridAccessException() {
+        // Disable stack captures
+        // If you need a stack from this exception, just comment out this constructor
+        super(null, null, false, false);
+    }
 }

--- a/src/main/java/appeng/me/GridAccessException.java
+++ b/src/main/java/appeng/me/GridAccessException.java
@@ -10,13 +10,14 @@
 
 package appeng.me;
 
+import appeng.core.AEConfig;
+
 public class GridAccessException extends Exception {
 
     private static final long serialVersionUID = 3914554394866375300L;
 
     public GridAccessException() {
-        // Disable stack captures
-        // If you need a stack from this exception, just comment out this constructor
-        super(null, null, false, false);
+        // Disable stack captures by default
+        super(null, null, false, AEConfig.instance.captureGAEStacks);
     }
 }


### PR DESCRIPTION
These exceptions are just used to unwind the stack when an AE machine's state is invalid. They're never logged, and the stack will likely never be relevant. This exception can cause severe performance issues in situations where a machine has some illegal state that cannot be resolved. This change should help reduce any TPS lag caused by this type of problem.