### PR TITLE
Added Color to the ME Drives to reflect ME Chests.

### DIFF
--- a/src/main/java/appeng/client/render/blocks/RenderDrive.java
+++ b/src/main/java/appeng/client/render/blocks/RenderDrive.java
@@ -20,6 +20,7 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.client.IItemRenderer.ItemRenderType;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import appeng.api.util.AEColor;
 import appeng.block.storage.BlockDrive;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.texture.ExtraBlockTextures;
@@ -121,7 +122,6 @@ public class RenderDrive extends BaseBlockRender<BlockDrive, TileDrive> {
                 }
             }
         }
-
         for (int yy = 0; yy < 5; yy++) {
             for (int xx = 0; xx < 2; xx++) {
                 final int stat = sp.getCellStatus(yy * 2 + (1 - xx));
@@ -151,7 +151,9 @@ public class RenderDrive extends BaseBlockRender<BlockDrive, TileDrive> {
                 double v4 = ico.getInterpolatedV(((spin) % 4 < 2) ? m : mx);
 
                 tess.setBrightness(b);
-                tess.setColorOpaque_I(0xffffff);
+                // uses base color for base ae2 drive color, otherwise uses the drives color
+                AEColor color = sp.getColor();
+                tess.setColorOpaque_I(color != AEColor.Transparent ? color.mediumVariant : 0xffffff);
                 switch (forward.offsetX + forward.offsetY * 2 + forward.offsetZ * 3) {
                     case 1 -> {
                         tess.addVertexWithUV(

--- a/src/main/java/appeng/client/render/blocks/RenderMEChest.java
+++ b/src/main/java/appeng/client/render/blocks/RenderMEChest.java
@@ -92,7 +92,8 @@ public class RenderMEChest extends BaseBlockRender<BlockChest, TileChest> {
         int b = world.getLightBrightnessForSkyBlocks(x + forward.offsetX, y + forward.offsetY, z + forward.offsetZ, 0);
         final Tessellator tess = Tessellator.instance;
         tess.setBrightness(b);
-        tess.setColorOpaque_I(0xffffff);
+        AEColor color = sp.getColor();
+        tess.setColorOpaque_I(color != AEColor.Transparent ? color.mediumVariant : 0xffffff);
 
         final FlippableIcon flippableIcon = new FlippableIcon(
                 new OffsetIcon(ExtraBlockTextures.MEStorageCellTextures.getIcon(), offsetU, offsetV));


### PR DESCRIPTION

addresses this: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21599#issuecomment-3346104877

Adds color to the ME drive's proxy. works more or less identical to the ME chest. I also made the render reflect the current color (chest is the same), as shown in the images attached.
<img width="2560" height="1361" alt="2025-09-29_03 44 40" src="https://github.com/user-attachments/assets/e0c340dc-0660-4b34-9d52-adab5bfb7788" />
<img width="2560" height="1361" alt="2025-09-29_03 44 37" src="https://github.com/user-attachments/assets/12220960-43ef-4c6a-aa26-79c4ff8bbc7a" />
