### PR TITLE
Middle click craft ordering inserts a proper count

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiCraftAmount.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCraftAmount.java
@@ -58,9 +58,7 @@ public class GuiCraftAmount extends GuiAmount {
                         Settings.CRAFTING_MODE,
                         CraftingMode.STANDARD));
 
-        this.amountTextField.setText("1");
-        this.amountTextField.setCursorPositionEnd();
-        this.amountTextField.setSelectionPos(0);
+        ((ContainerCraftAmount) this.inventorySlots).setAmountField(this.amountTextField);
     }
 
     @Override

--- a/src/main/java/appeng/client/gui/implementations/GuiCraftingCPU.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCraftingCPU.java
@@ -261,7 +261,7 @@ public class GuiCraftingCPU extends AEBaseGui implements ISortSource, IGuiToolti
             final PacketInventoryAction p = new PacketInventoryAction(
                     InventoryAction.AUTO_CRAFT,
                     inventorySlots.inventorySlots.size(),
-                    0);
+                    hoveredAEStack.getStackSize());
             NetworkHandler.instance.sendToServer(p);
         }
         super.mouseClicked(xCoord, yCoord, btn);

--- a/src/main/java/appeng/client/gui/implementations/GuiPriority.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiPriority.java
@@ -20,10 +20,6 @@ import appeng.api.AEApi;
 import appeng.api.definitions.IBlocks;
 import appeng.api.definitions.IDefinitions;
 import appeng.api.definitions.IParts;
-import appeng.client.gui.AEBaseGui;
-import appeng.client.gui.widgets.GuiNumberBox;
-import appeng.client.gui.widgets.GuiTabButton;
-import appeng.container.AEBaseContainer;
 import appeng.container.implementations.ContainerPriority;
 import appeng.core.AEConfig;
 import appeng.core.AELog;
@@ -31,7 +27,6 @@ import appeng.core.localization.GuiColors;
 import appeng.core.localization.GuiText;
 import appeng.core.sync.GuiBridge;
 import appeng.core.sync.network.NetworkHandler;
-import appeng.core.sync.packets.PacketSwitchGuis;
 import appeng.core.sync.packets.PacketValueConfig;
 import appeng.helpers.IPriorityHost;
 import appeng.parts.automation.PartFormationPlane;
@@ -40,22 +35,10 @@ import appeng.parts.misc.PartStorageBus;
 import appeng.tile.misc.TileInterface;
 import appeng.tile.storage.TileChest;
 import appeng.tile.storage.TileDrive;
+import appeng.util.calculators.ArithHelper;
+import appeng.util.calculators.Calculator;
 
