### PR TITLE
add an interface to allow for block containers to disable facades based on metadata.

### DIFF
--- a/src/main/java/appeng/api/parts/IFacadeControl.java
+++ b/src/main/java/appeng/api/parts/IFacadeControl.java
@@ -1,0 +1,13 @@
+package appeng.api.parts;
+
+/**
+ * Allows for fine-tuning of facade creation for block containers based on meta. Default true but would return false in
+ * implementation. false = no facade created.
+ */
+public interface IFacadeControl {
+
+    default boolean createFacadeForBlock(int meta) {
+        return true;
+    }
+
+}

--- a/src/main/java/appeng/core/FacadeConfig.java
+++ b/src/main/java/appeng/core/FacadeConfig.java
@@ -18,6 +18,7 @@ import java.util.regex.Pattern;
 import net.minecraft.block.Block;
 import net.minecraftforge.common.config.Configuration;
 
+import appeng.api.parts.IFacadeControl;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.common.registry.GameRegistry.UniqueIdentifier;
 
@@ -33,6 +34,10 @@ public class FacadeConfig extends Configuration {
 
     public boolean checkEnabled(final Block id, final int metadata, final boolean automatic) {
         if (id == null) {
+            return false;
+        }
+
+        if (id instanceof IFacadeControl facadeControl && !facadeControl.createFacadeForBlock(metadata)) {
             return false;
         }
 


### PR DESCRIPTION
this is for use in sheetmetal https://github.com/GTNewHorizons/GT5-Unofficial/pull/5387, 
which uses a custom renderer but doesn't have any of the other properties that would otherwise disable a facade for being created

tested in sheetmetal branch and it does work

before
<img width="2560" height="1438" alt="image" src="https://github.com/user-attachments/assets/d1e9b367-0200-465b-afc7-e9c7d3c7e559" />

after
<img width="2560" height="1408" alt="image" src="https://github.com/user-attachments/assets/88121989-7b6b-4895-b484-2a2ec474cc38" />
