### PR TITLE
Update EnderIO P2P Integrations

### DIFF
--- a/src/main/java/appeng/core/features/registries/P2PTunnelRegistry.java
+++ b/src/main/java/appeng/core/features/registries/P2PTunnelRegistry.java
@@ -129,9 +129,7 @@ public final class P2PTunnelRegistry implements IP2PTunnelRegistry {
             this.addNewAttunement(parts.cableDense().stack(c, 1), TunnelType.ME);
             this.addNewAttunement(parts.cableDenseCovered().stack(c, 1), TunnelType.ME);
         }
-        this.addNewAttunement(
-                this.getModItem("EnderIO", "itemMeConduit", OreDictionary.WILDCARD_VALUE),
-                TunnelType.ME);
+        this.addNewAttunement(this.getModItem("EnderIO", "itemMeConduit", OreDictionary.WILDCARD_VALUE), TunnelType.ME);
     }
 
     @Override

--- a/src/main/java/appeng/core/features/registries/P2PTunnelRegistry.java
+++ b/src/main/java/appeng/core/features/registries/P2PTunnelRegistry.java
@@ -45,6 +45,9 @@ public final class P2PTunnelRegistry implements IP2PTunnelRegistry {
         this.addNewAttunement(new ItemStack(Blocks.torch), TunnelType.LIGHT);
         this.addNewAttunement(new ItemStack(Blocks.glowstone), TunnelType.LIGHT);
         this.addNewAttunement(new ItemStack(Items.glowstone_dust), TunnelType.LIGHT);
+        this.addNewAttunement(
+                this.getModItem("EnderIO", "blockElectricLight", OreDictionary.WILDCARD_VALUE),
+                TunnelType.ME);
 
         // Sound
         this.addNewAttunement(new ItemStack(Blocks.noteblock), TunnelType.SOUND);
@@ -126,6 +129,9 @@ public final class P2PTunnelRegistry implements IP2PTunnelRegistry {
             this.addNewAttunement(parts.cableDense().stack(c, 1), TunnelType.ME);
             this.addNewAttunement(parts.cableDenseCovered().stack(c, 1), TunnelType.ME);
         }
+        this.addNewAttunement(
+                this.getModItem("EnderIO", "itemMeConduit", OreDictionary.WILDCARD_VALUE),
+                TunnelType.ME);
     }
 
     @Override

--- a/src/main/java/appeng/core/features/registries/P2PTunnelRegistry.java
+++ b/src/main/java/appeng/core/features/registries/P2PTunnelRegistry.java
@@ -129,7 +129,7 @@ public final class P2PTunnelRegistry implements IP2PTunnelRegistry {
             this.addNewAttunement(parts.cableDense().stack(c, 1), TunnelType.ME);
             this.addNewAttunement(parts.cableDenseCovered().stack(c, 1), TunnelType.ME);
         }
-        this.addNewAttunement(this.getModItem("EnderIO", "itemMeConduit", OreDictionary.WILDCARD_VALUE), TunnelType.ME);
+        this.addNewAttunement(this.getModItem("EnderIO", "itemMEConduit", OreDictionary.WILDCARD_VALUE), TunnelType.ME);
     }
 
     @Override

--- a/src/main/java/appeng/core/features/registries/P2PTunnelRegistry.java
+++ b/src/main/java/appeng/core/features/registries/P2PTunnelRegistry.java
@@ -47,7 +47,7 @@ public final class P2PTunnelRegistry implements IP2PTunnelRegistry {
         this.addNewAttunement(new ItemStack(Items.glowstone_dust), TunnelType.LIGHT);
         this.addNewAttunement(
                 this.getModItem("EnderIO", "blockElectricLight", OreDictionary.WILDCARD_VALUE),
-                TunnelType.ME);
+                TunnelType.LIGHT);
 
         // Sound
         this.addNewAttunement(new ItemStack(Blocks.noteblock), TunnelType.SOUND);

--- a/src/main/java/appeng/integration/modules/RF.java
+++ b/src/main/java/appeng/integration/modules/RF.java
@@ -71,6 +71,7 @@ public final class RF implements IIntegrationModule {
         this.registerRFAttunement("EnderIO", "itemPowerConduit", OreDictionary.WILDCARD_VALUE);
         this.registerRFAttunement("EnderIO", "blockCapBank", OreDictionary.WILDCARD_VALUE);
         this.registerRFAttunement("EnderIO", "blockPowerMonitor", 0);
+        this.registerRFAttunement("EnderIO", "itemPowerConduitEndergy", OreDictionary.WILDCARD_VALUE);
     }
 
     private void registerRFAttunement(final String mod, final String name, final int dmg) {

--- a/src/main/java/appeng/integration/modules/RF.java
+++ b/src/main/java/appeng/integration/modules/RF.java
@@ -69,7 +69,7 @@ public final class RF implements IIntegrationModule {
         this.registerRFAttunement("ThermalDynamics", "ThermalDynamics_0", 6);
 
         this.registerRFAttunement("EnderIO", "itemPowerConduit", OreDictionary.WILDCARD_VALUE);
-        this.registerRFAttunement("EnderIO", "blockCapBank", 0);
+        this.registerRFAttunement("EnderIO", "blockCapBank", OreDictionary.WILDCARD_VALUE);
         this.registerRFAttunement("EnderIO", "blockPowerMonitor", 0);
     }
 

--- a/src/main/java/appeng/integration/modules/RF.java
+++ b/src/main/java/appeng/integration/modules/RF.java
@@ -69,7 +69,7 @@ public final class RF implements IIntegrationModule {
         this.registerRFAttunement("ThermalDynamics", "ThermalDynamics_0", 6);
 
         this.registerRFAttunement("EnderIO", "itemPowerConduit", OreDictionary.WILDCARD_VALUE);
-        this.registerRFAttunement("EnderIO", "blockCapacitorBank", 0);
+        this.registerRFAttunement("EnderIO", "blockCapBank", 0);
         this.registerRFAttunement("EnderIO", "blockPowerMonitor", 0);
     }
 


### PR DESCRIPTION
[I am removing legacy code](https://github.com/GTNewHorizons/EnderIO/pull/197) for the deprecated CapacitorBank in enderIO. This item has been uncraftable since 2014. The existing usable version is called CapBank in all code. This PR ensures this RF integration won't break once the refactor goes through on the EnderIO repo.

UPDATE: As per Koolkrafter's suggestions, this also adds P2P attunement for ME Conduit and ElectricLights