### PR TITLE
Meteorite Generation Updates

### DIFF
--- a/src/main/java/appeng/worldgen/MeteoriteWorldGen.java
+++ b/src/main/java/appeng/worldgen/MeteoriteWorldGen.java
@@ -32,6 +32,12 @@ public final class MeteoriteWorldGen implements IWorldGenerator {
                                                    // spawnSurfaceMeteorite. These variables should be reassigned unless
                                                    // something goes wrong.
 
+    //TODO In this PR you need to...
+    //TODO Make meteorite spawns less gridlike (remove the guarantee that you find a meteor 700 blocks away from the previous one)
+    //TODO Make underground meteorites an actually consistent and proper config option (set to 0 and you are guaranteed only surface meteorites, regardless of ANYTHING)
+    //TODO Add the ability to configure the block that makes up the lava moat, check with liquid lead, water, etc. (At the same time make sure meteorites that spawn in water (if they can) have automatically flooded moats)
+    //TODO Make it all configurable and per-dimension configs
+    //TODO I guess also take a look and see if you can add any more options to the loot table
     @Override
     public void generate(final Random rng, final int chunkX, final int chunkZ, final World world,
             final IChunkProvider chunkGenerator, final IChunkProvider chunkProvider) {


### PR DESCRIPTION
# This PR covers everything that was discussed about meteorite generation here: 
### [#github-discussion](https://discord.com/channels/181078474394566657/401118216228831252/1417893256045269082) and [#beta-testing](https://discord.com/channels/181078474394566657/522098956491030558/1417650563117748264)

# What this does in general
- Makes meteorite spawns less gridlike (removes the guarantee that you find a meteor 700 blocks away from the previous one)
- Makes underground meteorites an actually consistent and proper config option (set to 0 and you are guaranteed only surface meteorites, regardless of ANYTHING)
- Adds the ability to configure the block that makes up the lava moat (with configurable liquid depth (for balancing))
- Makes meteorites that spawn in water have automatically flooded moats to the correct y-level (and lets meteorites spawn in water as long as there's enough land)
- Make the spawn location seed based (if it's not already)
- All configurable and per-dimension configs

