### PR TITLE
change network energy storage display to infinity when it is so

### DIFF
--- a/src/main/java/appeng/api/networking/energy/IEnergyGrid.java
+++ b/src/main/java/appeng/api/networking/energy/IEnergyGrid.java
@@ -93,4 +93,6 @@ public interface IEnergyGrid extends IGridCache, IEnergySource, IEnergyGridProvi
      * internal use only
      */
     void setHasInfiniteStore(boolean infinite);
+
+    boolean getHasInfiniteStore();
 }

--- a/src/main/java/appeng/client/gui/implementations/GuiNetworkStatus.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiNetworkStatus.java
@@ -273,16 +273,29 @@ public class GuiNetworkStatus extends AEBaseGui implements ISortSource {
         this.fontRendererObj
                 .drawString(GuiText.NetworkDetails.getLocal(), 8, 6, GuiColors.NetworkStatusDetails.getColor());
 
-        this.fontRendererObj.drawString(
-                GuiText.StoredPower.getLocal() + ": " + Platform.formatPowerLong(ns.getCurrentPower(), false),
-                13,
-                16,
-                GuiColors.NetworkStatusStoredPower.getColor());
-        this.fontRendererObj.drawString(
-                GuiText.MaxPower.getLocal() + ": " + Platform.formatPowerLong(ns.getMaxPower(), false),
-                13,
-                26,
-                GuiColors.NetworkStatusMaxPower.getColor());
+        if (ns.isPowerInfinite()) {
+            this.fontRendererObj.drawString(
+                    GuiText.StoredPower.getLocal() + ": ∞",
+                    13,
+                    16,
+                    GuiColors.NetworkStatusStoredPower.getColor());
+            this.fontRendererObj.drawString(
+                    GuiText.MaxPower.getLocal() + ": ∞",
+                    13,
+                    26,
+                    GuiColors.NetworkStatusMaxPower.getColor());
+        } else {
+            this.fontRendererObj.drawString(
+                    GuiText.StoredPower.getLocal() + ": " + Platform.formatPowerLong(ns.getCurrentPower(), false),
+                    13,
+                    16,
+                    GuiColors.NetworkStatusStoredPower.getColor());
+            this.fontRendererObj.drawString(
+                    GuiText.MaxPower.getLocal() + ": " + Platform.formatPowerLong(ns.getMaxPower(), false),
+                    13,
+                    26,
+                    GuiColors.NetworkStatusMaxPower.getColor());
+        }
 
         this.fontRendererObj.drawString(
                 GuiText.PowerInputRate.getLocal() + ": " + Platform.formatPowerLong(ns.getAverageAddition(), true),

--- a/src/main/java/appeng/container/implementations/ContainerNetworkStatus.java
+++ b/src/main/java/appeng/container/implementations/ContainerNetworkStatus.java
@@ -137,6 +137,9 @@ public class ContainerNetworkStatus extends AEBaseContainer {
     @GuiSync(30)
     public long essentiaCellCount;
 
+    @GuiSync(31)
+    public boolean powerInfinite;
+
     private IGrid network;
     private int delay = 40;
     private boolean isConsume = true;
@@ -178,6 +181,7 @@ public class ContainerNetworkStatus extends AEBaseContainer {
                 this.setPowerUsage((long) (100.0 * eg.getAvgPowerUsage()));
                 this.setCurrentPower((long) (100.0 * eg.getStoredPower()));
                 this.setMaxPower((long) (100.0 * eg.getMaxStoredPower()));
+                this.setPowerInfinite(eg.getHasInfiniteStore());
             }
 
             try {
@@ -409,5 +413,13 @@ public class ContainerNetworkStatus extends AEBaseContainer {
 
     public long getEssentiaCellCount() {
         return essentiaCellCount;
+    }
+
+    public boolean isPowerInfinite() {
+        return powerInfinite;
+    }
+
+    public void setPowerInfinite(boolean powerInfinite) {
+        this.powerInfinite = powerInfinite;
     }
 }

--- a/src/main/java/appeng/me/cache/EnergyGridCache.java
+++ b/src/main/java/appeng/me/cache/EnergyGridCache.java
@@ -382,6 +382,11 @@ public class EnergyGridCache implements IEnergyGrid {
     }
 
     @Override
+    public boolean getHasInfiniteStore() {
+        return this.infinite;
+    }
+
+    @Override
     public boolean calculateInfiniteStore(boolean currentInfinite, Set<IEnergyGrid> seen) {
         if (!seen.add(this)) {
             return currentInfinite;


### PR DESCRIPTION
this is mainly to help debugging the recurring claim of "infinity flag doesn't work"

I'm unable to replicate the situation, and the reporting person does not know how to verify infinity flag is set, so I made this. It's also nice to have a special marker when you did something special you know 