### PR TITLE
Fix memory leak? (still need to check the dump file)

### DIFF
--- a/src/main/java/appeng/me/helpers/AENetworkProxyMultiblock.java
+++ b/src/main/java/appeng/me/helpers/AENetworkProxyMultiblock.java
@@ -24,9 +24,13 @@ import appeng.util.iterators.ProxyNodeIterator;
 
 public class AENetworkProxyMultiblock extends AENetworkProxy implements IGridMultiblock {
 
+    // Wish this can fix Memory leak.
+    private static final WeakHashMap<AENetworkProxyMultiblock, IAEMultiBlock> Map = new WeakHashMap<AENetworkProxyMultiblock, IAEMultiBlock>();
+
     public AENetworkProxyMultiblock(final IGridProxyable te, final String nbtName, final ItemStack itemStack,
             final boolean inWorld) {
         super(te, nbtName, itemStack, inWorld);
+        Map.put(this, (IAEMultiBlock) te);
     }
 
     @Override
@@ -39,6 +43,12 @@ public class AENetworkProxyMultiblock extends AENetworkProxy implements IGridMul
     }
 
     private IAECluster getCluster() {
-        return ((IAEMultiBlock) this.getMachine()).getCluster();
+        IAEMultiBlock te = Map.get(this);
+        if (te == null) {
+            AELog.error(
+                    "[AppEng_Patch] Cannot get te from Map. Use this.getMachine() instead but this can cause memory leak.");
+            te = (IAEMultiBlock) this.getMachine();
+        }
+        return te.getCluster();
     }
 }

--- a/src/main/java/appeng/me/helpers/AENetworkProxyMultiblock.java
+++ b/src/main/java/appeng/me/helpers/AENetworkProxyMultiblock.java
@@ -11,6 +11,7 @@
 package appeng.me.helpers;
 
 import java.util.Iterator;
+import java.util.WeakHashMap;
 
 import net.minecraft.item.ItemStack;
 
@@ -18,6 +19,7 @@ import com.google.common.collect.Iterators;
 
 import appeng.api.networking.IGridMultiblock;
 import appeng.api.networking.IGridNode;
+import appeng.core.AELog;
 import appeng.me.cluster.IAECluster;
 import appeng.me.cluster.IAEMultiBlock;
 import appeng.util.iterators.ProxyNodeIterator;


### PR DESCRIPTION
see GTNewHorizons/GT-New-Horizons-Modpack#20816.

sorry my english is bad. 

After 12 hours of testing, the server didn't crash. 


<img width="640" height="312" alt="F5MPOI(8LJK7TOG 1EN6Q{N" src="https://github.com/user-attachments/assets/3abd19e8-66b4-45bc-a3ad-0c7f8e3bf41b" />
<img width="1156" height="564" alt="ZV8~HGNT3G@{XWA6(DT9BB0" src="https://github.com/user-attachments/assets/e01457de-2d4a-4885-bac9-1e33db60869a" />

↑before the commit


<img width="600" height="336" alt="OMQQ49I{3ZO%} 48`X6QU3N" src="https://github.com/user-attachments/assets/33fcf79d-4b87-415c-bcf6-b7077dd58d85" />
<img width="953" height="536" alt="Q)}BWA_7 )87F5WOKA3J`8A" src="https://github.com/user-attachments/assets/fac46347-83d6-43d0-964c-9194ecc62a00" />

↑after the commit



after the commit, the Retained Heap of appeng.me.cluster.implementations.CraftingCPUCluster sightly reduced, this means CraftingCPUCluster now use less memory.