### PR TITLE
Search all entire network (including subnets) to find item locations

### DIFF
--- a/src/main/java/appeng/api/networking/IGrid.java
+++ b/src/main/java/appeng/api/networking/IGrid.java
@@ -17,6 +17,7 @@ import java.util.UUID;
 
 import appeng.api.networking.events.MENetworkEvent;
 import appeng.api.util.IReadOnlyCollection;
+import appeng.me.NetworkList;
 
 /**
  * Gives you access to Grid based information.
@@ -84,4 +85,20 @@ public interface IGrid {
      * @return the node considered the pivot point of the grid.
      */
     IGridNode getPivot();
+
+    /**
+     * List of every adjacent grids
+     * 
+     * @param accessType Type of access extending the grid, ie. PartStorageBus/PartFluidStorageBus
+     * @return List of connected Grids
+     */
+    public NetworkList getGridConnections(Class<? extends IGridHost> accessType);
+
+    /**
+     * Complete list of every grid on a network, flattened.
+     * 
+     * @param accessType Type of access extending the grid, ie. PartStorageBus/PartFluidStorageBus
+     * @return List of connected Grids, recursively found on the entire network
+     */
+    public NetworkList getAllRecursiveGridConnections(Class<? extends IGridHost> accessType);
 }

--- a/src/main/java/appeng/api/networking/IGrid.java
+++ b/src/main/java/appeng/api/networking/IGrid.java
@@ -13,10 +13,10 @@
 
 package appeng.api.networking;
 
+import java.util.UUID;
+
 import appeng.api.networking.events.MENetworkEvent;
 import appeng.api.util.IReadOnlyCollection;
-
-import java.util.UUID;
 
 /**
  * Gives you access to Grid based information.

--- a/src/main/java/appeng/api/networking/IGrid.java
+++ b/src/main/java/appeng/api/networking/IGrid.java
@@ -16,6 +16,8 @@ package appeng.api.networking;
 import appeng.api.networking.events.MENetworkEvent;
 import appeng.api.util.IReadOnlyCollection;
 
+import java.util.UUID;
+
 /**
  * Gives you access to Grid based information.
  * <p>
@@ -72,6 +74,11 @@ public interface IGrid {
      * @return true if the last node has been removed from the grid.
      */
     boolean isEmpty();
+
+    /**
+     * @return unique id generated on initialization of the grid
+     */
+    UUID getId();
 
     /**
      * @return the node considered the pivot point of the grid.

--- a/src/main/java/appeng/api/storage/data/IAEStack.java
+++ b/src/main/java/appeng/api/storage/data/IAEStack.java
@@ -222,4 +222,9 @@ public interface IAEStack<StackType extends IAEStack> {
      * @return ITEM or FLUID
      */
     StorageChannel getChannel();
+
+    /**
+     * @return Display name of item
+     */
+    String getName();
 }

--- a/src/main/java/appeng/api/util/ItemSearchDTO.java
+++ b/src/main/java/appeng/api/util/ItemSearchDTO.java
@@ -1,0 +1,84 @@
+package appeng.api.util;
+
+import appeng.api.storage.data.IAEStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.common.util.ForgeDirection;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ItemSearchDTO {
+
+    public DimensionalCoord coord;
+    public int cellSlot;
+    public long itemCount;
+    public ForgeDirection forward;
+    public ForgeDirection up;
+    public String name;
+
+    public ItemSearchDTO(DimensionalCoord coord, IAEStack items, String name, int cellSlot, ForgeDirection forward, ForgeDirection up) {
+        this.coord = coord;
+        this.cellSlot = cellSlot;
+        this.itemCount = items.getStackSize();
+        this.name = name;
+        this.forward = forward;
+        this.up = up;
+    }
+
+    public ItemSearchDTO(DimensionalCoord coord, IAEStack items, String name) {
+        this(coord, items, name,-1, ForgeDirection.UNKNOWN, ForgeDirection.UNKNOWN);
+    }
+
+    public ItemSearchDTO(final NBTTagCompound data) {
+        this.readFromNBT(data);
+    }
+
+    public void writeToNBT(final NBTTagCompound data) {
+        data.setInteger("dim", coord.dimId);
+        data.setInteger("x", coord.x);
+        data.setInteger("y", coord.y);
+        data.setInteger("z", coord.z);
+        data.setInteger("s", cellSlot);
+        data.setLong("c", itemCount);
+        data.setString("n", name);
+        data.setString("f", this.forward.name());
+        data.setString("u", this.up.name());
+    }
+
+    public static void writeListToNBT(final NBTTagCompound tag, List<ItemSearchDTO> list) {
+        int i = 0;
+        for (ItemSearchDTO d : list) {
+            NBTTagCompound data = new NBTTagCompound();
+            d.writeToNBT(data);
+            tag.setTag("pos#" + i, data);
+            i++;
+        }
+    }
+
+    public static List<ItemSearchDTO> readAsListFromNBT(final NBTTagCompound tag) {
+        List<ItemSearchDTO> list = new ArrayList<>();
+        int i = 0;
+        while (tag.hasKey("pos#" + i)) {
+            NBTTagCompound data = tag.getCompoundTag("pos#" + i);
+            list.add(new ItemSearchDTO(data));
+            i++;
+        }
+        return list;
+    }
+
+    private void readFromNBT(final NBTTagCompound data) {
+        int dim = data.getInteger("dim");
+        int x = data.getInteger("x");
+        int y = data.getInteger("y");
+        int z = data.getInteger("z");
+        this.name = data.getString("n");
+        this.itemCount = data.getLong("c");
+        this.cellSlot = data.getInteger("s");
+        this.coord = new DimensionalCoord(x, y, z, dim);
+        this.forward = ForgeDirection.valueOf(data.getString("f"));
+        this.up = ForgeDirection.valueOf(data.getString("u"));
+    }
+
+
+
+}

--- a/src/main/java/appeng/api/util/ItemSearchDTO.java
+++ b/src/main/java/appeng/api/util/ItemSearchDTO.java
@@ -1,11 +1,12 @@
 package appeng.api.util;
 