-public class GuiPriority extends AEBaseGui {
-
-    private GuiNumberBox priority;
-    private GuiTabButton originalGuiBtn;
-
-    private GuiButton plus1;
-    private GuiButton plus10;
-    private GuiButton plus100;
-    private GuiButton plus1000;
-    private GuiButton minus1;
-    private GuiButton minus10;
-    private GuiButton minus100;
-    private GuiButton minus1000;
-
-    private GuiBridge OriginalGui;
+public class GuiPriority extends GuiAmount {
 
     public GuiPriority(final InventoryPlayer inventoryPlayer, final IPriorityHost te) {
         super(new ContainerPriority(inventoryPlayer, te));
@@ -69,23 +52,17 @@ public class GuiPriority extends AEBaseGui {
     public void initGui() {
         super.initGui();
 
-        final int a = AEConfig.instance.priorityByStacksAmounts(0);
-        final int b = AEConfig.instance.priorityByStacksAmounts(1);
-        final int c = AEConfig.instance.priorityByStacksAmounts(2);
-        final int d = AEConfig.instance.priorityByStacksAmounts(3);
+        // Hide and remove the "Next" button; priority GUI doesn't use it.
+        this.nextBtn.enabled = false;
+        this.nextBtn.visible = false;
+        this.buttonList.remove(this.nextBtn);
 
-        this.buttonList.add(this.plus1 = new GuiButton(0, this.guiLeft + 20, this.guiTop + 32, 22, 20, "+" + a));
-        this.buttonList.add(this.plus10 = new GuiButton(0, this.guiLeft + 48, this.guiTop + 32, 28, 20, "+" + b));
-        this.buttonList.add(this.plus100 = new GuiButton(0, this.guiLeft + 82, this.guiTop + 32, 32, 20, "+" + c));
-        this.buttonList.add(this.plus1000 = new GuiButton(0, this.guiLeft + 120, this.guiTop + 32, 38, 20, "+" + d));
+        // Hook the container up with our amount field for client sync updates.
+        ((ContainerPriority) this.inventorySlots).setTextField(this.amountTextField);
+    }
 
-        this.buttonList.add(this.minus1 = new GuiButton(0, this.guiLeft + 20, this.guiTop + 69, 22, 20, "-" + a));
-        this.buttonList.add(this.minus10 = new GuiButton(0, this.guiLeft + 48, this.guiTop + 69, 28, 20, "-" + b));
-        this.buttonList.add(this.minus100 = new GuiButton(0, this.guiLeft + 82, this.guiTop + 69, 32, 20, "-" + c));
-        this.buttonList.add(this.minus1000 = new GuiButton(0, this.guiLeft + 120, this.guiTop + 69, 38, 20, "-" + d));
-
-        ItemStack myIcon = null;
-        final Object target = ((AEBaseContainer) this.inventorySlots).getTarget();
+    @Override
+    protected void setOriginGUI(Object target) {
         final IDefinitions definitions = AEApi.instance().definitions();
         final IParts parts = definitions.parts();
         final IBlocks blocks = definitions.blocks();
@@ -94,70 +71,43 @@ public class GuiPriority extends AEBaseGui {
             for (final ItemStack storageBusStack : parts.storageBus().maybeStack(1).asSet()) {
                 myIcon = storageBusStack;
             }
-            this.OriginalGui = GuiBridge.GUI_STORAGEBUS;
+            this.originalGui = GuiBridge.GUI_STORAGEBUS;
         }
 
         if (target instanceof PartFormationPlane) {
             for (final ItemStack formationPlaneStack : parts.formationPlane().maybeStack(1).asSet()) {
                 myIcon = formationPlaneStack;
             }
-            this.OriginalGui = GuiBridge.GUI_FORMATION_PLANE;
+            this.originalGui = GuiBridge.GUI_FORMATION_PLANE;
         }
 
         if (target instanceof TileDrive) {
             for (final ItemStack driveStack : blocks.drive().maybeStack(1).asSet()) {
                 myIcon = driveStack;
             }
-
-            this.OriginalGui = GuiBridge.GUI_DRIVE;
+            this.originalGui = GuiBridge.GUI_DRIVE;
         }
 
         if (target instanceof TileChest) {
             for (final ItemStack chestStack : blocks.chest().maybeStack(1).asSet()) {
                 myIcon = chestStack;
             }
-
-            this.OriginalGui = GuiBridge.GUI_CHEST;
+            this.originalGui = GuiBridge.GUI_CHEST;
         }
 
         if (target instanceof TileInterface) {
             for (final ItemStack interfaceStack : blocks.iface().maybeStack(1).asSet()) {
                 myIcon = interfaceStack;
             }
-
-            this.OriginalGui = GuiBridge.GUI_INTERFACE;
+            this.originalGui = GuiBridge.GUI_INTERFACE;
         }
 
         if (target instanceof PartInterface) {
             for (final ItemStack interfaceStack : parts.iface().maybeStack(1).asSet()) {
                 myIcon = interfaceStack;
             }
-            this.OriginalGui = GuiBridge.GUI_INTERFACE;
+            this.originalGui = GuiBridge.GUI_INTERFACE;
         }
-
-        if (this.OriginalGui != null && myIcon != null) {
-            this.buttonList.add(
-                    this.originalGuiBtn = new GuiTabButton(
-                            this.guiLeft + 154,
-                            this.guiTop,
-                            myIcon,
-                            myIcon.getDisplayName(),
-                            itemRender));
-        }
-
-        this.priority = new GuiNumberBox(
-                this.fontRendererObj,
-                this.guiLeft + 62,
-                this.guiTop + 57,
-                59,
-                this.fontRendererObj.FONT_HEIGHT,
-                Long.class);
-        this.priority.setEnableBackgroundDrawing(false);
-        this.priority.setMaxStringLength(16);
-        this.priority.setTextColor(GuiColors.PriorityValue.getColor());
-        this.priority.setVisible(true);
-        this.priority.setFocused(true);
-        ((ContainerPriority) this.inventorySlots).setTextField(this.priority);
     }
 
     @Override
@@ -167,19 +117,13 @@ public class GuiPriority extends AEBaseGui {
 
     @Override
     public void drawBG(final int offsetX, final int offsetY, final int mouseX, final int mouseY) {
-        this.bindTexture("guis/priority.png");
-        this.drawTexturedModalRect(offsetX, offsetY, 0, 0, this.xSize, this.ySize);
-
-        this.priority.drawTextBox();
+        super.drawBG(offsetX, offsetY, mouseX, mouseY);
+        this.amountTextField.drawTextBox();
     }
 
     @Override
     protected void actionPerformed(final GuiButton btn) {
         super.actionPerformed(btn);
-
-        if (btn == this.originalGuiBtn) {
-            NetworkHandler.instance.sendToServer(new PacketSwitchGuis(this.OriginalGui));
-        }
 
         final boolean isPlus = btn == this.plus1 || btn == this.plus10 || btn == this.plus100 || btn == this.plus1000;
         final boolean isMinus = btn == this.minus1 || btn == this.minus10
@@ -187,74 +131,45 @@ public class GuiPriority extends AEBaseGui {
                 || btn == this.minus1000;
 
         if (isPlus || isMinus) {
-            this.addQty(this.getQty(btn));
-        }
-    }
-
-    private void addQty(final int i) {
-        try {
-            String out = this.priority.getText();
-
-            boolean fixed = false;
-            while (out.startsWith("0") && out.length() > 1) {
-                out = out.substring(1);
-                fixed = true;
+            try {
+                NetworkHandler.instance
+                        .sendToServer(new PacketValueConfig("PriorityHost.Priority", String.valueOf(getAmount())));
+            } catch (final IOException e) {
+                AELog.debug(e);
             }
-
-            if (fixed) {
-                this.priority.setText(out);
-            }
-
-            if (out.isEmpty()) {
-                out = "0";
-            }
-
-            long result = Long.parseLong(out);
-            result += i;
-
-            this.priority.setText(out = Long.toString(result));
-
-            NetworkHandler.instance.sendToServer(new PacketValueConfig("PriorityHost.Priority", out));
-        } catch (final NumberFormatException e) {
-            // nope..
-            this.priority.setText("0");
-        } catch (final IOException e) {
-            AELog.debug(e);
         }
     }
 
     @Override
     protected void keyTyped(final char character, final int key) {
-        if (!this.checkHotbarKeys(key)) {
-            if ((key == 211 || key == 205
-                    || key == 203
-                    || key == 14
-                    || character == '-'
-                    || Character.isDigit(character)) && this.priority.textboxKeyTyped(character, key)) {
-                try {
-                    String out = this.priority.getText();
+        super.keyTyped(character, key);
+        try {
+            NetworkHandler.instance
+                    .sendToServer(new PacketValueConfig("PriorityHost.Priority", String.valueOf(getAmount())));
+        } catch (final IOException e) {
+            AELog.debug(e);
+        }
+    }
 
-                    boolean fixed = false;
-                    while (out.startsWith("0") && out.length() > 1) {
-                        out = out.substring(1);
-                        fixed = true;
-                    }
+    // Use priority-specific button quantities
+    @Override
+    protected int getButtonQtyByIndex(int index) {
+        return AEConfig.instance.priorityByStacksAmounts(index);
+    }
 
-                    if (fixed) {
-                        this.priority.setText(out);
-                    }
-
-                    if (out.isEmpty()) {
-                        out = "0";
-                    }
-
-                    NetworkHandler.instance.sendToServer(new PacketValueConfig("PriorityHost.Priority", out));
-                } catch (final IOException e) {
-                    AELog.debug(e);
-                }
+    // Allow negative priorities and no clamping
+    @Override
+    protected int getAmount() {
+        try {
+            String out = this.amountTextField.getText();
+            double result = Calculator.conversion(out);
+            if (Double.isNaN(result)) {
+                return 0;
             } else {
-                super.keyTyped(character, key);
+                return (int) ArithHelper.round(result, 0);
             }
+        } catch (final NumberFormatException e) {
+            return 0;
         }
     }
 

--- a/src/main/java/appeng/container/implementations/ContainerCraftAmount.java
+++ b/src/main/java/appeng/container/implementations/ContainerCraftAmount.java
@@ -25,13 +25,23 @@ import appeng.api.networking.security.IActionHost;
 import appeng.api.networking.security.PlayerSource;
 import appeng.api.storage.ITerminalHost;
 import appeng.api.storage.data.IAEItemStack;
+import appeng.client.gui.widgets.MEGuiTextField;
 import appeng.container.AEBaseContainer;
+import appeng.container.guisync.GuiSync;
 import appeng.container.slot.SlotInaccessible;
 import appeng.core.sync.GuiBridge;
 import appeng.tile.inventory.AppEngInternalInventory;
 import appeng.util.Platform;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 
 public class ContainerCraftAmount extends AEBaseContainer {
+
+    @SideOnly(Side.CLIENT)
+    private MEGuiTextField amountField;
+
+    @GuiSync(1)
+    public long InitialCraftAmount = -1;
 
     private final Slot craftingItem;
     private IAEItemStack itemToCreate;
@@ -72,6 +82,39 @@ public class ContainerCraftAmount extends AEBaseContainer {
 
     public void setItemToCraft(@Nonnull final IAEItemStack itemToCreate) {
         this.itemToCreate = itemToCreate;
+    }
+
+    public long getInitialCraftAmount() {
+        return InitialCraftAmount;
+    }
+
+    public void setInitialCraftAmount(long initialCraftAmount) {
+        this.InitialCraftAmount = initialCraftAmount;
+    }
+
+    @SideOnly(Side.CLIENT)
+    public void setAmountField(MEGuiTextField amountField) {
+        this.amountField = amountField;
+        if (this.InitialCraftAmount > 0) {
+            this.amountField.setText(String.valueOf(this.InitialCraftAmount));
+        } else {
+            this.amountField.setText("1");
+        }
+        this.amountField.setCursorPositionEnd();
+        this.amountField.setSelectionPos(0);
+    }
+
+    @Override
+    public void onUpdate(String field, Object oldValue, Object newValue) {
+        if (field.equals("InitialCraftAmount")) {
+            if (this.amountField != null) {
+                this.amountField.setText(String.valueOf(this.InitialCraftAmount));
+                this.amountField.setCursorPositionEnd();
+                this.amountField.setSelectionPos(0);
+            }
+        }
+
+        super.onUpdate(field, oldValue, newValue);
     }
 
     public void openConfirmationGUI(EntityPlayer player, TileEntity te) {

--- a/src/main/java/appeng/container/implementations/ContainerCraftAmount.java
+++ b/src/main/java/appeng/container/implementations/ContainerCraftAmount.java
@@ -41,7 +41,7 @@ public class ContainerCraftAmount extends AEBaseContainer {
     private MEGuiTextField amountField;
 
     @GuiSync(1)
-    public long InitialCraftAmount = -1;
+    public long initialCraftAmount = -1;
 
     private final Slot craftingItem;
     private IAEItemStack itemToCreate;
@@ -84,31 +84,23 @@ public class ContainerCraftAmount extends AEBaseContainer {
         this.itemToCreate = itemToCreate;
     }
 
-    public long getInitialCraftAmount() {
-        return InitialCraftAmount;
-    }
-
     public void setInitialCraftAmount(long initialCraftAmount) {
-        this.InitialCraftAmount = initialCraftAmount;
+        this.initialCraftAmount = initialCraftAmount;
     }
 
     @SideOnly(Side.CLIENT)
     public void setAmountField(MEGuiTextField amountField) {
         this.amountField = amountField;
-        if (this.InitialCraftAmount > 0) {
-            this.amountField.setText(String.valueOf(this.InitialCraftAmount));
-        } else {
-            this.amountField.setText("1");
-        }
+        this.amountField.setText(String.valueOf(Math.max(1, this.initialCraftAmount)));
         this.amountField.setCursorPositionEnd();
         this.amountField.setSelectionPos(0);
     }
 
     @Override
     public void onUpdate(String field, Object oldValue, Object newValue) {
-        if (field.equals("InitialCraftAmount")) {
+        if (field.equals("initialCraftAmount")) {
             if (this.amountField != null) {
-                this.amountField.setText(String.valueOf(this.InitialCraftAmount));
+                this.amountField.setText(String.valueOf(Math.max(1, this.initialCraftAmount)));
                 this.amountField.setCursorPositionEnd();
                 this.amountField.setSelectionPos(0);
             }

--- a/src/main/java/appeng/container/implementations/ContainerPriority.java
+++ b/src/main/java/appeng/container/implementations/ContainerPriority.java
@@ -10,12 +10,12 @@
 
 package appeng.container.implementations;
 
-import net.minecraft.client.gui.GuiTextField;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 
 import appeng.api.config.SecurityPermissions;
 import appeng.api.implementations.guiobjects.IGuiItemObject;
+import appeng.client.gui.widgets.MEGuiTextField;
 import appeng.container.AEBaseContainer;
 import appeng.container.guisync.GuiSync;
 import appeng.helpers.IPriorityHost;
@@ -28,7 +28,7 @@ public class ContainerPriority extends AEBaseContainer {
     private final IPriorityHost priHost;
 
     @SideOnly(Side.CLIENT)
-    private GuiTextField textField;
+    private MEGuiTextField textField;
 
     @GuiSync(2)
     public long PriorityValue = -1;
@@ -39,7 +39,7 @@ public class ContainerPriority extends AEBaseContainer {
     }
 
     @SideOnly(Side.CLIENT)
-    public void setTextField(final GuiTextField level) {
+    public void setTextField(final MEGuiTextField level) {
         this.textField = level;
         this.textField.setText(String.valueOf(this.PriorityValue));
     }

--- a/src/main/java/appeng/container/implementations/ContainerPriority.java
+++ b/src/main/java/appeng/container/implementations/ContainerPriority.java
@@ -34,7 +34,7 @@ public class ContainerPriority extends AEBaseContainer {
     private boolean priorityTextInitialized = false;
 
     @GuiSync(2)
-    public long PriorityValue = -1;
+    public long priorityValue = -1;
 
     public ContainerPriority(final InventoryPlayer ip, final IPriorityHost host) {
         super(ip, host);
@@ -49,7 +49,7 @@ public class ContainerPriority extends AEBaseContainer {
 
     public void setPriority(final int newValue, final EntityPlayer player) {
         this.priHost.setPriority(newValue);
-        this.PriorityValue = newValue;
+        this.priorityValue = newValue;
     }
 
     @Override
@@ -59,7 +59,7 @@ public class ContainerPriority extends AEBaseContainer {
         }
 
         if (Platform.isServer()) {
-            this.PriorityValue = this.priHost.getPriority();
+            this.priorityValue = this.priHost.getPriority();
         }
 
         super.detectAndSendChanges();
@@ -67,7 +67,7 @@ public class ContainerPriority extends AEBaseContainer {
 
     @Override
     public void onUpdate(final String field, final Object oldValue, final Object newValue) {
-        if (field.equals("PriorityValue")) {
+        if (field.equals("priorityValue")) {
             if (this.priorityTextField != null && !this.priorityTextInitialized) {
                 updatePriorityTextFieldValue();
                 priorityTextInitialized = true;
@@ -78,7 +78,7 @@ public class ContainerPriority extends AEBaseContainer {
     }
 
     private void updatePriorityTextFieldValue() {
-        this.priorityTextField.setText(String.valueOf(this.PriorityValue));
+        this.priorityTextField.setText(String.valueOf(this.priorityValue));
         this.priorityTextField.setCursorPositionEnd();
         this.priorityTextField.setSelectionPos(0);
     }

--- a/src/main/java/appeng/container/implementations/ContainerPriority.java
+++ b/src/main/java/appeng/container/implementations/ContainerPriority.java
@@ -28,7 +28,7 @@ public class ContainerPriority extends AEBaseContainer {
     private final IPriorityHost priHost;
 
     @SideOnly(Side.CLIENT)
-    private MEGuiTextField textField;
+    private MEGuiTextField priorityTextField;
 
     @GuiSync(2)
     public long PriorityValue = -1;
@@ -40,8 +40,8 @@ public class ContainerPriority extends AEBaseContainer {
 
     @SideOnly(Side.CLIENT)
     public void setTextField(final MEGuiTextField level) {
-        this.textField = level;
-        this.textField.setText(String.valueOf(this.PriorityValue));
+        this.priorityTextField = level;
+        updatePriorityTextFieldValue();
     }
 
     public void setPriority(final int newValue, final EntityPlayer player) {
@@ -64,11 +64,17 @@ public class ContainerPriority extends AEBaseContainer {
     @Override
     public void onUpdate(final String field, final Object oldValue, final Object newValue) {
         if (field.equals("PriorityValue")) {
-            if (this.textField != null) {
-                this.textField.setText(String.valueOf(this.PriorityValue));
+            if (this.priorityTextField != null) {
+                updatePriorityTextFieldValue();
             }
         }
 
         super.onUpdate(field, oldValue, newValue);
+    }
+
+    private void updatePriorityTextFieldValue() {
+        this.priorityTextField.setText(String.valueOf(this.PriorityValue));
+        this.priorityTextField.setCursorPositionEnd();
+        this.priorityTextField.setSelectionPos(0);
     }
 }

--- a/src/main/java/appeng/container/implementations/ContainerPriority.java
+++ b/src/main/java/appeng/container/implementations/ContainerPriority.java
@@ -30,6 +30,9 @@ public class ContainerPriority extends AEBaseContainer {
     @SideOnly(Side.CLIENT)
     private MEGuiTextField priorityTextField;
 
+    @SideOnly(Side.CLIENT)
+    private boolean priorityTextInitialized = false;
+
     @GuiSync(2)
     public long PriorityValue = -1;
 
@@ -51,7 +54,6 @@ public class ContainerPriority extends AEBaseContainer {
 
     @Override
     public void detectAndSendChanges() {
-        super.detectAndSendChanges();
         if (!(priHost instanceof IGuiItemObject)) {
             this.verifyPermissions(SecurityPermissions.BUILD, false);
         }
@@ -59,13 +61,16 @@ public class ContainerPriority extends AEBaseContainer {
         if (Platform.isServer()) {
             this.PriorityValue = this.priHost.getPriority();
         }
+
+        super.detectAndSendChanges();
     }
 
     @Override
     public void onUpdate(final String field, final Object oldValue, final Object newValue) {
         if (field.equals("PriorityValue")) {
-            if (this.priorityTextField != null) {
+            if (this.priorityTextField != null && !this.priorityTextInitialized) {
                 updatePriorityTextFieldValue();
+                priorityTextInitialized = true;
             }
         }
 

--- a/src/main/java/appeng/core/sync/packets/PacketInventoryAction.java
+++ b/src/main/java/appeng/core/sync/packets/PacketInventoryAction.java
@@ -120,6 +120,7 @@ public class PacketInventoryAction extends AppEngPacket {
                         if (baseContainer.getTargetStack() != null) {
                             cca.getCraftingItem().putStack(baseContainer.getTargetStack().getItemStack());
                             cca.setItemToCraft(baseContainer.getTargetStack());
+                            cca.setInitialCraftAmount(this.id);
                         }
 
                         cca.detectAndSendChanges();


### PR DESCRIPTION
- Migrates GuiPriority to be inherited from GuiAmount as this is done in AE2FC. Replaces GuiNumberBox with MEGuiTextField
- Sets proper items count in GuiCraftAmount when middleclicking on item in GuiCraftCPU

Actual change: 

E.g. we have running craft:

<img width="493" height="158" alt="image" src="https://github.com/user-attachments/assets/5471b1e0-f4f4-41e4-85ba-91d6d1aecd4f" />

Middle click on item to request more (of request missing) open the GUI with a proper amount of items inserted:

<img width="359" height="219" alt="image" src="https://github.com/user-attachments/assets/00e80430-5d5c-477b-b468-7f39136d8c2f" />

Before there is only `1` in textbox in this GUI.

Required https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/329

