### PR TITLE
Fix MENetworkChannelChanged not woking

### DIFF
--- a/src/main/java/appeng/me/cache/PathGridCache.java
+++ b/src/main/java/appeng/me/cache/PathGridCache.java
@@ -327,7 +327,7 @@ public class PathGridCache implements IPathingGrid {
     }
 
     @MENetworkEventSubscribe
-    void updateNodReq(final MENetworkChannelChanged ev) {
+    public void updateNodReq(final MENetworkChannelChanged ev) {
         final IGridNode gridNode = ev.node;
 
         if (AEConfig.instance.debugPathFinding) {


### PR DESCRIPTION
appeng.me.NetworkEventBus use class.getMethods() to scan event subscribers
package-private methods will NOT be included in getMethods()
So posting a MENetworkChannelChanged event to AE will not work.
This PR wil fix it.