### PR TITLE
Add new crafting keyboard shortcuts

### DIFF
--- a/src/main/java/appeng/api/networking/crafting/ICraftingGrid.java
+++ b/src/main/java/appeng/api/networking/crafting/ICraftingGrid.java
@@ -68,6 +68,26 @@ public interface ICraftingGrid extends IGridCache {
      *                          find the lower end cpus, automatic processes generally should pick lower end cpus.
      * @param src               - the action source to use when starting the job, this will be used for extracting
      *                          items, should usually be the same as the one provided to beginCraftingJob.
+     * @param followCraft       - Whether to follow the craft and send a notification to the requesting player when it
+     *                          completes
+     * @return null ( if failed ) or an {@link ICraftingLink} other wise, if you send requestingMachine you need to
+     *         properly keep track of this and handle the nbt saving and loading of the object as well as the
+     *         {@link ICraftingRequester} methods. if you send null, this object should be discarded after verifying the
+     *         return state.
+     */
+    ICraftingLink submitJob(ICraftingJob job, ICraftingRequester requestingMachine, ICraftingCPU target,
+            boolean prioritizePower, BaseActionSource src, boolean followCraft);
+
+    /**
+     * Submit the job to the Crafting system for processing.
+     *
+     * @param job               - the crafting job from beginCraftingJob
+     * @param requestingMachine - a machine if its being requested via automation, may be null.
+     * @param target            - can be null
+     * @param prioritizePower   - if cpu is null, this determine if the system should prioritize power, or if it should
+     *                          find the lower end cpus, automatic processes generally should pick lower end cpus.
+     * @param src               - the action source to use when starting the job, this will be used for extracting
+     *                          items, should usually be the same as the one provided to beginCraftingJob.
      * @return null ( if failed ) or an {@link ICraftingLink} other wise, if you send requestingMachine you need to
      *         properly keep track of this and handle the nbt saving and loading of the object as well as the
      *         {@link ICraftingRequester} methods. if you send null, this object should be discarded after verifying the

--- a/src/main/java/appeng/client/gui/implementations/GuiCraftAmount.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCraftAmount.java
@@ -150,6 +150,7 @@ public class GuiCraftAmount extends GuiAmount {
                         new PacketCraftRequest(
                                 addOrderAmount(0),
                                 isShiftKeyDown(),
+                                isCtrlKeyDown(),
                                 (CraftingMode) this.craftingMode.getCurrentValue()));
             }
         } catch (final NumberFormatException e) {

--- a/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
@@ -362,7 +362,12 @@ public class GuiCraftConfirm extends AEBaseGui implements ICraftingCPUTableHolde
                 this.start.enabled = false;
             }
         }
-        this.startWithFollow.enabled = this.start.enabled;
+
+        this.startWithFollow.enabled = this.start.enabled && !this.ccc.isManualStartAndFollow();
+
+        if (this.ccc.isManualStartAndFollow()) {
+            this.startWithFollow.displayString = GuiText.AutoFollowEnabled.getLocal();
+        }
 
         this.selectCPU.enabled = (displayMode == DisplayMode.LIST) && !this.isSimulation();
         this.optimizeButton.enabled = (displayMode == DisplayMode.LIST) && !this.isSimulation()
@@ -1021,14 +1026,17 @@ public class GuiCraftConfirm extends AEBaseGui implements ICraftingCPUTableHolde
             }
         } else if (btn == this.start) {
             try {
-                NetworkHandler.instance.sendToServer(new PacketValueConfig("Terminal.Start", "Start"));
+                if (this.ccc.isManualStartAndFollow()) {
+                    NetworkHandler.instance.sendToServer(new PacketValueConfig("Terminal.StartWithFollow", "Start"));
+                } else {
+                    NetworkHandler.instance.sendToServer(new PacketValueConfig("Terminal.Start", "Start"));
+                }
             } catch (final Throwable e) {
                 AELog.debug(e);
             }
         } else if (btn == this.startWithFollow) {
-            final String playerName = this.mc.thePlayer.getCommandSenderName();
             try {
-                NetworkHandler.instance.sendToServer(new PacketValueConfig("Terminal.StartWithFollow", playerName));
+                NetworkHandler.instance.sendToServer(new PacketValueConfig("Terminal.StartWithFollow", "Start"));
             } catch (final Throwable e) {
                 AELog.debug(e);
             }

--- a/src/main/java/appeng/container/implementations/ContainerCraftConfirm.java
+++ b/src/main/java/appeng/container/implementations/ContainerCraftConfirm.java
@@ -83,6 +83,9 @@ public class ContainerCraftConfirm extends AEBaseContainer implements ICraftingC
     @GuiSync(4)
     public boolean simulation = true;
 
+    @GuiSync(5)
+    public boolean autoStartAndFollow = false;
+
     @GuiSync(6)
     public boolean noCPU = true;
 
@@ -97,6 +100,9 @@ public class ContainerCraftConfirm extends AEBaseContainer implements ICraftingC
 
     @GuiSync(10)
     public String serializedItemToCraft = "";
+
+    @GuiSync(11)
+    public boolean manualStartAndFollow = false;
 
     public ContainerCraftConfirm(final InventoryPlayer ip, final ITerminalHost te) {
         super(ip, te);
@@ -144,7 +150,12 @@ public class ContainerCraftConfirm extends AEBaseContainer implements ICraftingC
 
                 if (!this.result.isSimulation()) {
                     this.setSimulation(false);
-                    if (this.isAutoStart()) {
+                    if (this.isAutoStartAndFollow()) {
+                        // Call start job with follow enabled
+                        this.startJob(true);
+                        return;
+                    } else if (this.isAutoStart()) {
+                        // If only Shift is held and not Ctrl then we end up here and start the job with no follow
                         this.startJob();
                         return;
                     }
@@ -282,23 +293,10 @@ public class ContainerCraftConfirm extends AEBaseContainer implements ICraftingC
     }
 
     public void startJob() {
-        if (this.result != null && !this.isSimulation() && getGrid() != null) {
-            final ICraftingGrid cc = this.getGrid().getCache(ICraftingGrid.class);
-            CraftingCPUStatus selected = this.cpuTable.getSelectedCPU();
-            final ICraftingLink g = cc.submitJob(
-                    this.result,
-                    null,
-                    (selected == null) ? null : selected.getServerCluster(),
-                    true,
-                    this.getActionSrc());
-            this.setAutoStart(false);
-            if (g != null) {
-                this.switchToOriginalGUI();
-            }
-        }
+        startJob(false);
     }
 
-    public void startJob(String playerName) {
+    public void startJob(final boolean followCraft) {
         if (this.result != null && !this.isSimulation() && getGrid() != null) {
             final ICraftingGrid cc = this.getGrid().getCache(ICraftingGrid.class);
             CraftingCPUStatus selected = this.cpuTable.getSelectedCPU();
@@ -307,9 +305,10 @@ public class ContainerCraftConfirm extends AEBaseContainer implements ICraftingC
                     null,
                     (selected == null) ? null : selected.getServerCluster(),
                     true,
-                    this.getActionSrc());
-            selected.getServerCluster().togglePlayerFollowStatus(playerName);
+                    this.getActionSrc(),
+                    followCraft);
             this.setAutoStart(false);
+            this.setAutoStartAndFollow(false);
             if (g != null) {
                 this.switchToOriginalGUI();
             }
@@ -395,8 +394,24 @@ public class ContainerCraftConfirm extends AEBaseContainer implements ICraftingC
         return this.autoStart;
     }
 
+    public boolean isAutoStartAndFollow() {
+        return this.autoStartAndFollow;
+    }
+
+    public boolean isManualStartAndFollow() {
+        return this.manualStartAndFollow;
+    }
+
     public void setAutoStart(final boolean autoStart) {
         this.autoStart = autoStart;
+    }
+
+    public void setAutoStartAndFollow(final boolean autoStartAndFollow) {
+        this.autoStartAndFollow = autoStartAndFollow;
+    }
+
+    public void setManualStartAndFollow(final boolean manualStartAndFollow) {
+        this.manualStartAndFollow = manualStartAndFollow;
     }
 
     public long getUsedBytes() {

--- a/src/main/java/appeng/core/localization/GuiText.java
+++ b/src/main/java/appeng/core/localization/GuiText.java
@@ -164,6 +164,7 @@ public enum GuiText implements Localization {
     CalculatingWait,
     Start,
     StartWithFollow,
+    AutoFollowEnabled,
     Merge,
     Bytes,
     Set,

--- a/src/main/java/appeng/core/sync/packets/PacketCraftRequest.java
+++ b/src/main/java/appeng/core/sync/packets/PacketCraftRequest.java
@@ -36,29 +36,34 @@ public class PacketCraftRequest extends AppEngPacket {
 
     private final long amount;
     private final boolean heldShift;
+    private final boolean heldCtrl;
 
     private final CraftingMode craftingMode;
 
     // automatic.
     public PacketCraftRequest(final ByteBuf stream) {
         this.heldShift = stream.readBoolean();
+        this.heldCtrl = stream.readBoolean();
         this.amount = stream.readLong();
         this.craftingMode = CraftingMode.values()[stream.readByte()];
     }
 
-    public PacketCraftRequest(final int craftAmt, final boolean shift) {
-        this(craftAmt, shift, CraftingMode.STANDARD);
+    public PacketCraftRequest(final int craftAmt, final boolean shift, final boolean control) {
+        this(craftAmt, shift, control, CraftingMode.STANDARD);
     }
 
-    public PacketCraftRequest(final long craftAmt, final boolean shift, final CraftingMode craftingMode) {
+    public PacketCraftRequest(final long craftAmt, final boolean shift, final boolean control,
+            final CraftingMode craftingMode) {
         this.amount = craftAmt;
         this.heldShift = shift;
+        this.heldCtrl = control;
         this.craftingMode = craftingMode;
 
         final ByteBuf data = Unpooled.buffer();
 
         data.writeInt(this.getPacketID());
         data.writeBoolean(shift);
+        data.writeBoolean(control);
         data.writeLong(this.amount);
         data.writeByte(craftingMode.ordinal());
 
@@ -108,7 +113,9 @@ public class PacketCraftRequest extends AppEngPacket {
                         cca.openConfirmationGUI(player, te);
 
                         if (player.openContainer instanceof ContainerCraftConfirm ccc) {
-                            ccc.setAutoStart(this.heldShift);
+                            ccc.setAutoStart(this.heldShift && !this.heldCtrl);
+                            ccc.setAutoStartAndFollow(this.heldShift && this.heldCtrl);
+                            ccc.setManualStartAndFollow(this.heldCtrl && !this.heldShift);
                             ccc.setJob(futureJob);
                             cca.detectAndSendChanges();
                         }

--- a/src/main/java/appeng/core/sync/packets/PacketValueConfig.java
+++ b/src/main/java/appeng/core/sync/packets/PacketValueConfig.java
@@ -98,7 +98,7 @@ public class PacketValueConfig extends AppEngPacket {
         } else if (this.Name.equals("CPUTable.Cpu.Set") && c instanceof final ICraftingCPUSelectorContainer qk) {
             qk.selectCPU(Integer.parseInt(this.Value));
         } else if (this.Name.equals("Terminal.StartWithFollow") && c instanceof final ContainerCraftConfirm qk) {
-        	qk.startJob(this.Value);
+        	qk.startJob(true);
         } else if (this.Name.equals("Terminal.Start") && c instanceof final ContainerCraftConfirm qk) {
         	qk.startJob();
         } else if(this.Name.equals("Terminal.OptimizePatterns") && c instanceof final ContainerCraftConfirm qk) {

--- a/src/main/java/appeng/me/cache/CraftingGridCache.java
+++ b/src/main/java/appeng/me/cache/CraftingGridCache.java
@@ -64,6 +64,7 @@ import appeng.api.networking.events.MENetworkCraftingPatternChange;
 import appeng.api.networking.events.MENetworkEventSubscribe;
 import appeng.api.networking.events.MENetworkPostCacheConstruction;
 import appeng.api.networking.security.BaseActionSource;
+import appeng.api.networking.security.PlayerSource;
 import appeng.api.networking.storage.IStorageGrid;
 import appeng.api.storage.ICellProvider;
 import appeng.api.storage.IMEInventoryHandler;
@@ -499,8 +500,15 @@ public class CraftingGridCache
     }
 
     @Override
+    public ICraftingLink submitJob(ICraftingJob job, ICraftingRequester requestingMachine, ICraftingCPU target,
+            boolean prioritizePower, BaseActionSource src) {
+        return submitJob(job, requestingMachine, target, prioritizePower, src, false);
+    }
+
+    @Override
     public ICraftingLink submitJob(final ICraftingJob job, final ICraftingRequester requestingMachine,
-            final ICraftingCPU target, final boolean prioritizePower, final BaseActionSource src) {
+            final ICraftingCPU target, final boolean prioritizePower, final BaseActionSource src,
+            final boolean followCraft) {
         if (job.isSimulation()) {
             return null;
         }
@@ -561,7 +569,14 @@ public class CraftingGridCache
         }
 
         if (cpuCluster != null) {
-            return cpuCluster.submitJob(this.grid, job, src, requestingMachine);
+            ICraftingLink submittedJob = cpuCluster.submitJob(this.grid, job, src, requestingMachine);
+
+            if (src instanceof PlayerSource && followCraft) {
+                System.out.println("Player source: " + ((PlayerSource) src).player.getCommandSenderName());
+                cpuCluster.togglePlayerFollowStatus(((PlayerSource) src).player.getCommandSenderName());
+            }
+
+            return submittedJob;
         }
 
         return null;

--- a/src/main/resources/assets/appliedenergistics2/lang/en_US.lang
+++ b/src/main/resources/assets/appliedenergistics2/lang/en_US.lang
@@ -287,6 +287,7 @@ gui.appliedenergistics2.CraftingPlan=Crafting Plan
 gui.appliedenergistics2.Automatic=Automatic
 gui.appliedenergistics2.Start=Start
 gui.appliedenergistics2.StartWithFollow=Start With Follow
+gui.appliedenergistics2.AutoFollowEnabled=Auto following
 gui.appliedenergistics2.Merge=Merge
 gui.appliedenergistics2.Missing=Missing
 gui.appliedenergistics2.NoCraftingTreeReceived=No crafting tree received


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20893

Currently we have shift click for auto starting a craft but after a quick chat on discord regarding the linked issue I've rounded out the UX for auto crafting as follows:

1. No Ctrl or Shift + Click = default AE2 behaviour
2. Shift + Click = current auto start behaviour
3. Ctrl + Click = show recipe tree but have the "start with follow" button disabled and it's text replaced with "Auto Following"
4. Ctrl + Shift + Click = auto start the craft and follow it

The only graphical change to the UI is for scenario 3:
<img width="2820" height="1592" alt="2025-08-22 23_47_39-Minecraft 1 7 10" src="https://github.com/user-attachments/assets/c3091e8d-6a9f-47aa-b588-ac9aba8da686" />

I did hit one issue with implementing scenario 4:

The current auto start behaviour simply calls `submitJob` with a null crafting CPU so then AE can just figure out which CPU it can run the craft on inside the `submitJob` method however to follow a craft we need to know which CPU it was started on so I re-factored submitJob to take a `followCraft` bool that it checks after passing the job to the crafting CPU near the end of the method and if the request source is a player and the bool is true it'll follow the craft.

I have confirmed the all current auto crafting request behaviour still works as expected as well as the new features.

The only thing I've not done is change the crafting amount screen so when you hold ctrl+shift it'll just say "start" like it does when just shift is held if I wanted to change the text on that screen I'd probably have to make the button bigger or maybe just set the display text to "Follow".

I'd be very interested to hear people's thoughts on the implementation.