### PR TITLE
Fix usage >100% in crafting calculation 

### DIFF
--- a/src/main/java/appeng/api/networking/crafting/ICraftingJob.java
+++ b/src/main/java/appeng/api/networking/crafting/ICraftingJob.java
@@ -73,4 +73,10 @@ public interface ICraftingJob {
      */
     default void startCrafting(final MECraftingInventory storage, final ICraftingCPU craftingCPUCluster,
             final BaseActionSource src) {}
+
+    /**
+     * Return the snapshot of the storage when crafting calculation begins, should be read-only, do not modify. Note
+     * that this might be different from the current storage.
+     */
+    public MECraftingInventory getStorageAtBeginning();
 }

--- a/src/main/java/appeng/api/networking/crafting/ICraftingJob.java
+++ b/src/main/java/appeng/api/networking/crafting/ICraftingJob.java
@@ -78,5 +78,7 @@ public interface ICraftingJob {
      * Return the snapshot of the storage when crafting calculation begins, should be read-only, do not modify. Note
      * that this might be different from the current storage.
      */
-    public MECraftingInventory getStorageAtBeginning();
+    default public MECraftingInventory getStorageAtBeginning() {
+        return new MECraftingInventory();
+    }
 }

--- a/src/main/java/appeng/container/implementations/ContainerCraftConfirm.java
+++ b/src/main/java/appeng/container/implementations/ContainerCraftConfirm.java
@@ -183,7 +183,7 @@ public class ContainerCraftConfirm extends AEBaseContainer implements ICraftingC
                         toCraft.setCountRequestableCrafts(plannedItem.getCountRequestableCrafts());
 
                         final IStorageGrid sg = this.getGrid().getCache(IStorageGrid.class);
-                        final IMEInventory<IAEItemStack> items = sg.getItemInventory();
+                        final IMEInventory<IAEItemStack> items = this.result.getStorageAtBeginning();
 
                         IAEItemStack missing = null;
                         if (missingUpdate != null && this.result.isSimulation()) {

--- a/src/main/java/appeng/crafting/CraftingJob.java
+++ b/src/main/java/appeng/crafting/CraftingJob.java
@@ -341,4 +341,6 @@ public class CraftingJob implements ICraftingJob, Runnable {
         private final long perOp = 0;
         private final long times = 0;
     }
+	
+	public MECraftingInventory getStorageAtBeginning(){return original;}
 }

--- a/src/main/java/appeng/crafting/CraftingJob.java
+++ b/src/main/java/appeng/crafting/CraftingJob.java
@@ -341,6 +341,8 @@ public class CraftingJob implements ICraftingJob, Runnable {
         private final long perOp = 0;
         private final long times = 0;
     }
-	
-	public MECraftingInventory getStorageAtBeginning(){return original;}
+
+    public MECraftingInventory getStorageAtBeginning() {
+        return original;
+    }
 }

--- a/src/main/java/appeng/crafting/v2/CraftingJobV2.java
+++ b/src/main/java/appeng/crafting/v2/CraftingJobV2.java
@@ -299,4 +299,8 @@ public class CraftingJobV2 implements ICraftingJob, Future<ICraftingJob>, ITreeS
             default -> throw new IllegalStateException();
         };
     }
+
+    public MECraftingInventory getStorageAtBeginning() {
+        return getContext().availableCache;
+    }
 }


### PR DESCRIPTION
Might fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18988

Used percentage and missing items are calculated depending on current storage.
However the result(craftingjobV2) is calculated depending on storage when calculation starts, for example:

1.you have 3 iron ingots in storage.
2.Order 2 iron plates.
3.when calculating, remove 2 iron ingot, there's only one
4.calculation done, result says: consume 2 iron ingots,  current storage is 1 iron ingot, so used percentage is 200%

This PR let ContainerCraftConfirm use the starting storage(instead of current storage) to calculate the percentage, which makes more sense. (Will display 66.66% instaed of 200%)

Note: this will not fix the problem of being unable to craft after calculation is done, you will still get 'cannot craft, missing item: iron ingot x1' warning in chat if you press the button.