### PR TITLE
Fix mergeJob return wrong crafting link

### DIFF
--- a/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
+++ b/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
@@ -1035,7 +1035,7 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
         if (this.myLastLink != null && this.isBusy()
                 && this.finalOutput.isSameType((Object) job.getOutput())
                 && this.availableStorage >= this.usedStorage + job.getByteTotal()) {
-            return mergeJob(g, job, src);
+            return mergeJob(g, job, src, requestingMachine);
         }
 
         if (!this.tasks.isEmpty() || !this.waitingFor.isEmpty()) {
@@ -1169,7 +1169,8 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
         }
     }
 
-    public ICraftingLink mergeJob(final IGrid g, final ICraftingJob job, final BaseActionSource src) {
+    public ICraftingLink mergeJob(final IGrid g, final ICraftingJob job, final BaseActionSource src,
+            final ICraftingRequester requestingMachine) {
         final IStorageGrid sg = g.getCache(IStorageGrid.class);
         final MECraftingInventory ci = new MECraftingInventory(sg, true, false, false);
 
@@ -1197,7 +1198,13 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
                 this.prepareStepCount();
                 this.markDirty();
                 this.updateCPU();
-                return this.myLastLink;
+
+                final ICraftingLink whatLink = new CraftingLink(
+                        this.generateLinkData(this.myLastLink.getCraftingID(), false, true),
+                        requestingMachine);
+
+                this.submitLink(whatLink);
+                return whatLink;
             } else {
                 inventory = backupInventory;
                 waitingForMissing = backupWaitingForMissing;


### PR DESCRIPTION
Fix buses/interfaces with Crafting Card disapper after server reboot


**Explainations:**

Crafting Links (appeng.crafting.CraftingLink) has two types:
type1: For CPU internal use, construced by CraftingLink(NBTTagCompound, ICraftingCPU) 
type2: For requester to serailze/deserailze the crafting context, construced by CraftingLink(NBTTagCompound, ICraftingRequester) 

CraftingCPUCluster.submitJob should return a type2 CraftingLink, and in most cases it's a type2 CraftingLink.
But if a job merging happens, it accidently returns CraftingCPUCluster.myLastLink, which is a type1 CraftingLink!
That is to say, if an autocrafter submits a job, and the job is merged to a running CPU, autocrafter will get a  type1 CraftingLink.
When the autocrafter saves and loads (expects a type2, which is not) the CraftingLink, it crashes and removes the block/cable.


**To reproduce:**
1.Two export buses, with same config: stone marked, a Crafting Card installed.
2.Wait for bus to submit jobs.
3.Save & load the game
4.One export bus disappers itself.
5.Get err in log:
<details>
<summary>Expand logs</summary>
<p>

```
[16:31:27] [Server thread/ERROR] [FML/]: A TileEntity BlockCableBus(appeng.parts.layers.LayerIEnergyConnected_TileCableBus) has thrown an exception during loading, its state cannot be restored. Report this to the mod author
java.lang.IllegalStateException: java.lang.reflect.InvocationTargetException
	at appeng.tile.events.AETileEventHandler.readFromNBT(AETileEventHandler.java:54) ~[AETileEventHandler.class:?]
	at appeng.tile.AEBaseTile.func_145839_a(AEBaseTile.java:121) ~[AEBaseTile.class:?]
	at net.minecraft.tileentity.TileEntity.func_145827_c(TileEntity.java:116) [aor.class:?]
	at net.minecraft.world.chunk.storage.AnvilChunkLoader.loadEntities(AnvilChunkLoader.java:496) [aqk.class:?]
	at net.minecraftforge.common.chunkio.ChunkIOProvider.callStage2(ChunkIOProvider.java:41) [ChunkIOProvider.class:?]
	at net.minecraftforge.common.chunkio.ChunkIOProvider.callStage2(ChunkIOProvider.java:12) [ChunkIOProvider.class:?]
	at net.minecraftforge.common.util.AsynchronousExecutor.skipQueue(AsynchronousExecutor.java:344) [AsynchronousExecutor.class:?]
	at net.minecraftforge.common.util.AsynchronousExecutor.getSkipQueue(AsynchronousExecutor.java:302) [AsynchronousExecutor.class:?]
	at net.minecraftforge.common.chunkio.ChunkIOExecutor.syncChunkLoad(ChunkIOExecutor.java:12) [ChunkIOExecutor.class:?]
	at net.minecraft.world.gen.ChunkProviderServer.loadChunk(ChunkProviderServer.java:126) [ms.class:?]
	at net.minecraft.world.gen.ChunkProviderServer.func_73158_c(ChunkProviderServer.java:101) [ms.class:?]
	at net.minecraft.server.MinecraftServer.func_71222_d(MinecraftServer.java:265) [MinecraftServer.class:?]
	at net.minecraft.server.integrated.IntegratedServer.func_71247_a(IntegratedServer.java:78) [bsx.class:?]
	at net.minecraft.server.integrated.IntegratedServer.func_71197_b(IntegratedServer.java:92) [bsx.class:?]
	at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:387) [MinecraftServer.class:?]
	at net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:685) [?:?]
Caused by: java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_51]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_51]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_51]
	at java.lang.reflect.Method.invoke(Method.java:497) ~[?:1.8.0_51]
	at appeng.tile.events.AETileEventHandler.readFromNBT(AETileEventHandler.java:52) ~[AETileEventHandler.class:?]
	... 15 more
Caused by: java.lang.IllegalStateException: Invalid Crafting Link for Object
	at appeng.crafting.CraftingLink.<init>(CraftingLink.java:38) ~[CraftingLink.class:?]
	at appeng.core.api.ApiStorage.loadCraftingLink(ApiStorage.java:41) ~[ApiStorage.class:?]
	at appeng.helpers.MultiCraftingTracker.readFromNBT(MultiCraftingTracker.java:49) ~[MultiCraftingTracker.class:?]
	at appeng.parts.automation.PartExportBus.readFromNBT(PartExportBus.java:80) ~[PartExportBus.class:?]
	at appeng.parts.CableBusContainer.readFromNBT(CableBusContainer.java:878) ~[CableBusContainer.class:?]
	at appeng.tile.networking.TileCableBus.readFromNBT_TileCableBus(TileCableBus.java:61) ~[TileCableBus.class:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_51]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_51]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_51]
	at java.lang.reflect.Method.invoke(Method.java:497) ~[?:1.8.0_51]
	at appeng.tile.events.AETileEventHandler.readFromNBT(AETileEventHandler.java:52) ~[AETileEventHandler.class:?]
	... 15 more
```

</p>
</details>



**What this PR does**
Constructs a new type2 CraftingLink when a merging happes, rather than CraftingCPUCluster.myLastLink.