### PR TITLE
Fix for crafting to complete correctly

### DIFF
--- a/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
+++ b/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
@@ -521,7 +521,7 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
     }
 
     private void completeJob() {
-        if (isBusy()) return; // dont complete if still working
+        if (!this.waitingFor.isEmpty()) return; // dont complete if still working
         if (this.myLastLink != null) {
             ((CraftingLink) this.myLastLink).markDone();
             this.myLastLink = null;

--- a/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
+++ b/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
@@ -516,7 +516,7 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
     }
 
     private void completeJob() {
-        if (!this.waitingFor.isEmpty()) return; // dont complete if still working
+        if (isBusy()) return; // dont complete if still working
         if (this.myLastLink != null) {
             ((CraftingLink) this.myLastLink).markDone();
             this.myLastLink = null;

--- a/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
+++ b/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
@@ -427,9 +427,7 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
                         return leftover; // ignore it.
                     }
 
-                    if (!this.isBusy()) {
                         this.completeJob();
-                    }
 
                     // 2000
                     return this.inventory.injectItems(what, type, src);
@@ -463,10 +461,7 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
                 }
 
                 this.inventory.injectItems(insert, type, src);
-
-                if (!this.isBusy()) {
                     this.completeJob();
-                }
 
                 this.markDirty();
 

--- a/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
+++ b/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
@@ -427,8 +427,6 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
                         return leftover; // ignore it.
                     }
 
-                    this.completeJob();
-
                     // 2000
                     return this.inventory.injectItems(what, type, src);
                 }
@@ -461,7 +459,6 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
                 }
 
                 this.inventory.injectItems(insert, type, src);
-                this.completeJob();
 
                 this.markDirty();
 
@@ -516,7 +513,7 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
     }
 
     private void completeJob() {
-        if (isBusy()) return; // dont complete if still working
+        if (this.hasRemainingTasks()) return; // dont complete if still working
         if (this.myLastLink != null) {
             ((CraftingLink) this.myLastLink).markDone();
             this.myLastLink = null;
@@ -1185,14 +1182,16 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
         return null;
     }
 
-    @Override
-    public boolean isBusy() {
-
+    private boolean hasRemainingTasks() {
         this.tasks.entrySet().removeIf(
                 iCraftingPatternDetailsTaskProgressEntry -> iCraftingPatternDetailsTaskProgressEntry.getValue().value
                         <= 0);
+        return !this.tasks.isEmpty();
+    }
 
-        return !this.tasks.isEmpty() || !this.waitingFor.isEmpty();
+    @Override
+    public boolean isBusy() {
+        return this.hasRemainingTasks() || !this.waitingFor.isEmpty();
     }
 
     @Override

--- a/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
+++ b/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
@@ -427,6 +427,10 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
                         return leftover; // ignore it.
                     }
 
+                    if (!this.isBusy()) {
+                        this.completeJob();
+                    }
+
                     // 2000
                     return this.inventory.injectItems(what, type, src);
                 }
@@ -459,6 +463,11 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
                 }
 
                 this.inventory.injectItems(insert, type, src);
+
+                if (!this.isBusy()) {
+                    this.completeJob();
+                }
+
                 this.markDirty();
 
                 return what;

--- a/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
+++ b/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
@@ -427,7 +427,7 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
                         return leftover; // ignore it.
                     }
 
-                        this.completeJob();
+                    this.completeJob();
 
                     // 2000
                     return this.inventory.injectItems(what, type, src);
@@ -461,7 +461,7 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
                 }
 
                 this.inventory.injectItems(insert, type, src);
-                    this.completeJob();
+                this.completeJob();
 
                 this.markDirty();
 


### PR DESCRIPTION
Fixes https://discord.com/channels/181078474394566657/522098956491030558/1399875195547816127

Due to #766, `completeJob` will now return early if the ordered item has been crafted but ingredients remain to be crafted.
However, after the ordered item has been crafted, `completeJob` is not called, so the crafting task is not completed successfully.