### PR TITLE
Fixed level emitter watcher's doesn't track fluids

### DIFF
--- a/src/main/java/appeng/parts/automation/PartLevelEmitter.java
+++ b/src/main/java/appeng/parts/automation/PartLevelEmitter.java
@@ -249,7 +249,6 @@ public class PartLevelEmitter extends PartUpgradeable implements ILevelEmitter {
             if (this.getInstalledUpgrades(Upgrades.FUZZY) > 0 || myStack == null) {
                 this.getProxy().getStorage().getItemInventory().addListener(this, this.getProxy().getGrid());
                 this.getProxy().getStorage().getFluidInventory().addListener(this, this.getProxy().getGrid());
-
             } else {
                 this.getProxy().getStorage().getItemInventory().removeListener(this);
                 this.getProxy().getStorage().getFluidInventory().removeListener(this);


### PR DESCRIPTION
- Fixed fluid listener was created never
- Fixed emitter track items only with empty filter

Fixed https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/22991