### PR TITLE
Limiting installation one void and distribution card

### DIFF
--- a/src/main/java/appeng/parts/automation/UpgradeInventory.java
+++ b/src/main/java/appeng/parts/automation/UpgradeInventory.java
@@ -42,6 +42,7 @@ public abstract class UpgradeInventory extends AppEngInternalInventory implement
     private int fakeCraftingUpgrades = 0;
     private int stickyUpgrades = 0;
     private int voidUpgrades = 0;
+    private int distributionUpgrades = 0;
 
     public UpgradeInventory(final IAEAppEngInventory parent, final int s) {
         super(null, s);
@@ -95,6 +96,7 @@ public abstract class UpgradeInventory extends AppEngInternalInventory implement
             case FAKE_CRAFTING -> this.fakeCraftingUpgrades;
             case SUPERLUMINALSPEED -> this.SuperluminalSpeedUpgrades;
             case VOID_OVERFLOW -> this.voidUpgrades;
+            case DISTRIBUTION -> this.distributionUpgrades;
             default -> 0;
         };
     }
@@ -103,7 +105,7 @@ public abstract class UpgradeInventory extends AppEngInternalInventory implement
 
     private void updateUpgradeInfo() {
         this.cached = true;
-        this.patternCapacityUpgrades = this.SuperluminalSpeedUpgrades = this.stickyUpgrades = this.inverterUpgrades = this.capacityUpgrades = this.redstoneUpgrades = this.speedUpgrades = this.superSpeedUpgrades = this.fuzzyUpgrades = this.craftingUpgrades = this.oreFilterUpgrades = this.advancedBlockingUpgrades = this.lockCraftingUpgrades = this.fakeCraftingUpgrades = this.voidUpgrades = 0;
+        this.patternCapacityUpgrades = this.SuperluminalSpeedUpgrades = this.stickyUpgrades = this.inverterUpgrades = this.capacityUpgrades = this.redstoneUpgrades = this.speedUpgrades = this.superSpeedUpgrades = this.fuzzyUpgrades = this.craftingUpgrades = this.oreFilterUpgrades = this.advancedBlockingUpgrades = this.lockCraftingUpgrades = this.fakeCraftingUpgrades = this.voidUpgrades = this.distributionUpgrades = 0;
 
         for (final ItemStack is : this) {
             if (is == null || is.getItem() == null || !(is.getItem() instanceof IUpgradeModule)) {
@@ -127,6 +129,7 @@ public abstract class UpgradeInventory extends AppEngInternalInventory implement
                 case FAKE_CRAFTING -> this.fakeCraftingUpgrades++;
                 case SUPERLUMINALSPEED -> this.SuperluminalSpeedUpgrades++;
                 case VOID_OVERFLOW -> this.voidUpgrades++;
+                case DISTRIBUTION -> this.distributionUpgrades++;
                 default -> {}
             }
         }
@@ -149,6 +152,7 @@ public abstract class UpgradeInventory extends AppEngInternalInventory implement
         this.SuperluminalSpeedUpgrades = Math
                 .min(this.SuperluminalSpeedUpgrades, this.getMaxInstalled(Upgrades.SUPERLUMINALSPEED));
         this.voidUpgrades = Math.min(this.voidUpgrades, this.getMaxInstalled(Upgrades.VOID_OVERFLOW));
+        this.distributionUpgrades = Math.min(this.distributionUpgrades, this.getMaxInstalled(Upgrades.DISTRIBUTION));
     }
 
     @Override

--- a/src/main/java/appeng/parts/automation/UpgradeInventory.java
+++ b/src/main/java/appeng/parts/automation/UpgradeInventory.java
@@ -41,6 +41,7 @@ public abstract class UpgradeInventory extends AppEngInternalInventory implement
     private int lockCraftingUpgrades = 0;
     private int fakeCraftingUpgrades = 0;
     private int stickyUpgrades = 0;
+    private int voidUpgrades = 0;
 
     public UpgradeInventory(final IAEAppEngInventory parent, final int s) {
         super(null, s);
@@ -93,6 +94,7 @@ public abstract class UpgradeInventory extends AppEngInternalInventory implement
             case STICKY -> this.stickyUpgrades;
             case FAKE_CRAFTING -> this.fakeCraftingUpgrades;
             case SUPERLUMINALSPEED -> this.SuperluminalSpeedUpgrades;
+            case VOID_OVERFLOW -> this.voidUpgrades;
             default -> 0;
         };
     }
@@ -101,7 +103,7 @@ public abstract class UpgradeInventory extends AppEngInternalInventory implement
 
     private void updateUpgradeInfo() {
         this.cached = true;
-        this.patternCapacityUpgrades = this.SuperluminalSpeedUpgrades = this.stickyUpgrades = this.inverterUpgrades = this.capacityUpgrades = this.redstoneUpgrades = this.speedUpgrades = this.superSpeedUpgrades = this.fuzzyUpgrades = this.craftingUpgrades = this.oreFilterUpgrades = this.advancedBlockingUpgrades = this.lockCraftingUpgrades = this.fakeCraftingUpgrades = 0;
+        this.patternCapacityUpgrades = this.SuperluminalSpeedUpgrades = this.stickyUpgrades = this.inverterUpgrades = this.capacityUpgrades = this.redstoneUpgrades = this.speedUpgrades = this.superSpeedUpgrades = this.fuzzyUpgrades = this.craftingUpgrades = this.oreFilterUpgrades = this.advancedBlockingUpgrades = this.lockCraftingUpgrades = this.fakeCraftingUpgrades = this.voidUpgrades = 0;
 
         for (final ItemStack is : this) {
             if (is == null || is.getItem() == null || !(is.getItem() instanceof IUpgradeModule)) {
@@ -124,6 +126,7 @@ public abstract class UpgradeInventory extends AppEngInternalInventory implement
                 case STICKY -> this.stickyUpgrades++;
                 case FAKE_CRAFTING -> this.fakeCraftingUpgrades++;
                 case SUPERLUMINALSPEED -> this.SuperluminalSpeedUpgrades++;
+                case VOID_OVERFLOW -> this.voidUpgrades++;
                 default -> {}
             }
         }
@@ -145,6 +148,7 @@ public abstract class UpgradeInventory extends AppEngInternalInventory implement
         this.stickyUpgrades = Math.min(this.stickyUpgrades, this.getMaxInstalled(Upgrades.STICKY));
         this.SuperluminalSpeedUpgrades = Math
                 .min(this.SuperluminalSpeedUpgrades, this.getMaxInstalled(Upgrades.SUPERLUMINALSPEED));
+        this.voidUpgrades = Math.min(this.voidUpgrades, this.getMaxInstalled(Upgrades.VOID_OVERFLOW));
     }
 
     @Override


### PR DESCRIPTION
I was using Shift+LMB when putting cards in cells and noticed that void and distribution card can be put more than one piece in a cell. This fix sets the limit to 1 piece. As far as I understand `Registration.java` had the basics for this but `UpgradeInventory.java` has not been changed