### PR TITLE
Show pattern output recipe/usage when pressing R/U on encoded pattern

### DIFF
--- a/src/main/java/appeng/integration/modules/NEI.java
+++ b/src/main/java/appeng/integration/modules/NEI.java
@@ -46,6 +46,7 @@ import appeng.integration.modules.NEIHelpers.NEIAEShapelessRecipeHandler;
 import appeng.integration.modules.NEIHelpers.NEIAETerminalBookmarkContainerHandler;
 import appeng.integration.modules.NEIHelpers.NEICellViewHandler;
 import appeng.integration.modules.NEIHelpers.NEICraftingHandler;
+import appeng.integration.modules.NEIHelpers.NEIEncodedPatternStringifyHandler;
 import appeng.integration.modules.NEIHelpers.NEIFacadeRecipeHandler;
 import appeng.integration.modules.NEIHelpers.NEIGrinderRecipeHandler;
 import appeng.integration.modules.NEIHelpers.NEIGuiHandler;
@@ -66,6 +67,7 @@ import codechicken.nei.guihook.IContainerObjectHandler;
 import codechicken.nei.guihook.IContainerTooltipHandler;
 import codechicken.nei.recipe.Recipe;
 import codechicken.nei.recipe.Recipe.RecipeId;
+import codechicken.nei.recipe.StackInfo;
 
 public class NEI implements INEI, IContainerTooltipHandler, IIntegrationModule, IContainerObjectHandler {
 
@@ -110,6 +112,8 @@ public class NEI implements INEI, IContainerTooltipHandler, IIntegrationModule, 
         this.registerRecipeHandler(new NEIAEShapelessRecipeHandler());
         this.registerRecipeHandler(new NEIInscriberRecipeHandler());
         this.registerRecipeHandler(new NEIWorldCraftingHandler());
+
+        StackInfo.stackStringifyHandlers.add(new NEIEncodedPatternStringifyHandler());
 
         this.registerUsageHandler.invoke(this.apiClass, new NEICellViewHandler());
 

--- a/src/main/java/appeng/integration/modules/NEIHelpers/NEIEncodedPatternStringifyHandler.java
+++ b/src/main/java/appeng/integration/modules/NEIHelpers/NEIEncodedPatternStringifyHandler.java
@@ -1,0 +1,27 @@
+package appeng.integration.modules.NEIHelpers;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+
+import appeng.items.misc.ItemEncodedPattern;
+import codechicken.nei.api.IStackStringifyHandler;
+import codechicken.nei.recipe.stackinfo.DefaultStackStringifyHandler;
+
+public class NEIEncodedPatternStringifyHandler implements IStackStringifyHandler {
+
+    private static final DefaultStackStringifyHandler defaultStackStringifyHandler = new DefaultStackStringifyHandler();
+
+    public NBTTagCompound convertItemStackToNBT(ItemStack stack, boolean saveStackSize) {
+        if (!(stack.getItem() instanceof ItemEncodedPattern pattern)) {
+            return null;
+        }
+
+        stack = pattern.getOutput(stack);
+
+        if (stack == null) {
+            return null;
+        }
+
+        return defaultStackStringifyHandler.convertItemStackToNBT(stack, saveStackSize);
+    }
+}


### PR DESCRIPTION
Make pressing R/U shows the recipe/usage of actual item which will be produced it this encoded pattern (first of it, which got displayed, if there is a more then one).

Should at least partially address https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19318