### PR TITLE
Fix crafting calculation aborted by NPE

### DIFF
--- a/src/main/java/appeng/container/implementations/ContainerCraftConfirm.java
+++ b/src/main/java/appeng/container/implementations/ContainerCraftConfirm.java
@@ -193,9 +193,11 @@ public class ContainerCraftConfirm extends AEBaseContainer implements ICraftingC
 
                         if (toExtract.getStackSize() > 0 && toCraft.getStackSize() <= 0
                                 && (missing == null || missing.getStackSize() <= 0)) {
-                            long available = items.getAvailableItem(toExtract, IterationCounter.fetchNewId())
-                                    .getStackSize();
-                            toExtract.setUsedPercent(toExtract.getStackSize() / (available / 100f));
+                            IAEItemStack availableStack = items
+                                    .getAvailableItem(toExtract, IterationCounter.fetchNewId());
+                            long available = (availableStack == null) ? 0 : availableStack.getStackSize();
+                            if (available > 0) toExtract.setUsedPercent(toExtract.getStackSize() / (available / 100f));
+                            else toExtract.setUsedPercent(0f);
                         }
 
                         if (toExtract.getStackSize() > 0) {


### PR DESCRIPTION
## To reproduce the bug
1. Start a crafting calculation in an AE Terminal.
2. When crafting calculation is not yet done, extract all items that this crafting will consume.
3. Crafting calculation is done, server will try to sync data to client.
4. When calculating the percentage of item used, an NPE is thrown and closes the GUI.


Here's a video of reproducing this bug.
This ME network has a pattern(1 grass input, 1 dirt output)
and an Export Bus that is removing grass outside the network.
Put some grass into the Terminal and order 1 dirt block.
When calculating, Export Bus exhausts all dirt, and the GUI closes itself and print err message in chat.
<details>
<summary>video of reproducing this bug</summary>
<p>

https://github.com/user-attachments/assets/33fbcdcf-bb58-4d50-92d6-f51f5226c6c5

</p>
</details>

## Note
### Note 1
To trigger this bug, items must be removed during the calculation, once the calculation is done, this bug will not happen.
(however, when you press 'craft' button in this situation, crafting will not start and something like 'Cannot craft, missing item:foobar x10' will show in chat)

To reproduce easier, I use a simple mixin mod(used in the video) to slow down the calculation(used in the video), like this:
<details>
<summary>mixin code</summary>
<p>

```
import org.spongepowered.asm.mixin.Mixin;
import org.spongepowered.asm.mixin.injection.At;
import org.spongepowered.asm.mixin.injection.Inject;
import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
import appeng.crafting.v2.CraftingContext;
import appeng.crafting.v2.resolvers.CraftingTask;

@Mixin(value=CraftingContext.class,remap=false)
public class MyMixin {
	@Inject (method="doWork", at = { @At("HEAD") },cancellable=true)

	public void a(CallbackInfoReturnable c){
		if(in++>10)
                {in=0;}
                else {
			try {
				Thread.sleep(2);//slow down the calculation
			} catch (InterruptedException e) {
			}
			c.setReturnValue(CraftingTask.State.NEEDS_MORE_WORK);//return early to prevent further calculation
		
		}
	}
	private int in;
}
```

</p>
</details>

### Note 2
The removed item must have no crafting ways, in order to reproduce this bug.
For example:
There is only a pattern(grass->dirt), then reprocude is successful.
There are 2 patterns(rock->grass) & (grass->dirt), then reprocude will fail.

<details>
<summary>failed example of reprocude </summary>
<p>


https://github.com/user-attachments/assets/6e155673-3e4a-44d3-a43f-61573e84ad23



</p>
</details>

But you can still see something is not right: used percentage ≈ Long.MAX/10.


## What this PR do to fix it

AE will make a clone of the item list in storage and freeze it during the calculation.
But when sending calculation result to client, the used percentage is calculated depending on **current** storage.

```
//'items' is current storage
long available = items.getAvailableItem(toExtract, IterationCounter.fetchNewId()) .getStackSize();
```

It's possible that items.getAvailableItem returns null, since the storage might alter during calculating.
However, if you have a pattern that might provide crafting of such missing item,
getAvailableItem will return an AEItemStack with stacksize=0 and craftable=true.(and makes used percentage≈Long.MAX/10)

This PR simply add null check to return value of getAvailableItem, and set percentage to zero if item missing, it now prevent the GUI from being closed and displays <0.01%
And also fix 'used percentage'=922,337,180,385,280%, it now just displays <0.01%
<img width="845" alt="9bfad0647bad8951391986be4dbdf36" src="https://github.com/user-attachments/assets/68828c08-7d29-4263-88e0-bc4b84cf7189" />


