### PR TITLE
Disable hotbar keys handling to allow input numbers in the search field in terminals

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
@@ -795,4 +795,11 @@ public class GuiMEMonitorable extends AEBaseMEGui
     public IItemList<IAEItemStack> getAvaibleItems() {
         return repo.getAvailableItems();
     }
+
+    // Moving items via hotbar keys in terminals isn't working anyway.
+    // Let's disable hotbar keys processing to allow proper input of numbers in the search field
+    @Override
+    protected boolean checkHotbarKeys(int keyCode) {
+        return false;
+    }
 }


### PR DESCRIPTION
Moving items via hotbar keys from AE2 terminals isn't working anyway. (or I can't figure out how to actually use this).
Let's disable hotbar keys processing to allow proper input of numbers in the search field.

Before: hovering over an item in terminal and pressing 1-9 do nothing
After: it inserts number into search bar if it focused