### PR TITLE
Make the charge rate of the Charger be affected by the multiplier of the power config

### DIFF
--- a/src/main/java/appeng/tile/misc/TileCharger.java
+++ b/src/main/java/appeng/tile/misc/TileCharger.java
@@ -105,9 +105,11 @@ public class TileCharger extends AENetworkPowerTile implements ICrankable {
                 this.injectExternalPower(
                         PowerUnits.AE,
                         this.getProxy().getEnergy().extractAEPower(
-                                Math.min(150.0, getInternalMaxPower() - this.getInternalCurrentPower()),
+                                Math.min(
+                                        PowerMultiplier.CONFIG.multiply(150.0),
+                                        getInternalMaxPower() - this.getInternalCurrentPower()),
                                 Actionable.MODULATE,
-                                PowerMultiplier.CONFIG) * PowerMultiplier.CONFIG.multiplier);
+                                PowerMultiplier.ONE));
                 this.tickTickTimer = 20; // keep ticking...
             } catch (final GridAccessException e) {
                 // continue!

--- a/src/main/java/appeng/tile/misc/TileCharger.java
+++ b/src/main/java/appeng/tile/misc/TileCharger.java
@@ -107,7 +107,7 @@ public class TileCharger extends AENetworkPowerTile implements ICrankable {
                         this.getProxy().getEnergy().extractAEPower(
                                 Math.min(150.0, getInternalMaxPower() - this.getInternalCurrentPower()),
                                 Actionable.MODULATE,
-                                PowerMultiplier.ONE));
+                                PowerMultiplier.CONFIG) * PowerMultiplier.CONFIG.multiplier);
                 this.tickTickTimer = 20; // keep ticking...
             } catch (final GridAccessException e) {
                 // continue!


### PR DESCRIPTION
I've tested it some with the pack config in my dev env.

![image](https://github.com/user-attachments/assets/173221d9-c416-4b70-9a36-250359a10b85)
It drains power FAST, but it keeps it topped up when running. 
So as long as you have enough energy in your AE Network, it will keep running.
