### PR TITLE
Fix Interface Terminal search function.

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiInterfaceTerminal.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiInterfaceTerminal.java
@@ -964,7 +964,7 @@ public class GuiInterfaceTerminal extends AEBaseGui
         if (searchTerm.length() >= 2 && searchTerm.startsWith("\"") && searchTerm.endsWith("\"")) {
             return sectionName.contains(searchTerm.substring(1, searchTerm.length() - 1).toLowerCase());
         } else {
-            String[] terms = searchTerm.toLowerCase().split("\s*");
+            String[] terms = searchTerm.toLowerCase().split("\s+");
 
             for (int i = 0; i < terms.length; i++) {
                 if (!sectionName.contains(terms[i])) {


### PR DESCRIPTION
Regex `\s*` matches the empty string, therefore it would split the search string at *every character*. This means that searching for "abcd" would in fact return all interfaces which contain "a", "b", "c", and "d", in any order or position.

New regex correctly splits only at *non-empty* sections of whitespace characters.

My testing of the initial PR just happened to use interface names where this was not an issue.