### PR TITLE
Fix missing field on server resulting in player kick when opening priority GUI

### DIFF
--- a/src/main/java/appeng/container/implementations/ContainerPriority.java
+++ b/src/main/java/appeng/container/implementations/ContainerPriority.java
@@ -30,7 +30,6 @@ public class ContainerPriority extends AEBaseContainer {
     @SideOnly(Side.CLIENT)
     private MEGuiTextField priorityTextField;
 
-    @SideOnly(Side.CLIENT)
     private boolean priorityTextInitialized = false;
 
     @GuiSync(2)


### PR DESCRIPTION
The field `priorityTextInitialized` has been marked as client only but it is referred to in `onUpdate` which is called on the server so when opening the priority GUI of a storage bus on a dedicated server the player is kicked with a NoSuchFieldException.

```
[13:11:37] [Server thread/ERROR] [FML/]: There was a critical exception handling a packet on channel ae2fc
java.lang.NoSuchFieldError: priorityTextInitialized
        at Launch//appeng.container.implementations.ContainerPriority.<init>(ContainerPriority.java:33) ~[ContainerPriority.class:?]
```

Confirmed that with this PR the priority GUI opens as expected and priorities are set as expected when changed.