### PR TITLE
Remove error log from CellInventory as it can lead to log spam

### DIFF
--- a/src/main/java/appeng/me/storage/CellInventory.java
+++ b/src/main/java/appeng/me/storage/CellInventory.java
@@ -39,7 +39,6 @@ import appeng.api.storage.ISaveProvider;
 import appeng.api.storage.StorageChannel;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IItemList;
-import appeng.core.AELog;
 import appeng.util.IterationCounter;
 import appeng.util.Platform;
 import appeng.util.item.AEItemStack;
@@ -212,9 +211,6 @@ public class CellInventory implements ICellInventory {
         }
 
         if (input.isCraftable()) {
-            AELog.error(
-                    new Throwable(),
-                    "FATAL: DETECTED ILLEGAL ITEM TO BE INSERTED ON STORAGE CELL, PLEASE REPORT ON GITHUB! STACKTRACE:");
             input.setCraftable(false);
         }
 


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20959

Remove the error log line from CellInventory which was added by PR #537 as it can lead to log spam and that PR was merged over a year ago so we probably don't need that logging any more.