-import appeng.api.storage.data.IAEStack;
+import java.util.ArrayList;
+import java.util.List;
+
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import java.util.ArrayList;
-import java.util.List;
+import appeng.api.storage.data.IAEStack;
 
 public class ItemSearchDTO {
 
@@ -16,7 +17,8 @@ public class ItemSearchDTO {
     public ForgeDirection up;
     public String name;
 
-    public ItemSearchDTO(DimensionalCoord coord, IAEStack items, String name, int cellSlot, ForgeDirection forward, ForgeDirection up) {
+    public ItemSearchDTO(DimensionalCoord coord, IAEStack items, String name, int cellSlot, ForgeDirection forward,
+            ForgeDirection up) {
         this.coord = coord;
         this.cellSlot = cellSlot;
         this.itemCount = items.getStackSize();
@@ -26,7 +28,7 @@ public class ItemSearchDTO {
     }
 
     public ItemSearchDTO(DimensionalCoord coord, IAEStack items, String name) {
-        this(coord, items, name,-1, ForgeDirection.UNKNOWN, ForgeDirection.UNKNOWN);
+        this(coord, items, name, -1, ForgeDirection.UNKNOWN, ForgeDirection.UNKNOWN);
     }
 
     public ItemSearchDTO(final NBTTagCompound data) {
@@ -78,7 +80,5 @@ public class ItemSearchDTO {
         this.forward = ForgeDirection.valueOf(data.getString("f"));
         this.up = ForgeDirection.valueOf(data.getString("u"));
     }
-
-
 
 }

--- a/src/main/java/appeng/api/util/ItemSearchDTO.java
+++ b/src/main/java/appeng/api/util/ItemSearchDTO.java
@@ -15,20 +15,23 @@ public class ItemSearchDTO {
     public long itemCount;
     public ForgeDirection forward;
     public ForgeDirection up;
-    public String name;
+    public String blockName;
+    public String itemName;
 
-    public ItemSearchDTO(DimensionalCoord coord, IAEStack items, String name, int cellSlot, ForgeDirection forward,
+    public ItemSearchDTO(DimensionalCoord coord, IAEStack items, String blockName, int cellSlot, ForgeDirection forward,
             ForgeDirection up) {
         this.coord = coord;
         this.cellSlot = cellSlot;
         this.itemCount = items.getStackSize();
-        this.name = name;
+        this.itemName = items.getName();
+        if (this.itemName == null) this.itemName = " ";
+        this.blockName = blockName;
         this.forward = forward;
         this.up = up;
     }
 
-    public ItemSearchDTO(DimensionalCoord coord, IAEStack items, String name) {
-        this(coord, items, name, -1, ForgeDirection.UNKNOWN, ForgeDirection.UNKNOWN);
+    public ItemSearchDTO(DimensionalCoord coord, IAEStack items, String blockName) {
+        this(coord, items, blockName, -1, ForgeDirection.UNKNOWN, ForgeDirection.UNKNOWN);
     }
 
     public ItemSearchDTO(final NBTTagCompound data) {
@@ -42,7 +45,8 @@ public class ItemSearchDTO {
         data.setInteger("z", coord.z);
         data.setInteger("s", cellSlot);
         data.setLong("c", itemCount);
-        data.setString("n", name);
+        data.setString("n", blockName);
+        data.setString("in", itemName);
         data.setString("f", this.forward.name());
         data.setString("u", this.up.name());
     }
@@ -73,7 +77,8 @@ public class ItemSearchDTO {
         int x = data.getInteger("x");
         int y = data.getInteger("y");
         int z = data.getInteger("z");
-        this.name = data.getString("n");
+        this.blockName = data.getString("n");
+        this.itemName = data.getString("in");
         this.itemCount = data.getLong("c");
         this.cellSlot = data.getInteger("s");
         this.coord = new DimensionalCoord(x, y, z, dim);

--- a/src/main/java/appeng/client/gui/AEBaseGui.java
+++ b/src/main/java/appeng/client/gui/AEBaseGui.java
@@ -616,6 +616,9 @@ public abstract class AEBaseGui extends GuiContainer {
                 NetworkHandler.instance.sendToServer(p);
             }
 
+            if (action.equals(InventoryAction.FIND_ITEMS)) {
+                this.mc.thePlayer.closeScreen();
+            }
             return;
         }
 

--- a/src/main/java/appeng/client/gui/AEBaseGui.java
+++ b/src/main/java/appeng/client/gui/AEBaseGui.java
@@ -538,7 +538,9 @@ public abstract class AEBaseGui extends GuiContainer {
                 }
                 case 1 -> action = ctrlDown == 1 ? InventoryAction.PICKUP_SINGLE : InventoryAction.SHIFT_CLICK;
                 case 3 -> { // creative dupe:
-                    if (player.capabilities.isCreativeMode) {
+                    if (isCtrlKeyDown()) {
+                        action = InventoryAction.FIND_ITEMS;
+                    } else if (player.capabilities.isCreativeMode) {
                         action = InventoryAction.CREATIVE_DUPLICATE;
                     }
                 } // drop item:
@@ -594,7 +596,9 @@ public abstract class AEBaseGui extends GuiContainer {
                 }
                 case 3 -> { // creative dupe:
                     stack = ((SlotME) slot).getAEStack();
-                    if (stack != null && stack.isCraftable()) {
+                    if (isCtrlKeyDown()) {
+                        action = InventoryAction.FIND_ITEMS;
+                    } else if (stack != null && stack.isCraftable()) {
                         action = InventoryAction.AUTO_CRAFT;
                     } else if (player.capabilities.isCreativeMode) {
                         final IAEItemStack slotItem = ((SlotME) slot).getAEStack();

--- a/src/main/java/appeng/client/render/BlockPosHighlighter.java
+++ b/src/main/java/appeng/client/render/BlockPosHighlighter.java
@@ -3,14 +3,21 @@ package appeng.client.render;
 import java.util.ArrayList;
 import java.util.List;
 
+import appeng.api.util.ItemSearchDTO;
+import appeng.client.texture.ExtraBlockTextures;
+import appeng.util.Platform;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
+import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.ChatComponentTranslation;
+import net.minecraft.util.IIcon;
 import net.minecraft.util.MathHelper;
 import net.minecraftforge.client.event.RenderWorldLastEvent;
 
+import net.minecraftforge.common.util.ForgeDirection;
 import org.lwjgl.opengl.GL11;
 
 import appeng.api.util.DimensionalCoord;
@@ -21,6 +28,7 @@ import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 public class BlockPosHighlighter {
 
     private static final List<DimensionalCoord> highlightedBlocks = new ArrayList<>();
+    private static final List<ItemSearchDTO> highlightedCells = new ArrayList<>();
     private static long expireHighlightTime;
     private static final int MIN_TIME = 3000;
     private static final int MAX_TIME = MIN_TIME * 10;
@@ -61,8 +69,35 @@ public class BlockPosHighlighter {
         highlightBlocks(player, interfaces, "", foundMsg, wrongDimMsg);
     }
 
+    public static void highlightStorage(EntityPlayer player, List<ItemSearchDTO> interfaces, String foundMsg, String wrongDimMsg) {
+        clear();
+        int highlightDuration = MIN_TIME;
+        for (ItemSearchDTO storage : interfaces) {
+
+            if(storage.cellSlot >= 0) {
+                highlightedCells.add(storage);
+            }
+            highlightedBlocks.add(storage.coord);
+
+            highlightDuration = Math.max(
+                    highlightDuration,
+                    MathHelper.clamp_int(500 * WorldCoord.getTaxicabDistance(storage.coord, player), MIN_TIME, MAX_TIME));
+
+            if (player.worldObj.provider.dimensionId == storage.coord.getDimension()) {
+                if (foundMsg == null) {
+                    continue;
+                }
+                player.addChatMessage(new ChatComponentTranslation(foundMsg, storage.name, storage.itemCount, storage.coord.x, storage.coord.y, storage.coord.z));
+            } else if (wrongDimMsg != null) {
+                player.addChatMessage(new ChatComponentTranslation(wrongDimMsg, storage.name, storage.itemCount, storage.coord.getDimension()));
+            }
+        }
+        expireHighlightTime = System.currentTimeMillis() + highlightDuration;
+    }
+
     private static void clear() {
         highlightedBlocks.clear();
+        highlightedCells.clear();
         expireHighlightTime = -1;
     }
 
@@ -105,6 +140,315 @@ public class BlockPosHighlighter {
             GL11.glPopAttrib();
             GL11.glPopMatrix();
         }
+        for (ItemSearchDTO storage : highlightedCells) {
+            DimensionalCoord c = storage.coord;
+            if (dimension != c.getDimension()) {
+                continue;
+            }
+            GL11.glPushMatrix();
+            GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS);
+            GL11.glLineWidth(3);
+            GL11.glTranslated(-doubleX, -doubleY, -doubleZ);
+
+            GL11.glDisable(GL11.GL_DEPTH_TEST);
+            GL11.glDisable(GL11.GL_TEXTURE_2D);
+
+            renderHighLightedCellSlotOverlay(c.x, c.y, c.z, storage.cellSlot, storage.forward, storage.up);
+
+            GL11.glPopAttrib();
+            GL11.glPopMatrix();
+        }
+    }
+
+    private static void renderHighLightedCellSlotOverlay(double x, double y, double z, int index, ForgeDirection forward, ForgeDirection up) {
+        Tessellator tess = Tessellator.instance;
+        tess.startDrawingQuads();
+
+        // Transparent yellow
+        tess.setColorRGBA_F(1.0f, 1.0f, 0.0f, 0.4f);
+
+        int spin = 0;
+
+        switch (forward.offsetX + forward.offsetY * 2 + forward.offsetZ * 3) {
+            case 1 -> {
+                switch (up) {
+                    case UP -> spin = 3;
+                    case DOWN -> spin = 1;
+                    case NORTH -> spin = 0;
+                    case SOUTH -> spin = 2;
+                    default -> {}
+                }
+            }
+            case -1 -> {
+                switch (up) {
+                    case UP -> spin = 1;
+                    case DOWN -> spin = 3;
+                    case NORTH -> spin = 0;
+                    case SOUTH -> spin = 2;
+                    default -> {}
+                }
+            }
+            case -2 -> {
+                switch (up) {
+                    case EAST -> spin = 1;
+                    case WEST -> spin = 3;
+                    case NORTH -> spin = 2;
+                    case SOUTH -> spin = 0;
+                    default -> {}
+                }
+            }
+            case 2 -> {
+                switch (up) {
+                    case EAST -> spin = 1;
+                    case WEST -> spin = 3;
+                    case NORTH -> spin = 0;
+                    case SOUTH -> spin = 0;
+                    default -> {}
+                }
+            }
+            case 3 -> {
+                switch (up) {
+                    case UP -> spin = 2;
+                    case DOWN -> spin = 0;
+                    case EAST -> spin = 3;
+                    case WEST -> spin = 1;
+                    default -> {}
+                }
+            }
+            case -3 -> {
+                switch (up) {
+                    case UP -> spin = 2;
+                    case DOWN -> spin = 0;
+                    case EAST -> spin = 1;
+                    case WEST -> spin = 3;
+                    default -> {}
+                }
+            }
+        }
+
+        // Calculate 2x5 grid position
+        int origCol = 1-(index % 2);
+        int origRow = index / 2;    // 0 or 1
+
+        final ForgeDirection west = Platform.crossProduct(forward, up);
+        RenderBlocks renderer = new RenderBlocks();
+        selectFace(renderer, west, up, forward,
+                2 + origCol * 7, 7 + origCol * 7, 1 + origRow * 3, 3 + origRow * 3);
+
+        double u1 = interpU((spin % 4 < 2) ? 1 : 6);
+        double u2 = interpU(((spin + 1) % 4 < 2) ? 1 : 6);
+        double u3 = interpU(((spin + 2) % 4 < 2) ? 1 : 6);
+        double u4 = interpU(((spin + 3) % 4 < 2) ? 1 : 6);
+
+        double v1 = interpU(((spin + 1) % 4 < 2) ? 1 : 3);
+        double v2 = interpU(((spin + 2) % 4 < 2) ? 1 : 3);
+        double v3 = interpU(((spin + 3) % 4 < 2) ? 1 : 3);
+        double v4 = interpU(((spin) % 4 < 2) ? 1 : 3);
+
+        switch (forward.offsetX + forward.offsetY * 2 + forward.offsetZ * 3) {
+            case 1 -> {
+                tess.addVertexWithUV(
+                        x + renderer.renderMaxX,
+                        y + renderer.renderMaxY,
+                        z + renderer.renderMinZ,
+                        u1,
+                        v1);
+                tess.addVertexWithUV(
+                        x + renderer.renderMaxX,
+                        y + renderer.renderMaxY,
+                        z + renderer.renderMaxZ,
+                        u2,
+                        v2);
+                tess.addVertexWithUV(
+                        x + renderer.renderMaxX,
+                        y + renderer.renderMinY,
+                        z + renderer.renderMaxZ,
+                        u3,
+                        v3);
+                tess.addVertexWithUV(
+                        x + renderer.renderMaxX,
+                        y + renderer.renderMinY,
+                        z + renderer.renderMinZ,
+                        u4,
+                        v4);
+            }
+            case -1 -> {
+                tess.addVertexWithUV(
+                        x + renderer.renderMaxX,
+                        y + renderer.renderMinY,
+                        z + renderer.renderMinZ,
+                        u1,
+                        v1);
+                tess.addVertexWithUV(
+                        x + renderer.renderMaxX,
+                        y + renderer.renderMinY,
+                        z + renderer.renderMaxZ,
+                        u2,
+                        v2);
+                tess.addVertexWithUV(
+                        x + renderer.renderMaxX,
+                        y + renderer.renderMaxY,
+                        z + renderer.renderMaxZ,
+                        u3,
+                        v3);
+                tess.addVertexWithUV(
+                        x + renderer.renderMaxX,
+                        y + renderer.renderMaxY,
+                        z + renderer.renderMinZ,
+                        u4,
+                        v4);
+            }
+            case -2 -> {
+                tess.addVertexWithUV(
+                        x + renderer.renderMaxX,
+                        y + renderer.renderMaxY,
+                        z + renderer.renderMinZ,
+                        u1,
+                        v1);
+                tess.addVertexWithUV(
+                        x + renderer.renderMaxX,
+                        y + renderer.renderMaxY,
+                        z + renderer.renderMaxZ,
+                        u2,
+                        v2);
+                tess.addVertexWithUV(
+                        x + renderer.renderMinX,
+                        y + renderer.renderMaxY,
+                        z + renderer.renderMaxZ,
+                        u3,
+                        v3);
+                tess.addVertexWithUV(
+                        x + renderer.renderMinX,
+                        y + renderer.renderMaxY,
+                        z + renderer.renderMinZ,
+                        u4,
+                        v4);
+            }
+            case 2 -> {
+                tess.addVertexWithUV(
+                        x + renderer.renderMinX,
+                        y + renderer.renderMaxY,
+                        z + renderer.renderMinZ,
+                        u1,
+                        v1);
+                tess.addVertexWithUV(
+                        x + renderer.renderMinX,
+                        y + renderer.renderMaxY,
+                        z + renderer.renderMaxZ,
+                        u2,
+                        v2);
+                tess.addVertexWithUV(
+                        x + renderer.renderMaxX,
+                        y + renderer.renderMaxY,
+                        z + renderer.renderMaxZ,
+                        u3,
+                        v3);
+                tess.addVertexWithUV(
+                        x + renderer.renderMaxX,
+                        y + renderer.renderMaxY,
+                        z + renderer.renderMinZ,
+                        u4,
+                        v4);
+            }
+            case 3 -> {
+                tess.addVertexWithUV(
+                        x + renderer.renderMaxX,
+                        y + renderer.renderMinY,
+                        z + renderer.renderMaxZ,
+                        u1,
+                        v1);
+                tess.addVertexWithUV(
+                        x + renderer.renderMaxX,
+                        y + renderer.renderMaxY,
+                        z + renderer.renderMaxZ,
+                        u2,
+                        v2);
+                tess.addVertexWithUV(
+                        x + renderer.renderMinX,
+                        y + renderer.renderMaxY,
+                        z + renderer.renderMaxZ,
+                        u3,
+                        v3);
+                tess.addVertexWithUV(
+                        x + renderer.renderMinX,
+                        y + renderer.renderMinY,
+                        z + renderer.renderMaxZ,
+                        u4,
+                        v4);
+            }
+            case -3 -> {
+                tess.addVertexWithUV(
+                        x + renderer.renderMinX,
+                        y + renderer.renderMinY,
+                        z + renderer.renderMaxZ,
+                        u1,
+                        v1);
+                tess.addVertexWithUV(
+                        x + renderer.renderMinX,
+                        y + renderer.renderMaxY,
+                        z + renderer.renderMaxZ,
+                        u2,
+                        v2);
+                tess.addVertexWithUV(
+                        x + renderer.renderMaxX,
+                        y + renderer.renderMaxY,
+                        z + renderer.renderMaxZ,
+                        u3,
+                        v3);
+                tess.addVertexWithUV(
+                        x + renderer.renderMaxX,
+                        y + renderer.renderMinY,
+                        z + renderer.renderMaxZ,
+                        u4,
+                        v4);
+            }
+        }
+        tess.draw();
+    }
+
+    private static void selectFace(final RenderBlocks renderer, final ForgeDirection west, final ForgeDirection up,
+                           final ForgeDirection forward, final int u1, final int u2, int v1, int v2) {
+        v1 = 16 - v1;
+        v2 = 16 - v2;
+
+        final double minX = (forward.offsetX > 0 ? 1 : 0) + mapFaceUV(west.offsetX, u1)
+                + mapFaceUV(up.offsetX, v1);
+        final double minY = (forward.offsetY > 0 ? 1 : 0) + mapFaceUV(west.offsetY, u1)
+                + mapFaceUV(up.offsetY, v1);
+        final double minZ = (forward.offsetZ > 0 ? 1 : 0) + mapFaceUV(west.offsetZ, u1)
+                + mapFaceUV(up.offsetZ, v1);
+
+        final double maxX = (forward.offsetX > 0 ? 1 : 0) + mapFaceUV(west.offsetX, u2)
+                + mapFaceUV(up.offsetX, v2);
+        final double maxY = (forward.offsetY > 0 ? 1 : 0) + mapFaceUV(west.offsetY, u2)
+                + mapFaceUV(up.offsetY, v2);
+        final double maxZ = (forward.offsetZ > 0 ? 1 : 0) + mapFaceUV(west.offsetZ, u2)
+                + mapFaceUV(up.offsetZ, v2);
+
+        renderer.renderMinX = Math.max(0.0, Math.min(minX, maxX) - (forward.offsetX != 0 ? 0 : 0.001));
+        renderer.renderMaxX = Math.min(1.0, Math.max(minX, maxX) + (forward.offsetX != 0 ? 0 : 0.001));
+
+        renderer.renderMinY = Math.max(0.0, Math.min(minY, maxY) - (forward.offsetY != 0 ? 0 : 0.001));
+        renderer.renderMaxY = Math.min(1.0, Math.max(minY, maxY) + (forward.offsetY != 0 ? 0 : 0.001));
+
+        renderer.renderMinZ = Math.max(0.0, Math.min(minZ, maxZ) - (forward.offsetZ != 0 ? 0 : 0.001));
+        renderer.renderMaxZ = Math.min(1.0, Math.max(minZ, maxZ) + (forward.offsetZ != 0 ? 0 : 0.001));
+    }
+
+    private static double mapFaceUV(final int offset, final int uv) {
+        if (offset == 0) {
+            return 0;
+        }
+
+        if (offset > 0) {
+            return uv / 16.0;
+        }
+
+        return (16.0 - uv) / 16.0;
+    }
+
+    private static float interpU(int texCoord) {
+        return texCoord / 16f;
     }
 
     private static void renderHighLightedBlocksOutline(double x, double y, double z) {

--- a/src/main/java/appeng/client/render/BlockPosHighlighter.java
+++ b/src/main/java/appeng/client/render/BlockPosHighlighter.java
@@ -3,25 +3,22 @@ package appeng.client.render;
 import java.util.ArrayList;
 import java.util.List;
 
-import appeng.api.util.ItemSearchDTO;
-import appeng.client.texture.ExtraBlockTextures;
-import appeng.util.Platform;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.ChatComponentTranslation;
-import net.minecraft.util.IIcon;
 import net.minecraft.util.MathHelper;
 import net.minecraftforge.client.event.RenderWorldLastEvent;
-
 import net.minecraftforge.common.util.ForgeDirection;
+
 import org.lwjgl.opengl.GL11;
 
 import appeng.api.util.DimensionalCoord;
+import appeng.api.util.ItemSearchDTO;
 import appeng.api.util.WorldCoord;
+import appeng.util.Platform;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 
 // taken from McJty's McJtyLib
@@ -69,27 +66,41 @@ public class BlockPosHighlighter {
         highlightBlocks(player, interfaces, "", foundMsg, wrongDimMsg);
     }
 
-    public static void highlightStorage(EntityPlayer player, List<ItemSearchDTO> interfaces, String foundMsg, String wrongDimMsg) {
+    public static void highlightStorage(EntityPlayer player, List<ItemSearchDTO> interfaces, String foundMsg,
+            String wrongDimMsg) {
         clear();
         int highlightDuration = MIN_TIME;
         for (ItemSearchDTO storage : interfaces) {
 
-            if(storage.cellSlot >= 0) {
+            if (storage.cellSlot >= 0) {
                 highlightedCells.add(storage);
             }
             highlightedBlocks.add(storage.coord);
 
             highlightDuration = Math.max(
                     highlightDuration,
-                    MathHelper.clamp_int(500 * WorldCoord.getTaxicabDistance(storage.coord, player), MIN_TIME, MAX_TIME));
+                    MathHelper
+                            .clamp_int(500 * WorldCoord.getTaxicabDistance(storage.coord, player), MIN_TIME, MAX_TIME));
 
             if (player.worldObj.provider.dimensionId == storage.coord.getDimension()) {
                 if (foundMsg == null) {
                     continue;
                 }
-                player.addChatMessage(new ChatComponentTranslation(foundMsg, storage.name, storage.itemCount, storage.coord.x, storage.coord.y, storage.coord.z));
+                player.addChatMessage(
+                        new ChatComponentTranslation(
+                                foundMsg,
+                                storage.name,
+                                storage.itemCount,
+                                storage.coord.x,
+                                storage.coord.y,
+                                storage.coord.z));
             } else if (wrongDimMsg != null) {
-                player.addChatMessage(new ChatComponentTranslation(wrongDimMsg, storage.name, storage.itemCount, storage.coord.getDimension()));
+                player.addChatMessage(
+                        new ChatComponentTranslation(
+                                wrongDimMsg,
+                                storage.name,
+                                storage.itemCount,
+                                storage.coord.getDimension()));
             }
         }
         expireHighlightTime = System.currentTimeMillis() + highlightDuration;
@@ -160,7 +171,8 @@ public class BlockPosHighlighter {
         }
     }
 
-    private static void renderHighLightedCellSlotOverlay(double x, double y, double z, int index, ForgeDirection forward, ForgeDirection up) {
+    private static void renderHighLightedCellSlotOverlay(double x, double y, double z, int index,
+            ForgeDirection forward, ForgeDirection up) {
         Tessellator tess = Tessellator.instance;
         tess.startDrawingQuads();
 
@@ -227,13 +239,12 @@ public class BlockPosHighlighter {
         }
 
         // Calculate 2x5 grid position
-        int origCol = 1-(index % 2);
-        int origRow = index / 2;    // 0 or 1
+        int origCol = 1 - (index % 2);
+        int origRow = index / 2; // 0 or 1
 
         final ForgeDirection west = Platform.crossProduct(forward, up);
         RenderBlocks renderer = new RenderBlocks();
-        selectFace(renderer, west, up, forward,
-                2 + origCol * 7, 7 + origCol * 7, 1 + origRow * 3, 3 + origRow * 3);
+        selectFace(renderer, west, up, forward, 2 + origCol * 7, 7 + origCol * 7, 1 + origRow * 3, 3 + origRow * 3);
 
         double u1 = interpU((spin % 4 < 2) ? 1 : 6);
         double u2 = interpU(((spin + 1) % 4 < 2) ? 1 : 6);
@@ -247,183 +258,57 @@ public class BlockPosHighlighter {
 
         switch (forward.offsetX + forward.offsetY * 2 + forward.offsetZ * 3) {
             case 1 -> {
-                tess.addVertexWithUV(
-                        x + renderer.renderMaxX,
-                        y + renderer.renderMaxY,
-                        z + renderer.renderMinZ,
-                        u1,
-                        v1);
-                tess.addVertexWithUV(
-                        x + renderer.renderMaxX,
-                        y + renderer.renderMaxY,
-                        z + renderer.renderMaxZ,
-                        u2,
-                        v2);
-                tess.addVertexWithUV(
-                        x + renderer.renderMaxX,
-                        y + renderer.renderMinY,
-                        z + renderer.renderMaxZ,
-                        u3,
-                        v3);
-                tess.addVertexWithUV(
-                        x + renderer.renderMaxX,
-                        y + renderer.renderMinY,
-                        z + renderer.renderMinZ,
-                        u4,
-                        v4);
+                tess.addVertexWithUV(x + renderer.renderMaxX, y + renderer.renderMaxY, z + renderer.renderMinZ, u1, v1);
+                tess.addVertexWithUV(x + renderer.renderMaxX, y + renderer.renderMaxY, z + renderer.renderMaxZ, u2, v2);
+                tess.addVertexWithUV(x + renderer.renderMaxX, y + renderer.renderMinY, z + renderer.renderMaxZ, u3, v3);
+                tess.addVertexWithUV(x + renderer.renderMaxX, y + renderer.renderMinY, z + renderer.renderMinZ, u4, v4);
             }
             case -1 -> {
-                tess.addVertexWithUV(
-                        x + renderer.renderMaxX,
-                        y + renderer.renderMinY,
-                        z + renderer.renderMinZ,
-                        u1,
-                        v1);
-                tess.addVertexWithUV(
-                        x + renderer.renderMaxX,
-                        y + renderer.renderMinY,
-                        z + renderer.renderMaxZ,
-                        u2,
-                        v2);
-                tess.addVertexWithUV(
-                        x + renderer.renderMaxX,
-                        y + renderer.renderMaxY,
-                        z + renderer.renderMaxZ,
-                        u3,
-                        v3);
-                tess.addVertexWithUV(
-                        x + renderer.renderMaxX,
-                        y + renderer.renderMaxY,
-                        z + renderer.renderMinZ,
-                        u4,
-                        v4);
+                tess.addVertexWithUV(x + renderer.renderMaxX, y + renderer.renderMinY, z + renderer.renderMinZ, u1, v1);
+                tess.addVertexWithUV(x + renderer.renderMaxX, y + renderer.renderMinY, z + renderer.renderMaxZ, u2, v2);
+                tess.addVertexWithUV(x + renderer.renderMaxX, y + renderer.renderMaxY, z + renderer.renderMaxZ, u3, v3);
+                tess.addVertexWithUV(x + renderer.renderMaxX, y + renderer.renderMaxY, z + renderer.renderMinZ, u4, v4);
             }
             case -2 -> {
-                tess.addVertexWithUV(
-                        x + renderer.renderMaxX,
-                        y + renderer.renderMaxY,
-                        z + renderer.renderMinZ,
-                        u1,
-                        v1);
-                tess.addVertexWithUV(
-                        x + renderer.renderMaxX,
-                        y + renderer.renderMaxY,
-                        z + renderer.renderMaxZ,
-                        u2,
-                        v2);
-                tess.addVertexWithUV(
-                        x + renderer.renderMinX,
-                        y + renderer.renderMaxY,
-                        z + renderer.renderMaxZ,
-                        u3,
-                        v3);
-                tess.addVertexWithUV(
-                        x + renderer.renderMinX,
-                        y + renderer.renderMaxY,
-                        z + renderer.renderMinZ,
-                        u4,
-                        v4);
+                tess.addVertexWithUV(x + renderer.renderMaxX, y + renderer.renderMaxY, z + renderer.renderMinZ, u1, v1);
+                tess.addVertexWithUV(x + renderer.renderMaxX, y + renderer.renderMaxY, z + renderer.renderMaxZ, u2, v2);
+                tess.addVertexWithUV(x + renderer.renderMinX, y + renderer.renderMaxY, z + renderer.renderMaxZ, u3, v3);
+                tess.addVertexWithUV(x + renderer.renderMinX, y + renderer.renderMaxY, z + renderer.renderMinZ, u4, v4);
             }
             case 2 -> {
-                tess.addVertexWithUV(
-                        x + renderer.renderMinX,
-                        y + renderer.renderMaxY,
-                        z + renderer.renderMinZ,
-                        u1,
-                        v1);
-                tess.addVertexWithUV(
-                        x + renderer.renderMinX,
-                        y + renderer.renderMaxY,
-                        z + renderer.renderMaxZ,
-                        u2,
-                        v2);
-                tess.addVertexWithUV(
-                        x + renderer.renderMaxX,
-                        y + renderer.renderMaxY,
-                        z + renderer.renderMaxZ,
-                        u3,
-                        v3);
-                tess.addVertexWithUV(
-                        x + renderer.renderMaxX,
-                        y + renderer.renderMaxY,
-                        z + renderer.renderMinZ,
-                        u4,
-                        v4);
+                tess.addVertexWithUV(x + renderer.renderMinX, y + renderer.renderMaxY, z + renderer.renderMinZ, u1, v1);
+                tess.addVertexWithUV(x + renderer.renderMinX, y + renderer.renderMaxY, z + renderer.renderMaxZ, u2, v2);
+                tess.addVertexWithUV(x + renderer.renderMaxX, y + renderer.renderMaxY, z + renderer.renderMaxZ, u3, v3);
+                tess.addVertexWithUV(x + renderer.renderMaxX, y + renderer.renderMaxY, z + renderer.renderMinZ, u4, v4);
             }
             case 3 -> {
-                tess.addVertexWithUV(
-                        x + renderer.renderMaxX,
-                        y + renderer.renderMinY,
-                        z + renderer.renderMaxZ,
-                        u1,
-                        v1);
-                tess.addVertexWithUV(
-                        x + renderer.renderMaxX,
-                        y + renderer.renderMaxY,
-                        z + renderer.renderMaxZ,
-                        u2,
-                        v2);
-                tess.addVertexWithUV(
-                        x + renderer.renderMinX,
-                        y + renderer.renderMaxY,
-                        z + renderer.renderMaxZ,
-                        u3,
-                        v3);
-                tess.addVertexWithUV(
-                        x + renderer.renderMinX,
-                        y + renderer.renderMinY,
-                        z + renderer.renderMaxZ,
-                        u4,
-                        v4);
+                tess.addVertexWithUV(x + renderer.renderMaxX, y + renderer.renderMinY, z + renderer.renderMaxZ, u1, v1);
+                tess.addVertexWithUV(x + renderer.renderMaxX, y + renderer.renderMaxY, z + renderer.renderMaxZ, u2, v2);
+                tess.addVertexWithUV(x + renderer.renderMinX, y + renderer.renderMaxY, z + renderer.renderMaxZ, u3, v3);
+                tess.addVertexWithUV(x + renderer.renderMinX, y + renderer.renderMinY, z + renderer.renderMaxZ, u4, v4);
             }
             case -3 -> {
-                tess.addVertexWithUV(
-                        x + renderer.renderMinX,
-                        y + renderer.renderMinY,
-                        z + renderer.renderMaxZ,
-                        u1,
-                        v1);
-                tess.addVertexWithUV(
-                        x + renderer.renderMinX,
-                        y + renderer.renderMaxY,
-                        z + renderer.renderMaxZ,
-                        u2,
-                        v2);
-                tess.addVertexWithUV(
-                        x + renderer.renderMaxX,
-                        y + renderer.renderMaxY,
-                        z + renderer.renderMaxZ,
-                        u3,
-                        v3);
-                tess.addVertexWithUV(
-                        x + renderer.renderMaxX,
-                        y + renderer.renderMinY,
-                        z + renderer.renderMaxZ,
-                        u4,
-                        v4);
+                tess.addVertexWithUV(x + renderer.renderMinX, y + renderer.renderMinY, z + renderer.renderMaxZ, u1, v1);
+                tess.addVertexWithUV(x + renderer.renderMinX, y + renderer.renderMaxY, z + renderer.renderMaxZ, u2, v2);
+                tess.addVertexWithUV(x + renderer.renderMaxX, y + renderer.renderMaxY, z + renderer.renderMaxZ, u3, v3);
+                tess.addVertexWithUV(x + renderer.renderMaxX, y + renderer.renderMinY, z + renderer.renderMaxZ, u4, v4);
             }
         }
         tess.draw();
     }
 
     private static void selectFace(final RenderBlocks renderer, final ForgeDirection west, final ForgeDirection up,
-                           final ForgeDirection forward, final int u1, final int u2, int v1, int v2) {
+            final ForgeDirection forward, final int u1, final int u2, int v1, int v2) {
         v1 = 16 - v1;
         v2 = 16 - v2;
 
-        final double minX = (forward.offsetX > 0 ? 1 : 0) + mapFaceUV(west.offsetX, u1)
-                + mapFaceUV(up.offsetX, v1);
-        final double minY = (forward.offsetY > 0 ? 1 : 0) + mapFaceUV(west.offsetY, u1)
-                + mapFaceUV(up.offsetY, v1);
-        final double minZ = (forward.offsetZ > 0 ? 1 : 0) + mapFaceUV(west.offsetZ, u1)
-                + mapFaceUV(up.offsetZ, v1);
+        final double minX = (forward.offsetX > 0 ? 1 : 0) + mapFaceUV(west.offsetX, u1) + mapFaceUV(up.offsetX, v1);
+        final double minY = (forward.offsetY > 0 ? 1 : 0) + mapFaceUV(west.offsetY, u1) + mapFaceUV(up.offsetY, v1);
+        final double minZ = (forward.offsetZ > 0 ? 1 : 0) + mapFaceUV(west.offsetZ, u1) + mapFaceUV(up.offsetZ, v1);
 
-        final double maxX = (forward.offsetX > 0 ? 1 : 0) + mapFaceUV(west.offsetX, u2)
-                + mapFaceUV(up.offsetX, v2);
-        final double maxY = (forward.offsetY > 0 ? 1 : 0) + mapFaceUV(west.offsetY, u2)
-                + mapFaceUV(up.offsetY, v2);
-        final double maxZ = (forward.offsetZ > 0 ? 1 : 0) + mapFaceUV(west.offsetZ, u2)
-                + mapFaceUV(up.offsetZ, v2);
+        final double maxX = (forward.offsetX > 0 ? 1 : 0) + mapFaceUV(west.offsetX, u2) + mapFaceUV(up.offsetX, v2);
+        final double maxY = (forward.offsetY > 0 ? 1 : 0) + mapFaceUV(west.offsetY, u2) + mapFaceUV(up.offsetY, v2);
+        final double maxZ = (forward.offsetZ > 0 ? 1 : 0) + mapFaceUV(west.offsetZ, u2) + mapFaceUV(up.offsetZ, v2);
 
         renderer.renderMinX = Math.max(0.0, Math.min(minX, maxX) - (forward.offsetX != 0 ? 0 : 0.001));
         renderer.renderMaxX = Math.min(1.0, Math.max(minX, maxX) + (forward.offsetX != 0 ? 0 : 0.001));

--- a/src/main/java/appeng/client/render/BlockPosHighlighter.java
+++ b/src/main/java/appeng/client/render/BlockPosHighlighter.java
@@ -89,8 +89,9 @@ public class BlockPosHighlighter {
                 player.addChatMessage(
                         new ChatComponentTranslation(
                                 foundMsg,
-                                storage.name,
+                                storage.blockName,
                                 storage.itemCount,
+                                storage.itemName,
                                 storage.coord.x,
                                 storage.coord.y,
                                 storage.coord.z));
@@ -98,8 +99,9 @@ public class BlockPosHighlighter {
                 player.addChatMessage(
                         new ChatComponentTranslation(
                                 wrongDimMsg,
-                                storage.name,
+                                storage.blockName,
                                 storage.itemCount,
+                                storage.itemName,
                                 storage.coord.getDimension()));
             }
         }

--- a/src/main/java/appeng/container/AEBaseContainer.java
+++ b/src/main/java/appeng/container/AEBaseContainer.java
@@ -22,24 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import appeng.api.networking.IGridHost;
-import appeng.api.networking.IMachineSet;
-import appeng.api.storage.IMEInventory;
-import appeng.api.storage.IMEMonitor;
-import appeng.api.storage.data.IAEStack;
-import appeng.api.util.DimensionalCoord;
-import appeng.api.util.ItemSearchDTO;
-import appeng.container.implementations.ContainerWireless;
-import appeng.container.implementations.ContainerWirelessTerm;
-import appeng.core.sync.packets.PacketHighlightBlock;
-import appeng.me.MachineSet;
-import appeng.me.cache.NetworkMonitor;
-import appeng.me.storage.MEInventoryHandler;
-import appeng.parts.misc.PartStorageBus;
-import appeng.tile.storage.TileChest;
-import appeng.tile.storage.TileDrive;
-import appeng.util.IterationCounter;
-import com.ibm.icu.text.MessagePattern.Part;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.entity.player.InventoryPlayer;
@@ -60,6 +42,7 @@ import appeng.api.config.Actionable;
 import appeng.api.config.SecurityPermissions;
 import appeng.api.implementations.guiobjects.IGuiItemObject;
 import appeng.api.networking.IGrid;
+import appeng.api.networking.IGridHost;
 import appeng.api.networking.IGridNode;
 import appeng.api.networking.energy.IEnergyGrid;
 import appeng.api.networking.energy.IEnergySource;
@@ -69,13 +52,17 @@ import appeng.api.networking.security.ISecurityGrid;
 import appeng.api.networking.security.PlayerSource;
 import appeng.api.parts.IPart;
 import appeng.api.storage.IMEInventoryHandler;
+import appeng.api.storage.IMEMonitor;
 import appeng.api.storage.data.IAEItemStack;
+import appeng.api.storage.data.IAEStack;
+import appeng.api.util.ItemSearchDTO;
 import appeng.client.me.InternalSlotME;
 import appeng.client.me.SlotME;
 import appeng.container.guisync.GuiSync;
 import appeng.container.guisync.SyncData;
 import appeng.container.implementations.ContainerCellWorkbench;
 import appeng.container.implementations.ContainerUpgradeable;
+import appeng.container.implementations.ContainerWirelessTerm;
 import appeng.container.slot.AppEngSlot;
 import appeng.container.slot.SlotCraftingMatrix;
 import appeng.container.slot.SlotCraftingTerm;
@@ -87,6 +74,7 @@ import appeng.container.slot.SlotPlayerHotBar;
 import appeng.container.slot.SlotPlayerInv;
 import appeng.core.AELog;
 import appeng.core.sync.network.NetworkHandler;
+import appeng.core.sync.packets.PacketHighlightBlock;
 import appeng.core.sync.packets.PacketInventoryAction;
 import appeng.core.sync.packets.PacketPartialItem;
 import appeng.core.sync.packets.PacketValueConfig;
@@ -94,8 +82,15 @@ import appeng.helpers.ICustomNameObject;
 import appeng.helpers.IPinsHandler;
 import appeng.helpers.InventoryAction;
 import appeng.items.materials.ItemMultiMaterial;
+import appeng.me.MachineSet;
+import appeng.me.cache.NetworkMonitor;
+import appeng.me.storage.MEInventoryHandler;
 import appeng.parts.automation.UpgradeInventory;
+import appeng.parts.misc.PartStorageBus;
+import appeng.tile.storage.TileChest;
+import appeng.tile.storage.TileDrive;
 import appeng.util.InventoryAdaptor;
+import appeng.util.IterationCounter;
 import appeng.util.Platform;
 import appeng.util.inv.AdaptorPlayerHand;
 import appeng.util.item.AEItemStack;
@@ -962,17 +957,14 @@ public abstract class AEBaseContainer extends Container {
                 }
             }
             case FIND_ITEMS -> {
-                final Class<? extends IGridHost>[] checkedMachineClasses = new Class[] {
-                        TileDrive.class,
-                        TileChest.class,
-                        PartStorageBus.class,
-                };
-                if(slotItem != null) {
+                final Class<? extends IGridHost>[] checkedMachineClasses = new Class[] { TileDrive.class,
+                        TileChest.class, PartStorageBus.class, };
+                if (slotItem != null) {
                     IGrid g = null;
-                    if(this instanceof ContainerWirelessTerm) {
+                    if (this instanceof ContainerWirelessTerm) {
                         ContainerWirelessTerm wireless = (ContainerWirelessTerm) this;
                         IMEMonitor monitor = wireless.getMonitor();
-                        if(monitor instanceof NetworkMonitor) {
+                        if (monitor instanceof NetworkMonitor) {
                             g = ((NetworkMonitor) monitor).getGrid();
                         }
                     } else {
@@ -988,19 +980,21 @@ public abstract class AEBaseContainer extends Container {
                         MachineSet masterList = null;
                         List<ItemSearchDTO> coords = new ArrayList<>();
 
-                        //Find all machines on net & subnets
-                        for(Class<? extends IGridHost> classType : checkedMachineClasses) {
-                            if(masterList == null) {
+                        // Find all machines on net & subnets
+                        for (Class<? extends IGridHost> classType : checkedMachineClasses) {
+                            if (masterList == null) {
                                 masterList = (MachineSet) g.getMachines(classType);
-                            } else if(classType == PartStorageBus.class) {
+                            } else if (classType == PartStorageBus.class) {
                                 MachineSet storageBuses = (MachineSet) g.getMachines(PartStorageBus.class);
-                                for(IGridNode machine : storageBuses) {
+                                for (IGridNode machine : storageBuses) {
                                     PartStorageBus bus = (PartStorageBus) machine.getMachine();
-                                    Map<Class<? extends IGridHost>, MachineSet> subnetMachines = bus.getDeepConnectedMachines(checkedMachineClasses, null);
-                                    if(subnetMachines == null) {
+                                    Map<Class<? extends IGridHost>, MachineSet> subnetMachines = bus
+                                            .getDeepConnectedMachines(checkedMachineClasses, null);
+                                    if (subnetMachines == null) {
                                         masterList.add(machine);
                                     }
-                                    for(Entry<Class<? extends IGridHost>, MachineSet> entry : subnetMachines.entrySet()) {
+                                    for (Entry<Class<? extends IGridHost>, MachineSet> entry : subnetMachines
+                                            .entrySet()) {
                                         masterList.addAll(entry.getValue());
                                     }
                                 }
@@ -1009,50 +1003,59 @@ public abstract class AEBaseContainer extends Container {
                             }
                         }
 
-                        for(IGridNode gridNode : masterList) {
+                        for (IGridNode gridNode : masterList) {
                             IGridHost machine = gridNode.getMachine();
-                            if(machine instanceof TileDrive) {
+                            if (machine instanceof TileDrive) {
                                 TileDrive innerMachine = (TileDrive) machine;
-                                for(int i = 0; i<innerMachine.getSizeInventory(); i++) {
+                                for (int i = 0; i < innerMachine.getSizeInventory(); i++) {
                                     IMEInventoryHandler cell = innerMachine.getCellInvBySlot(i);
-                                    if(cell == null || cell.getChannel() != slotItem.getChannel())
-                                        continue;
+                                    if (cell == null || cell.getChannel() != slotItem.getChannel()) continue;
 
                                     IAEStack result = cell.getAvailableItem(slotItem, IterationCounter.fetchNewId());
-                                    if (result == null)
-                                        continue;
+                                    if (result == null) continue;
 
-                                    coords.add(new ItemSearchDTO(innerMachine.getLocation(), result,
-                                            innerMachine.getCustomName(), i,
-                                            innerMachine.getForward(), innerMachine.getUp()));
+                                    coords.add(
+                                            new ItemSearchDTO(
+                                                    innerMachine.getLocation(),
+                                                    result,
+                                                    innerMachine.getCustomName(),
+                                                    i,
+                                                    innerMachine.getForward(),
+                                                    innerMachine.getUp()));
                                 }
-//                                    List<IMEInventoryHandler> cells = innerMachine.getCellArray(slotItem.getChannel());
-//                                    for (IMEInventoryHandler cell : cells) {
-//                                        IAEStack result = cell.getAvailableItem(slotItem, IterationCounter.fetchNewId());
-//                                        if (result == null)
-//                                            continue;
-//
-//                                        coords.add(new ItemSearchDTO(innerMachine.getLocation(), result,
-//                                                innerMachine.getCustomName(), cell.getSlot(),
-//                                                innerMachine.getForward()));
-//                                    }
+                                // List<IMEInventoryHandler> cells = innerMachine.getCellArray(slotItem.getChannel());
+                                // for (IMEInventoryHandler cell : cells) {
+                                // IAEStack result = cell.getAvailableItem(slotItem, IterationCounter.fetchNewId());
+                                // if (result == null)
+                                // continue;
+                                //
+                                // coords.add(new ItemSearchDTO(innerMachine.getLocation(), result,
+                                // innerMachine.getCustomName(), cell.getSlot(),
+                                // innerMachine.getForward()));
+                                // }
                             }
-                            if(machine instanceof PartStorageBus) {
+                            if (machine instanceof PartStorageBus) {
                                 PartStorageBus innerMachine = (PartStorageBus) machine;
                                 MEInventoryHandler handler = innerMachine.getInternalHandler();
                                 IAEStack result = handler.getAvailableItem(slotItem, IterationCounter.fetchNewId());
-                                if (result == null)
-                                    continue;
-                                coords.add(new ItemSearchDTO(innerMachine.getLocation(), result, innerMachine.getCustomName()));
+                                if (result == null) continue;
+                                coords.add(
+                                        new ItemSearchDTO(
+                                                innerMachine.getLocation(),
+                                                result,
+                                                innerMachine.getCustomName()));
                             }
-                            if(machine instanceof TileChest) {
+                            if (machine instanceof TileChest) {
                                 TileChest innerMachine = (TileChest) machine;
                                 try {
                                     IMEInventoryHandler handler = innerMachine.getHandler(slotItem.getChannel());
                                     IAEStack result = handler.getAvailableItem(slotItem, IterationCounter.fetchNewId());
-                                    if(result == null)
-                                        continue;
-                                    coords.add(new ItemSearchDTO(innerMachine.getLocation(), result, innerMachine.getCustomName()));
+                                    if (result == null) continue;
+                                    coords.add(
+                                            new ItemSearchDTO(
+                                                    innerMachine.getLocation(),
+                                                    result,
+                                                    innerMachine.getCustomName()));
                                 } catch (Exception e) {
 
                                 }
@@ -1086,16 +1089,12 @@ public abstract class AEBaseContainer extends Container {
     protected void highLightBlocks(final EntityPlayerMP p, List<ItemSearchDTO> coords) {
         if (Platform.isServer()) {
             try {
-                NetworkHandler.instance.sendTo(
-                        new PacketHighlightBlock(
-                                coords),
-                        p);
+                NetworkHandler.instance.sendTo(new PacketHighlightBlock(coords), p);
             } catch (final IOException e) {
                 AELog.debug(e);
             }
         }
     }
-
 
     private ItemStack shiftStoreItem(final ItemStack input) {
         if (this.getPowerSource() == null || this.getCellInventory() == null) {

--- a/src/main/java/appeng/core/localization/PlayerMessages.java
+++ b/src/main/java/appeng/core/localization/PlayerMessages.java
@@ -48,7 +48,9 @@ public enum PlayerMessages implements Localization {
     FinishCraftingRemind,
     CraftingCantExtract,
     MachineInOtherDim,
-    MachineHighlighted;
+    MachineHighlighted,
+    StorageInOtherDim,
+    StorageHighlighted;
 
     @Deprecated // kept for backward compat
     public IChatComponent get() {

--- a/src/main/java/appeng/core/sync/AppEngPacketHandlerBase.java
+++ b/src/main/java/appeng/core/sync/AppEngPacketHandlerBase.java
@@ -126,7 +126,6 @@ public class AppEngPacketHandlerBase {
         PACKET_PINS_UPDATE(PacketPinsUpdate.class),
         PACKET_HIGHLIGHT_BLOCKS(PacketHighlightBlock.class);
 
-
         private final Class<? extends AppEngPacket> packetClass;
         private final Constructor<? extends AppEngPacket> packetConstructor;
 

--- a/src/main/java/appeng/core/sync/AppEngPacketHandlerBase.java
+++ b/src/main/java/appeng/core/sync/AppEngPacketHandlerBase.java
@@ -26,6 +26,7 @@ import appeng.core.sync.packets.PacketCraftingCPUsUpdate;
 import appeng.core.sync.packets.PacketCraftingItemInterface;
 import appeng.core.sync.packets.PacketCraftingRemainingOperations;
 import appeng.core.sync.packets.PacketCraftingTreeData;
+import appeng.core.sync.packets.PacketHighlightBlock;
 import appeng.core.sync.packets.PacketInterfaceTerminalUpdate;
 import appeng.core.sync.packets.PacketInventoryAction;
 import appeng.core.sync.packets.PacketLightning;
@@ -122,7 +123,9 @@ public class AppEngPacketHandlerBase {
         PACKET_OPTIMIZE_PATTERNS(PacketOptimizePatterns.class),
         PACKET_NETWORK_STATUS_SELECTED(PacketNetworkStatusSelected.class),
         PACKET_PATTERN_ITEM_RENAMER(PacketPatternItemRenamer.class),
-        PACKET_PINS_UPDATE(PacketPinsUpdate.class);
+        PACKET_PINS_UPDATE(PacketPinsUpdate.class),
+        PACKET_HIGHLIGHT_BLOCKS(PacketHighlightBlock.class);
+
 
         private final Class<? extends AppEngPacket> packetClass;
         private final Constructor<? extends AppEngPacket> packetConstructor;

--- a/src/main/java/appeng/core/sync/packets/PacketHighlightBlock.java
+++ b/src/main/java/appeng/core/sync/packets/PacketHighlightBlock.java
@@ -10,12 +10,19 @@
 
 package appeng.core.sync.packets;
 
-import appeng.api.util.DimensionalCoord;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.nbt.CompressedStreamTools;
+import net.minecraft.nbt.NBTTagCompound;
+
 import appeng.api.util.ItemSearchDTO;
-import appeng.client.ClientHelper;
 import appeng.client.render.BlockPosHighlighter;
-import appeng.client.render.effects.LightningFX;
-import appeng.core.AEConfig;
 import appeng.core.localization.PlayerMessages;
 import appeng.core.sync.AppEngPacket;
 import appeng.core.sync.network.INetworkInfo;
@@ -24,18 +31,6 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import net.minecraft.client.Minecraft;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.nbt.CompressedStreamTools;
-import net.minecraft.nbt.NBTTagCompound;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.util.List;
-import java.util.stream.Collectors;
 
 public class PacketHighlightBlock extends AppEngPacket {
 

--- a/src/main/java/appeng/core/sync/packets/PacketHighlightBlock.java
+++ b/src/main/java/appeng/core/sync/packets/PacketHighlightBlock.java
@@ -1,0 +1,88 @@
+/*
+ * This file is part of Applied Energistics 2. Copyright (c) 2013 - 2014, AlgorithmX2, All rights reserved. Applied
+ * Energistics 2 is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version. Applied Energistics 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+ * Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+ * Applied Energistics 2. If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.core.sync.packets;
+
+import appeng.api.util.DimensionalCoord;
+import appeng.client.ClientHelper;
+import appeng.client.render.BlockPosHighlighter;
+import appeng.client.render.effects.LightningFX;
+import appeng.core.AEConfig;
+import appeng.core.localization.PlayerMessages;
+import appeng.core.sync.AppEngPacket;
+import appeng.core.sync.network.INetworkInfo;
+import appeng.util.Platform;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import net.minecraft.client.Minecraft;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.nbt.CompressedStreamTools;
+import net.minecraft.nbt.NBTTagCompound;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+public class PacketHighlightBlock extends AppEngPacket {
+
+    List<DimensionalCoord> coords;
+
+    // automatic.
+    public PacketHighlightBlock(final ByteBuf stream) throws IOException {
+        final int size = stream.readInt();
+        final byte[] tagBytes = new byte[size];
+        stream.readBytes(tagBytes);
+        final ByteArrayInputStream byteArray = new ByteArrayInputStream(tagBytes);
+        NBTTagCompound nbt = CompressedStreamTools.read(new DataInputStream(byteArray));
+        coords = DimensionalCoord.readAsListFromNBT(nbt);
+    }
+
+    // api
+    public PacketHighlightBlock(List<DimensionalCoord> coords) throws IOException {
+        this.coords = coords;
+
+        final ByteBuf buffer = Unpooled.buffer();
+        buffer.writeInt(this.getPacketID());
+        NBTTagCompound tag = new NBTTagCompound();
+        DimensionalCoord.writeListToNBT(tag, coords);
+
+        final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        final DataOutputStream data = new DataOutputStream(bytes);
+        CompressedStreamTools.write(tag, data);
+
+        final byte[] tagBytes = bytes.toByteArray();
+        final int size = tagBytes.length;
+
+        buffer.writeInt(size);
+        buffer.writeBytes(tagBytes);
+
+        this.configureWrite(buffer);
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public void clientPacketData(final INetworkInfo network, final AppEngPacket packet, final EntityPlayer player) {
+        try {
+            if (Platform.isClient()) {
+                BlockPosHighlighter.highlightBlocks(
+                        player,
+                        coords,
+                        "",
+                        PlayerMessages.MachineHighlighted.getUnlocalized(),
+                        PlayerMessages.MachineInOtherDim.getUnlocalized());
+            }
+        } catch (final Exception ignored) {}
+    }
+}

--- a/src/main/java/appeng/core/sync/packets/PacketHighlightBlock.java
+++ b/src/main/java/appeng/core/sync/packets/PacketHighlightBlock.java
@@ -11,6 +11,7 @@
 package appeng.core.sync.packets;
 
 import appeng.api.util.DimensionalCoord;
+import appeng.api.util.ItemSearchDTO;
 import appeng.client.ClientHelper;
 import appeng.client.render.BlockPosHighlighter;
 import appeng.client.render.effects.LightningFX;
@@ -34,10 +35,11 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class PacketHighlightBlock extends AppEngPacket {
 
-    List<DimensionalCoord> coords;
+    List<ItemSearchDTO> coords;
 
     // automatic.
     public PacketHighlightBlock(final ByteBuf stream) throws IOException {
@@ -46,17 +48,17 @@ public class PacketHighlightBlock extends AppEngPacket {
         stream.readBytes(tagBytes);
         final ByteArrayInputStream byteArray = new ByteArrayInputStream(tagBytes);
         NBTTagCompound nbt = CompressedStreamTools.read(new DataInputStream(byteArray));
-        coords = DimensionalCoord.readAsListFromNBT(nbt);
+        coords = ItemSearchDTO.readAsListFromNBT(nbt);
     }
 
     // api
-    public PacketHighlightBlock(List<DimensionalCoord> coords) throws IOException {
+    public PacketHighlightBlock(List<ItemSearchDTO> coords) throws IOException {
         this.coords = coords;
 
         final ByteBuf buffer = Unpooled.buffer();
         buffer.writeInt(this.getPacketID());
         NBTTagCompound tag = new NBTTagCompound();
-        DimensionalCoord.writeListToNBT(tag, coords);
+        ItemSearchDTO.writeListToNBT(tag, coords);
 
         final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
         final DataOutputStream data = new DataOutputStream(bytes);
@@ -76,12 +78,11 @@ public class PacketHighlightBlock extends AppEngPacket {
     public void clientPacketData(final INetworkInfo network, final AppEngPacket packet, final EntityPlayer player) {
         try {
             if (Platform.isClient()) {
-                BlockPosHighlighter.highlightBlocks(
+                BlockPosHighlighter.highlightStorage(
                         player,
                         coords,
-                        "",
-                        PlayerMessages.MachineHighlighted.getUnlocalized(),
-                        PlayerMessages.MachineInOtherDim.getUnlocalized());
+                        PlayerMessages.StorageHighlighted.getUnlocalized(),
+                        PlayerMessages.StorageInOtherDim.getUnlocalized());
             }
         } catch (final Exception ignored) {}
     }

--- a/src/main/java/appeng/helpers/InventoryAction.java
+++ b/src/main/java/appeng/helpers/InventoryAction.java
@@ -33,5 +33,6 @@ public enum InventoryAction {
     SET_PATTERN_VALUE,
     SET_PATTERN_MULTI,
     RENAME_PATTERN_ITEM,
-    SET_PIN
+    SET_PIN,
+    FIND_ITEMS
 }

--- a/src/main/java/appeng/me/Grid.java
+++ b/src/main/java/appeng/me/Grid.java
@@ -16,6 +16,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.UUID;
 
 import appeng.api.AEApi;
 import appeng.api.networking.IGrid;
@@ -34,6 +35,8 @@ import appeng.util.ReadOnlyCollection;
 
 public class Grid implements IGrid {
 
+    private final UUID id;
+
     private final NetworkEventBus eventBus = new NetworkEventBus();
     private final Map<Class<? extends IGridHost>, MachineSet> machines = new HashMap<>();
     private final Map<Class<? extends IGridCache>, IGridCache> caches = new HashMap<>();
@@ -47,6 +50,7 @@ public class Grid implements IGrid {
 
     public Grid(final GridNode center) {
         this.pivot = center;
+        this.id = UUID.randomUUID();
 
         final Map<Class<? extends IGridCache>, IGridCache> myCaches = AEApi.instance().registries().gridCache()
                 .createCacheInstance(this);
@@ -222,6 +226,11 @@ public class Grid implements IGrid {
     }
 
     @Override
+    public UUID getId() {
+        return this.id;
+    }
+
+    @Override
     public IGridNode getPivot() {
         return this.pivot;
     }
@@ -276,5 +285,13 @@ public class Grid implements IGrid {
     public void setImportantFlag(final int i, final boolean publicHasPower) {
         final int flag = 1 << i;
         this.priority = (this.priority & ~flag) | (publicHasPower ? flag : 0);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if(o instanceof Grid) {
+            return this.id.equals(((Grid) o).id);
+        }
+        return false;
     }
 }

--- a/src/main/java/appeng/me/Grid.java
+++ b/src/main/java/appeng/me/Grid.java
@@ -289,7 +289,7 @@ public class Grid implements IGrid {
 
     @Override
     public boolean equals(Object o) {
-        if(o instanceof Grid) {
+        if (o instanceof Grid) {
             return this.id.equals(((Grid) o).id);
         }
         return false;

--- a/src/main/java/appeng/me/MachineSet.java
+++ b/src/main/java/appeng/me/MachineSet.java
@@ -21,8 +21,7 @@ public class MachineSet extends HashSet<IGridNode> implements IMachineSet {
     private static final long serialVersionUID = 3224660708327386933L;
 
     private final Class<? extends IGridHost> machine;
-
-    MachineSet(final Class<? extends IGridHost> m) {
+    public MachineSet(final Class<? extends IGridHost> m) {
         this.machine = m;
     }
 

--- a/src/main/java/appeng/me/MachineSet.java
+++ b/src/main/java/appeng/me/MachineSet.java
@@ -21,6 +21,7 @@ public class MachineSet extends HashSet<IGridNode> implements IMachineSet {
     private static final long serialVersionUID = 3224660708327386933L;
 
     private final Class<? extends IGridHost> machine;
+
     public MachineSet(final Class<? extends IGridHost> m) {
         this.machine = m;
     }

--- a/src/main/java/appeng/me/NetworkList.java
+++ b/src/main/java/appeng/me/NetworkList.java
@@ -86,4 +86,13 @@ public class NetworkList implements Collection<Grid> {
     public void clear() {
         this.networks.clear();
     }
+
+    public void mergeDistinct(NetworkList other) {
+        for (Grid grid : other) {
+            if (!this.contains(grid)) {
+                this.add(grid);
+            }
+        }
+    }
+
 }

--- a/src/main/java/appeng/me/cache/NetworkMonitor.java
+++ b/src/main/java/appeng/me/cache/NetworkMonitor.java
@@ -13,7 +13,6 @@ package appeng.me.cache;
 import java.util.Collection;
 import java.util.Deque;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -22,13 +21,12 @@ import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import appeng.api.networking.IGrid;
-import appeng.api.storage.ICellProvider;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import appeng.api.config.AccessRestriction;
 import appeng.api.config.Actionable;
+import appeng.api.networking.IGrid;
 import appeng.api.networking.events.MENetworkStorageEvent;
 import appeng.api.networking.security.BaseActionSource;
 import appeng.api.storage.IMEInventoryHandler;

--- a/src/main/java/appeng/me/cache/NetworkMonitor.java
+++ b/src/main/java/appeng/me/cache/NetworkMonitor.java
@@ -13,6 +13,7 @@ package appeng.me.cache;
 import java.util.Collection;
 import java.util.Deque;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -21,6 +22,8 @@ import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import appeng.api.networking.IGrid;
+import appeng.api.storage.ICellProvider;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
@@ -177,6 +180,10 @@ public class NetworkMonitor<T extends IAEStack<T>> implements IMEMonitor<T> {
             default -> {}
         }
         return null;
+    }
+
+    public IGrid getGrid() {
+        return this.myGridCache.getGrid();
     }
 
     private Iterator<Entry<IMEMonitorHandlerReceiver<T>, Object>> getListeners() {

--- a/src/main/java/appeng/me/storage/MEPassThrough.java
+++ b/src/main/java/appeng/me/storage/MEPassThrough.java
@@ -21,7 +21,6 @@ import appeng.api.storage.IMEInventoryHandler;
 import appeng.api.storage.StorageChannel;
 import appeng.api.storage.data.IAEStack;
 import appeng.api.storage.data.IItemList;
-import appeng.api.util.DimensionalCoord;
 import appeng.me.cache.NetworkMonitor;
 
 public class MEPassThrough<T extends IAEStack<T>> implements IMEInventoryHandler<T> {
@@ -40,10 +39,11 @@ public class MEPassThrough<T extends IAEStack<T>> implements IMEInventoryHandler
 
     /**
      * Get Connected grid if applicable
+     * 
      * @return Connected grid
      */
     public IGrid getGrid() {
-        if(this.internal instanceof NetworkMonitor) {
+        if (this.internal instanceof NetworkMonitor) {
             NetworkMonitor nm = (NetworkMonitor) this.internal;
             return nm.getGrid();
         }

--- a/src/main/java/appeng/me/storage/MEPassThrough.java
+++ b/src/main/java/appeng/me/storage/MEPassThrough.java
@@ -14,12 +14,15 @@ import javax.annotation.Nonnull;
 
 import appeng.api.config.AccessRestriction;
 import appeng.api.config.Actionable;
+import appeng.api.networking.IGrid;
 import appeng.api.networking.security.BaseActionSource;
 import appeng.api.storage.IMEInventory;
 import appeng.api.storage.IMEInventoryHandler;
 import appeng.api.storage.StorageChannel;
 import appeng.api.storage.data.IAEStack;
 import appeng.api.storage.data.IItemList;
+import appeng.api.util.DimensionalCoord;
+import appeng.me.cache.NetworkMonitor;
 
 public class MEPassThrough<T extends IAEStack<T>> implements IMEInventoryHandler<T> {
 
@@ -33,6 +36,18 @@ public class MEPassThrough<T extends IAEStack<T>> implements IMEInventoryHandler
 
     protected IMEInventory<T> getInternal() {
         return this.internal;
+    }
+
+    /**
+     * Get Connected grid if applicable
+     * @return Connected grid
+     */
+    public IGrid getGrid() {
+        if(this.internal instanceof NetworkMonitor) {
+            NetworkMonitor nm = (NetworkMonitor) this.internal;
+            return nm.getGrid();
+        }
+        return null;
     }
 
     public void setInternal(final IMEInventory<T> i) {

--- a/src/main/java/appeng/parts/misc/PartStorageBus.java
+++ b/src/main/java/appeng/parts/misc/PartStorageBus.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Predicate;
@@ -576,8 +577,15 @@ public class PartStorageBus extends PartUpgradeable implements IGridTickable, IC
                         PartStorageBus inner = (PartStorageBus) sub.getMachine();
                          Map<Class<? extends IGridHost>, MachineSet> recursiveMachines = inner.getDeepConnectedMachines(classes, gridTracking);
                         //Merge result with parent
-                         if(recursiveMachines != null)
-                            machines.putAll(recursiveMachines);
+                         if(recursiveMachines != null) {
+                             for(Entry<Class<? extends IGridHost>, MachineSet> m : recursiveMachines.entrySet()) {
+                                 if(machines.containsKey(m.getKey())) {
+                                     machines.get(m.getKey()).addAll(m.getValue());
+                                 } else {
+                                     machines.put(m.getKey(), m.getValue());
+                                 }
+                             }
+                         }
                      }
                  } else { //Add All other types
                      machines.put(machineType, subMachines);

--- a/src/main/java/appeng/parts/misc/PartStorageBus.java
+++ b/src/main/java/appeng/parts/misc/PartStorageBus.java
@@ -533,76 +533,27 @@ public class PartStorageBus extends PartUpgradeable implements IGridTickable, IC
         Platform.postListChanges(before, after, this, this.mySrc);
     }
 
+
     /**
-     * If the storage bus is connected to an interface, ie. subnet, recursively search that subnet and all subsequent
-     * subnets and return all machines found. Will return null if not connected to a subnet
-     * 
-     * @param classes      List of machine classes to search (grid.getMachineClasses() to see available on current grid)
-     * @param gridTracking Tracker to prevent searching same connected grid twice, can set as null
-     * @return Map of machine types and machines, flattening subnets
+     *
+     * @return Subnet grid if found, null if not connected to a grid different from self
      */
-    @SuppressWarnings("unchecked")
-    public Map<Class<? extends IGridHost>, MachineSet> getDeepConnectedMachines(Class<? extends IGridHost>[] classes,
-            Set<UUID> gridTracking) {
+    public IGrid getConnectedGrid() {
         try {
-            IGrid grid = this.getProxy().getGrid();
-            if (gridTracking == null) {
-                gridTracking = new HashSet<UUID>();
-                gridTracking.add(grid.getId());
-            } else if (gridTracking.contains(grid.getId())) {
-                return null;
-            } else {
-                gridTracking.add(grid.getId());
+            IGrid currentGrid = this.getProxy().getGrid();
+            IMEInventory inv = this.getConnectedInventory();
+            if (inv instanceof MEPassThrough) {
+                MEPassThrough passThrough = (MEPassThrough) inv;
+                IGrid passThroughGrid = passThrough.getGrid();
+                if (!currentGrid.equals(passThroughGrid)) return passThroughGrid;
             }
         } catch (GridAccessException e) {
             return null;
         }
-
-        Map<Class<? extends IGridHost>, MachineSet> machines = new HashMap<>();
-        IMEInventory inv = this.getConnectedInventory();
-
-        if (inv instanceof MEPassThrough) {
-            MEPassThrough passThrough = (MEPassThrough) inv;
-            System.out.println();
-            IGrid grid = passThrough.getGrid();
-            if (gridTracking.contains(grid.getId())) {
-                return null; // Grid loop check
-            }
-
-            for (Class<? extends IGridHost> machineType : classes) {
-                MachineSet subMachines = (MachineSet) grid.getMachines(machineType);
-                if (machineType == PartStorageBus.class) { // Recursive Check Storage Buses
-                    for (IGridNode sub : subMachines) {
-                        PartStorageBus inner = (PartStorageBus) sub.getMachine();
-                        Map<Class<? extends IGridHost>, MachineSet> recursiveMachines = inner
-                                .getDeepConnectedMachines(classes, gridTracking);
-                        // Merge result with parent
-                        if (recursiveMachines != null) {
-                            for (Entry<Class<? extends IGridHost>, MachineSet> m : recursiveMachines.entrySet()) {
-                                if (machines.containsKey(m.getKey())) {
-                                    machines.get(m.getKey()).addAll(m.getValue());
-                                } else {
-                                    machines.put(m.getKey(), m.getValue());
-                                }
-                            }
-                        }
-                    }
-                } else { // Add All other types
-                    machines.put(machineType, subMachines);
-                }
-            }
-
-        } else {
-            MachineSet nodes = machines.get(PartStorageBus.class);
-            if (nodes == null) {
-                nodes = new MachineSet(PartStorageBus.class);
-                machines.put(PartStorageBus.class, nodes);
-            }
-            nodes.add(this.getGridNode());
-        }
-        return machines;
+        return null;
     }
 
+    //Looks for interfaces for subnet
     private IMEInventory getConnectedInventory() {
         final TileEntity self = this.getHost().getTile();
         final TileEntity target = self.getWorldObj().getTileEntity(

--- a/src/main/java/appeng/util/item/AEFluidStack.java
+++ b/src/main/java/appeng/util/item/AEFluidStack.java
@@ -353,4 +353,9 @@ public final class AEFluidStack extends AEStack<IAEFluidStack> implements IAEFlu
     public Fluid getFluid() {
         return this.fluid;
     }
+
+    @Override
+    public String getName() {
+        return this.fluid.getName();
+    }
 }

--- a/src/main/java/appeng/util/item/AEItemStack.java
+++ b/src/main/java/appeng/util/item/AEItemStack.java
@@ -24,6 +24,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompressedStreamTools;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.StatCollector;
 
 import appeng.api.config.FuzzyMode;
 import appeng.api.storage.StorageChannel;
@@ -364,6 +365,15 @@ public final class AEItemStack extends AEStack<IAEItemStack> implements IAEItemS
     @Override
     public StorageChannel getChannel() {
         return StorageChannel.ITEMS;
+    }
+
+    @Override
+    public String getName() {
+        String name = this.getDefinition().getDisplayName();
+        if (name == null) {
+            name = StatCollector.translateToLocal(this.getItem().getUnlocalizedName() + ".name");
+        }
+        return name;
     }
 
     @Override

--- a/src/main/resources/assets/appliedenergistics2/lang/en_US.lang
+++ b/src/main/resources/assets/appliedenergistics2/lang/en_US.lang
@@ -133,8 +133,8 @@ chat.appliedenergistics2.FinishCraftingRemind=Crafting of %s * %s finished in %s
 chat.appliedenergistics2.CraftingCantExtract=Can't extract required amount of ingredient from storage: %d / %d | %s
 chat.appliedenergistics2.MachineInOtherDim=%d located in dimension: %d and cant be highlighted
 chat.appliedenergistics2.MachineHighlighted=The %d is now highlighted at %d, %d, %d
-chat.appliedenergistics2.StorageHighlighted=The %d containing %d is now highlighted at %d, %d, %d
-chat.appliedenergistics2.StorageInOtherDim=%d containing %d is located in dimension: %d and cant be highlighted
+chat.appliedenergistics2.StorageHighlighted=The %d containing %d %d is now highlighted at %d, %d, %d
+chat.appliedenergistics2.StorageInOtherDim=%d containing %d %d is located in dimension: %d and cant be highlighted
 
 # Creative Tabs
 itemGroup.appliedenergistics2=Applied Energistics 2

--- a/src/main/resources/assets/appliedenergistics2/lang/en_US.lang
+++ b/src/main/resources/assets/appliedenergistics2/lang/en_US.lang
@@ -133,6 +133,8 @@ chat.appliedenergistics2.FinishCraftingRemind=Crafting of %s * %s finished in %s
 chat.appliedenergistics2.CraftingCantExtract=Can't extract required amount of ingredient from storage: %d / %d | %s
 chat.appliedenergistics2.MachineInOtherDim=%d located in dimension: %d and cant be highlighted
 chat.appliedenergistics2.MachineHighlighted=The %d is now highlighted at %d, %d, %d
+chat.appliedenergistics2.StorageHighlighted=The %d containing %d is now highlighted at %d, %d, %d
+chat.appliedenergistics2.StorageInOtherDim=%d containing %d is located in dimension: %d and cant be highlighted
 
 # Creative Tabs
 itemGroup.appliedenergistics2=Applied Energistics 2


### PR DESCRIPTION
Added methods in Grid to return a collection of connected grids (ie. storageBus subnets). 

This was used to then search all root item storage locations, to visualize where in a network things are being stored. 

Demo: 

https://github.com/user-attachments/assets/fdf1e40d-06be-43fe-8f63-90b2b03094ef

Currently only Items are supported, I didn't want to add fluid support with the current progress being done to integrate fluids into base. Additionally only base wireless terminal, not other AE2Stuff uni terminal

**Hotkey: Ctrl+Middle Click** (Maybe something better)

I'd appreciate code reviews, since this is the first modded project I've worked on. 