### PR TITLE
Show Correctly Required Power in SpatialIO

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiNetworkStatus.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiNetworkStatus.java
@@ -128,10 +128,15 @@ public class GuiNetworkStatus extends AEBaseGui implements ISortSource {
             return;
         }
 
-        final ItemStack is;
+        ItemStack is = null;
         if (tooltip > -1) {
-            is = repo.getReferenceItem(tooltip).getItemStack();
-        } else is = null;
+            final IAEItemStack aeStack = repo.getReferenceItem(tooltip);
+
+            if (aeStack != null) {
+                is = aeStack.getItemStack();
+            }
+
+        }
 
         if (is == null || !is.hasTagCompound()) {
             super.mouseClicked(xCoord, yCoord, btn);
@@ -223,7 +228,9 @@ public class GuiNetworkStatus extends AEBaseGui implements ISortSource {
 
         int y = 0;
         int x = 0;
-        for (int z = 0; z <= 4 * 5; z++) {
+        final int viewEnd = Math.min(5 * 4, this.repo.size());
+
+        for (int z = 0; z < viewEnd; z++) {
             final int minX = gx + 14 + x * 31;
             final int minY = gy + 41 + y * 18;
 

--- a/src/main/java/appeng/container/implementations/ContainerSpatialIOPort.java
+++ b/src/main/java/appeng/container/implementations/ContainerSpatialIOPort.java
@@ -13,6 +13,7 @@ package appeng.container.implementations;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import appeng.api.config.PowerMultiplier;
 import appeng.api.config.SecurityPermissions;
 import appeng.api.networking.IGrid;
 import appeng.api.networking.energy.IEnergyGrid;
@@ -81,7 +82,7 @@ public class ContainerSpatialIOPort extends AEBaseContainer {
                 if (eg != null) {
                     this.setCurrentPower((long) (100.0 * eg.getStoredPower()));
                     this.setMaxPower((long) (100.0 * eg.getMaxStoredPower()));
-                    this.setRequiredPower((long) (100.0 * sc.requiredPower()));
+                    this.setRequiredPower((long) (100.0 * PowerMultiplier.CONFIG.multiply(sc.requiredPower())));
                     this.setEfficency((long) (100.0f * sc.currentEfficiency()));
                 }
             }


### PR DESCRIPTION
### Correct show Required Power (used powerratios.UsageMultiplier config parameter):
<img width="537" height="362" alt="image" src="https://github.com/user-attachments/assets/616ec233-366a-4684-8a46-5dc2b3d0af33" />

### Fixed crash when clicking in free space:
<img width="602" height="556" alt="image" src="https://github.com/user-attachments/assets/042adc7c-935d-4e53-b9b6-e06e81d02621" />
