### PR TITLE
fix empty storage list returned when ME interface is configured with something

### DIFF
--- a/src/main/java/appeng/helpers/DualityInterface.java
+++ b/src/main/java/appeng/helpers/DualityInterface.java
@@ -25,7 +25,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
 
-import appeng.api.storage.data.IItemList;
 import net.minecraft.block.Block;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.ISidedInventory;
@@ -82,6 +81,7 @@ import appeng.api.storage.StorageChannel;
 import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IAEStack;
+import appeng.api.storage.data.IItemList;
 import appeng.api.util.AECableType;
 import appeng.api.util.DimensionalCoord;
 import appeng.api.util.IConfigManager;
@@ -1672,6 +1672,7 @@ public class DualityInterface implements IGridTickable, IStorageMonitorable, IIn
     }
 
     private class InterfaceInventory extends MEMonitorIInventory {
+
         public InterfaceInventory() {
             super(new AdaptorIInventory(storage));
             this.setActionSource(new MachineSource(iHost));


### PR DESCRIPTION
the storage list is typically only populated or updated when the MEMonitorIInventory is ticked, but this does not happen for this particular subclass since it's just a transient wrapper around an internal inventory. this fix attempt to address the issue by regenerating the item list every time it is accessed.

so far within the org this really only affects LP's provider pipe/module, but it might have a bigger impact if we include other logistics mods