### PR TITLE
Mitigate crashes caused by invalid CraftingLinks

### DIFF
--- a/src/main/java/appeng/helpers/MultiCraftingTracker.java
+++ b/src/main/java/appeng/helpers/MultiCraftingTracker.java
@@ -26,6 +26,7 @@ import appeng.api.networking.crafting.ICraftingLink;
 import appeng.api.networking.crafting.ICraftingRequester;
 import appeng.api.networking.security.BaseActionSource;
 import appeng.api.storage.data.IAEItemStack;
+import appeng.core.AELog;
 import appeng.util.InventoryAdaptor;
 
 public class MultiCraftingTracker {
@@ -46,7 +47,12 @@ public class MultiCraftingTracker {
             final NBTTagCompound link = extra.getCompoundTag("links-" + x);
 
             if (link != null && !link.hasNoTags()) {
-                this.setLink(x, AEApi.instance().storage().loadCraftingLink(link, this.owner));
+                try {
+                    this.setLink(x, AEApi.instance().storage().loadCraftingLink(link, this.owner));
+                } catch (Throwable t) {
+                    AELog.error("Could not load crafting link! Slot=%s, Tag=%s, Owner=%s", x, link, owner);
+                    AELog.error(t);
+                }
             }
         }
     }


### PR DESCRIPTION
There are several crashes caused by CraftingLinks returning invalid NBT when saved, causing them to throw an exception when the link is loaded. Without this change, export busses may be deleted and in some rare situations players can be chunkbanned.

This change just catches any error caused by loading a crafting link and skips that link. If a link is missing, the export bus will just forget that it started a craft. Since these crashes only happen when the server is restarted, this is a very minor problem.

I'm not sure why the links become invalid in the first place, so this error will log all relevant info.
