### PR TITLE
Fix: Ensure powered-off ME Drive cell status remains black with night vision

### DIFF
--- a/src/main/java/appeng/client/render/blocks/RenderDrive.java
+++ b/src/main/java/appeng/client/render/blocks/RenderDrive.java
@@ -331,21 +331,23 @@ public class RenderDrive extends BaseBlockRender<BlockDrive, TileDrive> {
 
                     if (sp.isPowered()) {
                         tess.setBrightness(15 << 20 | 15 << 4);
-                    } else {
-                        tess.setBrightness(0);
-                    }
 
-                    if (stat == 1) {
-                        tess.setColorOpaque_I(0x00ff00);
-                    }
-                    if (stat == 2) {
-                        tess.setColorOpaque_I(0x00aaff);
-                    }
-                    if (stat == 3) {
-                        tess.setColorOpaque_I(0xffaa00);
-                    }
-                    if (stat == 4) {
-                        tess.setColorOpaque_I(0xff0000);
+                        switch (stat) {
+                            case 1:
+                                tess.setColorOpaque_I(0x00ff00);
+                                break;
+                            case 2:
+                                tess.setColorOpaque_I(0x00aaff);
+                                break;
+                            case 3:
+                                tess.setColorOpaque_I(0xffaa00);
+                                break;
+                            case 4:
+                                tess.setColorOpaque_I(0xff0000);
+                        }
+                    } else {
+                        tess.setColorOpaque_I(0x000000);
+                        tess.setBrightness(0);
                     }
 
                     switch (forward.offsetX + forward.offsetY * 2 + forward.offsetZ * 3) {


### PR DESCRIPTION
The ME Drive cell status was incorrectly rendering with a color at full brightness when the device was powered off, but only when night vision mode was active. This was visually misleading as it suggested the drive might still be active.

Fixes GTNewHorizons/GT-New-Horizons-Modpack#18008