### PR TITLE
Fix exception and kick from server caused by trying to cast to AEBaseContainer without checking first

### DIFF
--- a/src/main/java/appeng/core/sync/packets/PacketValueConfig.java
+++ b/src/main/java/appeng/core/sync/packets/PacketValueConfig.java
@@ -207,7 +207,7 @@ public class PacketValueConfig extends AppEngPacket {
 
         if (this.Name.equals("CustomName") && c instanceof AEBaseContainer) {
             ((AEBaseContainer) c).setCustomName(this.Value);
-        } else if (this.Name.startsWith("SyncDat.")) {
+        } else if (this.Name.startsWith("SyncDat.") && c instanceof AEBaseContainer) {
             ((AEBaseContainer) c).stringSync(Integer.parseInt(this.Name.substring(8)), this.Value);
         } else if (this.Name.equals("CraftingStatus") && this.Value.equals("Clear")) {
             final GuiScreen gs = Minecraft.getMinecraft().currentScreen;


### PR DESCRIPTION
I got kicked from a server running current daily when hitting R to view a recipe for an item from the AE2 auto crafting confirm screen.

```
[16:31:45] [Client thread/ERROR] [FML]: NetworkEventFiringHandler exception
java.lang.ClassCastException: class codechicken.nei.recipe.ContainerRecipe cannot be cast to class appeng.container.AEBaseContainer (codechicken.nei.recipe.ContainerRecipe and appeng.container.AEBaseContainer are in unnamed module of loader 'Launch' @5fd4f8f5)
	at Launch//appeng.core.sync.packets.PacketValueConfig.clientPacketData(PacketValueConfig.java:211) ~[PacketValueConfig.class:?]
	at Launch//appeng.core.sync.network.AppEngClientPacketHandler.onPacketData(AppEngClientPacketHandler.java:35) ~[AppEngClientPacketHandler.class:?]
	at Launch//appeng.core.sync.network.NetworkHandler.clientPacket(NetworkHandler.java:85) ~[NetworkHandler.class:?]
	at cpw.mods.fml.common.eventhandler.ASMEventHandler_2111_NetworkHandler_clientPacket_ClientCustomPacketEvent.invoke(.dynamic) ~[?:?]
	at Launch//cpw.mods.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:54) ~[ASMEventHandler.class:?]
	at Launch//cpw.mods.fml.common.eventhandler.EventBus.post(EventBus.java:140) ~[EventBus.class:?]
	at Launch//cpw.mods.fml.common.network.FMLEventChannel.fireRead(FMLEventChannel.java:103) ~[FMLEventChannel.class:?]
	at Launch//cpw.mods.fml.common.network.NetworkEventFiringHandler.channelRead0(NetworkEventFiringHandler.java:30) ~[NetworkEventFiringHandler.class:?]
	at Launch//cpw.mods.fml.common.network.NetworkEventFiringHandler.channelRead0(NetworkEventFiringHandler.java:18) ~[NetworkEventFiringHandler.class:?]
	at Launch//io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:98) ~[netty-all-4.0.10.Final.jar:?]
	at Launch//io.netty.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:337) [netty-all-4.0.10.Final.jar:?]
	at Launch//io.netty.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:323) [netty-all-4.0.10.Final.jar:?]
	at Launch//io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:785) [netty-all-4.0.10.Final.jar:?]
	at Launch//io.netty.channel.embedded.EmbeddedChannel.writeInbound(EmbeddedChannel.java:169) [netty-all-4.0.10.Final.jar:?]
	at Launch//cpw.mods.fml.common.network.internal.FMLProxyPacket.func_148833_a(FMLProxyPacket.java:77) [FMLProxyPacket.class:?]
	at Launch//net.minecraft.network.NetworkManager.func_74428_b(NetworkManager.java:212) [ej.class:?]
	at Launch//net.minecraft.client.multiplayer.PlayerControllerMP.func_78765_e(PlayerControllerMP.java:273) [bje.class:?]
	at Launch//net.minecraft.client.Minecraft.func_71407_l(Minecraft.java:1602) [bao.class:?]
	at Launch//net.minecraft.client.Minecraft.func_71411_J(Minecraft.java:973) [bao.class:?]
	at Launch//net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:7110) [bao.class:?]
	at Launch//net.minecraft.client.main.Main.main(SourceFile:148) [Main.class:?]
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104) ~[?:?]
	at java.base/java.lang.reflect.Method.invoke(Method.java:565) ~[?:?]
	at System//net.minecraft.launchwrapper.Launch.rfb$realLaunch(Launch.java:250) [Launch.class:?]
	at System//net.minecraft.launchwrapper.Launch.launch(Launch.java:35) [Launch.class:?]
	at System//net.minecraft.launchwrapper.Launch.main(Launch.java:60) [Launch.class:?]
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104) ~[?:?]
	at java.base/java.lang.reflect.Method.invoke(Method.java:565) ~[?:?]
	at com.gtnewhorizons.retrofuturabootstrap.Main.main(Main.java:207) [lwjgl3ify-2.1.14-forgePatches.jar:?]
	at System//org.prismlauncher.launcher.impl.StandardLauncher.launch(StandardLauncher.java:105) [NewLaunch.jar:?]
	at System//org.prismlauncher.EntryPoint.listen(EntryPoint.java:129) [NewLaunch.jar:?]
	at System//org.prismlauncher.EntryPoint.main(EntryPoint.java:70) [NewLaunch.jar:?]
```

Upon checking I found we are not checking the open container with `instanceof` before casting.

I re-joined the server after this exception and immediately hit the NEE `IndexOutOfBounds` exception reported in https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21119 when scheduling an auto craft and crashed so are these potentially related?