### PR TITLE
Fix lag caused by 'setAccessible(true);' being called millions of times

### DIFF
--- a/src/main/java/appeng/util/Platform.java
+++ b/src/main/java/appeng/util/Platform.java
@@ -518,9 +518,11 @@ public class Platform {
         if (tagList == null) {
             try {
                 tagList = lB.getClass().getDeclaredField("tagList");
+                tagList.setAccessible(true);
             } catch (final Throwable t) {
                 try {
                     tagList = lB.getClass().getDeclaredField("field_74747_a");
+                    tagList.setAccessible(true);
                 } catch (final Throwable z) {
                     AELog.debug(t);
                     AELog.debug(z);
@@ -529,7 +531,6 @@ public class Platform {
         }
 
         try {
-            tagList.setAccessible(true);
             return (List<NBTBase>) tagList.get(lB);
         } catch (final Throwable t) {
             AELog.debug(t);

--- a/src/main/java/appeng/util/Platform.java
+++ b/src/main/java/appeng/util/Platform.java
@@ -11,7 +11,6 @@
 package appeng.util;
 
 import java.lang.ref.WeakReference;
-import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.security.InvalidParameterException;
 import java.text.DecimalFormat;
@@ -152,7 +151,6 @@ public class Platform {
      */
     private static final Random RANDOM_GENERATOR = new Random();
     private static final WeakHashMap<World, WeakReference<EntityPlayer>> FAKE_PLAYERS = new WeakHashMap<>();
-    private static Field tagList;
     private static Class playerInstance;
     private static Method getOrCreateChunkWatcher;
     private static Method sendToAllPlayersWatchingChunk;
@@ -463,8 +461,8 @@ public class Platform {
                         return false;
                     }
 
-                    final List<NBTBase> tag = tagList(lA);
-                    final List<NBTBase> aTag = tagList(lB);
+                    final List<NBTBase> tag = lA.tagList;
+                    final List<NBTBase> aTag = lB.tagList;
                     if (tag.size() != aTag.size()) {
                         return false;
                     }
@@ -514,31 +512,6 @@ public class Platform {
         return false;
     }
 
-    private static List<NBTBase> tagList(final NBTTagList lB) {
-        if (tagList == null) {
-            try {
-                tagList = lB.getClass().getDeclaredField("tagList");
-                tagList.setAccessible(true);
-            } catch (final Throwable t) {
-                try {
-                    tagList = lB.getClass().getDeclaredField("field_74747_a");
-                    tagList.setAccessible(true);
-                } catch (final Throwable z) {
-                    AELog.debug(t);
-                    AELog.debug(z);
-                }
-            }
-        }
-
-        try {
-            return (List<NBTBase>) tagList.get(lB);
-        } catch (final Throwable t) {
-            AELog.debug(t);
-        }
-
-        return new ArrayList<>();
-    }
-
     /*
      * Orderless hash on NBT Data, used to work thought huge piles fast, but ignores the order just in case MC decided
      * to change it... WHICH IS BAD...
@@ -565,7 +538,7 @@ public class Platform {
                 final NBTTagList lA = (NBTTagList) nbt;
                 hash += 9 * lA.tagCount();
 
-                final List<NBTBase> l = tagList(lA);
+                final List<NBTBase> l = lA.tagList;
                 for (int x = 0; x < l.size(); x++) {
                     hash += ((Integer) x).hashCode() ^ NBTOrderlessHash(l.get(x));
                 }

--- a/src/main/resources/META-INF/appeng_at.cfg
+++ b/src/main/resources/META-INF/appeng_at.cfg
@@ -6,3 +6,5 @@ public net.minecraft.client.gui.FontRenderer func_78280_d(Ljava/lang/String;I)Lj
 public net.minecraft.client.gui.inventory.GuiContainer field_147006_u #theSlot
 # RenderItem
 public net.minecraft.client.renderer.entity.RenderItem func_77017_a(Lnet/minecraft/client/renderer/Tessellator;IIIII)V #renderQuad
+# Platform
+public net.minecraft.nbt.NBTTagList field_74747_a # tagList


### PR DESCRIPTION
On IO operations, the comparation between ItemStacks may call getTagList()

That itself calls 'setAccessible(true)' lots of times.

It needs to be called only once.

![image](https://github.com/user-attachments/assets/2ab2c889-0dba-4b43-a462-5a47bf407ba6)
