### PR TITLE
Speedup event registration

### DIFF
--- a/src/main/java/appeng/block/solids/BlockSkyStone.java
+++ b/src/main/java/appeng/block/solids/BlockSkyStone.java
@@ -62,21 +62,24 @@ public class BlockSkyStone extends AEBaseBlock implements IOrientableBlock {
         this.setHarvestLevel("pickaxe", 3, 0);
         this.setFeature(EnumSet.of(AEFeature.Core));
 
-        MinecraftForge.EVENT_BUS.register(this);
+        MinecraftForge.EVENT_BUS.register(new EventHandler());
     }
 
-    @SubscribeEvent
-    public void breakFaster(final PlayerEvent.BreakSpeed event) {
-        if (event.block == this && event.entityPlayer != null) {
-            final ItemStack is = event.entityPlayer.inventory.getCurrentItem();
-            int level = -1;
+    public class EventHandler {
 
-            if (is != null && is.getItem() != null) {
-                level = is.getItem().getHarvestLevel(is, "pickaxe");
-            }
+        @SubscribeEvent
+        public void breakFaster(final PlayerEvent.BreakSpeed event) {
+            if (event.block == BlockSkyStone.this && event.entityPlayer != null) {
+                final ItemStack is = event.entityPlayer.inventory.getCurrentItem();
+                int level = -1;
 
-            if (event.metadata > 0 || level >= 3 || event.originalSpeed > BREAK_SPEAK_THRESHOLD) {
-                event.newSpeed /= BREAK_SPEAK_SCALAR;
+                if (is != null && is.getItem() != null) {
+                    level = is.getItem().getHarvestLevel(is, "pickaxe");
+                }
+
+                if (event.metadata > 0 || level >= 3 || event.originalSpeed > BREAK_SPEAK_THRESHOLD) {
+                    event.newSpeed /= BREAK_SPEAK_SCALAR;
+                }
             }
         }
     }

--- a/src/main/java/appeng/core/AEConfig.java
+++ b/src/main/java/appeng/core/AEConfig.java
@@ -124,7 +124,7 @@ public final class AEConfig extends Configuration implements IConfigurableObject
         super(configFile);
         this.configFile = configFile;
 
-        FMLCommonHandler.instance().bus().register(this);
+        FMLCommonHandler.instance().bus().register(new EventHandler());
 
         final double DEFAULT_MEKANISM_EXCHANGE = 0.2;
         PowerUnits.MK.conversionRatio = this.get("PowerRatios", "Mekanism", DEFAULT_MEKANISM_EXCHANGE)
@@ -440,10 +440,13 @@ public final class AEConfig extends Configuration implements IConfigurableObject
         }
     }
 
-    @SubscribeEvent
-    public void onConfigChanged(final ConfigChangedEvent.OnConfigChangedEvent eventArgs) {
-        if (eventArgs.modID.equals(AppEng.MOD_ID)) {
-            this.clientSync();
+    public class EventHandler {
+
+        @SubscribeEvent
+        public void onConfigChanged(final ConfigChangedEvent.OnConfigChangedEvent eventArgs) {
+            if (eventArgs.modID.equals(AppEng.MOD_ID)) {
+                AEConfig.this.clientSync();
+            }
         }
     }
 


### PR DESCRIPTION
Speed up event registration by encapusulating the event handlers in an inner class, this way when registering the event, forge only sees one method via reflection instead of all the methods of the class + parent class