### PR TITLE
Fix fluid name display in encoded pattern tooltip

### DIFF
--- a/src/main/java/appeng/items/misc/ItemEncodedPattern.java
+++ b/src/main/java/appeng/items/misc/ItemEncodedPattern.java
@@ -31,11 +31,12 @@ import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StringUtils;
 import net.minecraft.world.World;
 import net.minecraftforge.client.MinecraftForgeClient;
+import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
-import net.minecraftforge.common.util.Constants;
+
 import appeng.api.AEApi;
 import appeng.api.implementations.ICraftingPatternItem;
 import appeng.api.networking.crafting.ICraftingPatternDetails;
@@ -248,8 +249,7 @@ public class ItemEncodedPattern extends AEBaseItem implements ICraftingPatternIt
                                 ? Platform.getItemDisplayName(item) + " " + item.getItemStack().getItemDamage()
                                 : Platform.getItemDisplayName(item);
             } else {
-                itemText = isFluid ? getFluidNameFromStack(item.getItemStack())
-                        : Platform.getItemDisplayName(item);
+                itemText = isFluid ? getFluidNameFromStack(item.getItemStack()) : Platform.getItemDisplayName(item);
             }
             String fullText = "   " + EnumChatFormatting.WHITE
                     + itemCountText

--- a/src/main/java/appeng/items/misc/ItemEncodedPattern.java
+++ b/src/main/java/appeng/items/misc/ItemEncodedPattern.java
@@ -18,6 +18,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.WeakHashMap;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
@@ -30,7 +32,10 @@ import net.minecraft.util.StringUtils;
 import net.minecraft.world.World;
 import net.minecraftforge.client.MinecraftForgeClient;
 import net.minecraftforge.event.ForgeEventFactory;
-
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.common.util.Constants;
 import appeng.api.AEApi;
 import appeng.api.implementations.ICraftingPatternItem;
 import appeng.api.networking.crafting.ICraftingPatternDetails;
@@ -238,18 +243,18 @@ public class ItemEncodedPattern extends AEBaseItem implements ICraftingPatternIt
             String itemCountText = NumberFormat.getNumberInstance(locale).format(itemCount);
             String itemText;
             if (isGTLoaded) {
-                itemText = isFluid ? Platform.getItemDisplayName(item).replace("drop of", "")
+                itemText = isFluid ? getFluidNameFromStack(item.getItemStack())
                         : item.getItem() instanceof ItemIntegratedCircuit
                                 ? Platform.getItemDisplayName(item) + " " + item.getItemStack().getItemDamage()
                                 : Platform.getItemDisplayName(item);
             } else {
-                itemText = isFluid ? Platform.getItemDisplayName(item).replace("drop of", "")
+                itemText = isFluid ? getFluidNameFromStack(item.getItemStack())
                         : Platform.getItemDisplayName(item);
             }
             String fullText = "   " + EnumChatFormatting.WHITE
                     + itemCountText
                     + EnumChatFormatting.RESET
-                    + (isFluid ? EnumChatFormatting.WHITE + "L" : " ")
+                    + (isFluid ? EnumChatFormatting.WHITE + "L " : " ")
                     + EnumChatFormatting.RESET
                     + color
                     + itemText;
@@ -263,6 +268,28 @@ public class ItemEncodedPattern extends AEBaseItem implements ICraftingPatternIt
         }
 
         return recipeIsBroken;
+    }
+
+    @Nullable
+    private static FluidStack getFluidStack(ItemStack stack) {
+        if (stack == null || stack.getItem() == null || !stack.hasTagCompound()) return null;
+
+        NBTTagCompound tag = stack.getTagCompound();
+        if (!tag.hasKey("Fluid", Constants.NBT.TAG_STRING)) return null;
+
+        Fluid fluid = FluidRegistry.getFluid(tag.getString("Fluid").toLowerCase());
+        if (fluid == null) return null;
+
+        FluidStack fluidStack = new FluidStack(fluid, stack.stackSize);
+        if (tag.hasKey("FluidTag", Constants.NBT.TAG_COMPOUND)) {
+            fluidStack.tag = tag.getCompoundTag("FluidTag");
+        }
+        return fluidStack;
+    }
+
+    private static String getFluidNameFromStack(ItemStack stack) {
+        FluidStack fluidStack = getFluidStack(stack);
+        return fluidStack != null ? fluidStack.getLocalizedName() : "???";
     }
 
     private static Item getFluidDropItem() {


### PR DESCRIPTION
In the new tooltip for encoded patterns, the method used to get the fluid name for displaying in the ingredients and results list only works correctly for English.
As a result, there was no space between the fluid amount and its name, and extra text from the localization appeared.
This change corrects the display so that fluid names are shown properly for all languages and formatting issues are resolved.
Befor:
<img width="339" height="212" alt="java_WZuafuGyQ2" src="https://github.com/user-attachments/assets/03682403-0df0-4aa1-9d1a-df996c3de3bd" />
After:
<img width="459" height="217" alt="java_proZRQ1Dy7" src="https://github.com/user-attachments/assets/93cff9a2-296a-42cf-b482-21cd89573b8c" />
