### PR TITLE
Re-add the client only annotation to ContainerPriority but without a default value to avoid server-side exceptions

### DIFF
--- a/src/main/java/appeng/container/implementations/ContainerPriority.java
+++ b/src/main/java/appeng/container/implementations/ContainerPriority.java
@@ -30,7 +30,8 @@ public class ContainerPriority extends AEBaseContainer {
     @SideOnly(Side.CLIENT)
     private MEGuiTextField priorityTextField;
 
-    private boolean priorityTextInitialized = false;
+    @SideOnly(Side.CLIENT)
+    private boolean priorityTextInitialized;
 
     @GuiSync(2)
     public long priorityValue = -1;


### PR DESCRIPTION
Raising after a discussion with @Nikolay-Sitnikov on Discord.

This is a more correct way of addressing the issue I fixed in #837 by keeping the field client only but removing the default value so that we don't hit a runtime error when the class is constructed on the server side.