### PR TITLE
Fix button disappearing when pin state is changed

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
@@ -17,6 +17,8 @@ import net.minecraft.client.gui.GuiButton;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.client.event.GuiScreenEvent.InitGuiEvent;
+import net.minecraftforge.common.MinecraftForge;
 
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
@@ -248,8 +250,11 @@ public class GuiMEMonitorable extends AEBaseMEGui
 
     private void reinitalize() {
         memoryText = this.searchField.getText();
-        this.buttonList.clear();
-        this.initGui();
+        if (!MinecraftForge.EVENT_BUS.post(new InitGuiEvent.Pre(this, this.buttonList))) {
+            this.buttonList.clear();
+            this.initGui();
+        }
+        MinecraftForge.EVENT_BUS.post(new InitGuiEvent.Post(this, this.buttonList));
     }
 
     @Override

--- a/src/main/java/appeng/client/gui/implementations/GuiPatternTerm.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiPatternTerm.java
@@ -186,10 +186,22 @@ public class GuiPatternTerm extends GuiMEMonitorable {
                 ActionItems.DOUBLE);
         this.doubleBtn.setHalfSize(true);
         this.buttonList.add(this.doubleBtn);
+        updateButtonVisibility();
     }
 
     @Override
     public void drawFG(final int offsetX, final int offsetY, final int mouseX, final int mouseY) {
+        updateButtonVisibility();
+
+        super.drawFG(offsetX, offsetY, mouseX, mouseY);
+        this.fontRendererObj.drawString(
+                GuiText.PatternTerminal.getLocal(),
+                8,
+                this.ySize - 96 + 2 - this.getReservedSpace(),
+                GuiColors.PatternTerminalTitle.getColor());
+    }
+
+    private void updateButtonVisibility() {
         if (!this.container.isCraftingMode()) {
             this.tabCraftButton.visible = false;
             this.tabProcessButton.visible = true;
@@ -210,13 +222,6 @@ public class GuiPatternTerm extends GuiMEMonitorable {
 
         this.beSubstitutionsEnabledBtn.visible = this.container.beSubstitute;
         this.beSubstitutionsDisabledBtn.visible = !this.container.beSubstitute;
-
-        super.drawFG(offsetX, offsetY, mouseX, mouseY);
-        this.fontRendererObj.drawString(
-                GuiText.PatternTerminal.getLocal(),
-                8,
-                this.ySize - 96 + 2 - this.getReservedSpace(),
-                GuiColors.PatternTerminalTitle.getColor());
     }
 
     @Override

--- a/src/main/java/appeng/client/gui/implementations/GuiPatternTerm.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiPatternTerm.java
@@ -186,12 +186,12 @@ public class GuiPatternTerm extends GuiMEMonitorable {
                 ActionItems.DOUBLE);
         this.doubleBtn.setHalfSize(true);
         this.buttonList.add(this.doubleBtn);
-        updateButtonVisibility();
+        this.updateButtonVisibility();
     }
 
     @Override
     public void drawFG(final int offsetX, final int offsetY, final int mouseX, final int mouseY) {
-        updateButtonVisibility();
+        this.updateButtonVisibility();
 
         super.drawFG(offsetX, offsetY, mouseX, mouseY);
         this.fontRendererObj.drawString(

--- a/src/main/java/appeng/client/gui/widgets/GuiImgButton.java
+++ b/src/main/java/appeng/client/gui/widgets/GuiImgButton.java
@@ -67,7 +67,6 @@ public class GuiImgButton extends GuiButton implements ITooltip {
     private static final Pattern PATTERN_NEW_LINE = Pattern.compile("\\n", Pattern.LITERAL);
     private static Map<EnumPair, ButtonAppearance> appearances;
     private final Enum buttonSetting;
-    private boolean halfSize = false;
     private String fillVar;
     private Enum currentValue;
 
@@ -911,13 +910,9 @@ public class GuiImgButton extends GuiButton implements ITooltip {
     @Override
     public void drawButton(final Minecraft mc, final int mouseX, final int mouseY) {
         if (this.visible) {
-            if (this.halfSize) {
-                this.width = 8;
-                this.height = 8;
-            }
             this.field_146123_n = mouseX >= this.xPosition && mouseY >= this.yPosition
-                    && mouseX < this.xPosition + this.width
-                    && mouseY < this.yPosition + this.height;
+                    && mouseX < this.xPosition + this.getWidth()
+                    && mouseY < this.yPosition + this.getHeight();
             if (this.enabled) {
                 GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
             } else {
@@ -931,10 +926,10 @@ public class GuiImgButton extends GuiButton implements ITooltip {
             OpenGlHelper.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, 1, 0);
             GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
             GL11.glTranslatef(this.xPosition, this.yPosition, 0.0F);
-            if (this.halfSize) GL11.glScalef(0.5f, 0.5f, 0.5f);
+            if (this.isHalfSize()) GL11.glScalef(0.5f, 0.5f, 0.5f);
             this.drawTexturedModalRect(0, 0, 256 - 16, 256 - 16, 16, 16);
             this.drawTexturedModalRect(0, 0, uv_x * 16, uv_y * 16, 16, 16);
-            if (this.halfSize) GL11.glScalef(2f, 2f, 2f);
+            if (this.isHalfSize()) GL11.glScalef(2f, 2f, 2f);
             GL11.glTranslatef(-this.xPosition, -this.yPosition, 0.0F);
             this.mouseDragged(mc, mouseX, mouseY);
         }
@@ -1014,12 +1009,12 @@ public class GuiImgButton extends GuiButton implements ITooltip {
 
     @Override
     public int getWidth() {
-        return this.halfSize ? 8 : 16;
+        return this.width;
     }
 
     @Override
     public int getHeight() {
-        return this.halfSize ? 8 : 16;
+        return this.height;
     }
 
     @Override
@@ -1038,11 +1033,12 @@ public class GuiImgButton extends GuiButton implements ITooltip {
     }
 
     public boolean isHalfSize() {
-        return this.halfSize;
+        return this.width == 8;
     }
 
     public void setHalfSize(final boolean halfSize) {
-        this.halfSize = halfSize;
+        this.width = halfSize ? 8 : 16;
+        this.height = halfSize ? 8 : 16;
     }
 
     public String getFillVar() {


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21281

When the terminal height or pin state is changed, the button is cleared and the `init` method is re-called, but the `InitGuiEvent` is not called, so the button disappears.

The pre event is not actually necessary, but I added it based on the vanilla forge code for consistency.