### PR TITLE
Add en_US localization for the Terminal bauble type

### DIFF
--- a/src/main/resources/assets/appliedenergistics2/lang/en_US.lang
+++ b/src/main/resources/assets/appliedenergistics2/lang/en_US.lang
@@ -678,6 +678,8 @@ waila.appliedenergistics2.ConnectedTo=Connected to
 waila.appliedenergistics2.Disconnected=Disconnected
 waila.appliedenergistics2.Singularity=Singularity
 
+# Baubles Extended
+slot.Terminal=§aTerminal§7
 
 # Items
 item.appliedenergistics2.ItemBasicStorageCell.1k.name=§61k§r ME Storage Cell


### PR DESCRIPTION
Turns out the Terminal bauble type didn't have any localization, because the bauble tooltip is not used. Now that https://github.com/GTNewHorizons/Baubles-Expanded/pull/22 is merged, the localization is used somewhere else

Before:
<img width="367" height="487" alt="image" src="https://github.com/user-attachments/assets/b60f2349-59e5-493b-9bea-a0d692c6b516" />

After:
<img width="367" height="487" alt="image" src="https://github.com/user-attachments/assets/13f1d63c-3abf-484b-b65e-b01731618a70" />

The `§a` and `§7` are there so that this matches the localization of the other bauble types