### PR TITLE
Fix shift-clicking a slot unnecessarily placing items in phantom slot

### DIFF
--- a/src/main/java/appeng/client/gui/AEBaseGui.java
+++ b/src/main/java/appeng/client/gui/AEBaseGui.java
@@ -604,7 +604,7 @@ public abstract class AEBaseGui extends GuiContainer implements IGuiTooltipHandl
             if (this.inventorySlots instanceof AEBaseContainer baseContainer) {
                 if (slot instanceof AppEngSlot appEngSlot && baseContainer.isValidSrcSlotForTransfer(appEngSlot)) {
                     ItemStack stackInSlot = appEngSlot.getStack();
-                    final List<Slot> selectedSlots = baseContainer
+                    final List<AppEngSlot> selectedSlots = baseContainer
                             .getValidDestinationSlots(appEngSlot.isPlayerSide(), stackInSlot);
 
                     if (selectedSlots.isEmpty() && appEngSlot.isPlayerSide()

--- a/src/main/java/appeng/container/AEBaseContainer.java
+++ b/src/main/java/appeng/container/AEBaseContainer.java
@@ -45,6 +45,7 @@ import appeng.api.config.Actionable;
 import appeng.api.config.PowerMultiplier;
 import appeng.api.config.SecurityPermissions;
 import appeng.api.implementations.guiobjects.IGuiItemObject;
+import appeng.api.implementations.guiobjects.INetworkTool;
 import appeng.api.implementations.guiobjects.IPortableCell;
 import appeng.api.networking.IGrid;
 import appeng.api.networking.IGridHost;
@@ -455,8 +456,8 @@ public abstract class AEBaseContainer extends Container {
      * @return valid destination slot list
      */
     @NotNull
-    public List<Slot> getValidDestinationSlots(boolean isPlayerSideSlot, @NotNull ItemStack stackInSlot) {
-        final List<Slot> selectedSlots = new ArrayList<>();
+    public List<AppEngSlot> getValidDestinationSlots(boolean isPlayerSideSlot, @NotNull ItemStack stackInSlot) {
+        final List<AppEngSlot> selectedSlots = new ArrayList<>();
 
         // Gather a list of valid destinations.
         for (final Object inventorySlot : this.inventorySlots) {
@@ -512,7 +513,7 @@ public abstract class AEBaseContainer extends Container {
         }
 
         ItemStack stackInSlot = clickSlot.getStack();
-        final List<Slot> selectedSlots = this.getValidDestinationSlots(clickSlot.isPlayerSide(), stackInSlot);
+        final List<AppEngSlot> selectedSlots = this.getValidDestinationSlots(clickSlot.isPlayerSide(), stackInSlot);
 
         // Handle Fake Slot Shift clicking.
         if (selectedSlots.isEmpty() && clickSlot.isPlayerSide()) {
@@ -562,15 +563,22 @@ public abstract class AEBaseContainer extends Container {
         }
 
         // any match..
-        for (final Slot d : selectedSlots) {
+        for (final AppEngSlot d : selectedSlots) {
             // For shift click upgrade card logic
             if (ItemMultiMaterial.instance.getType(stackInSlot) != null) {
                 // Check now container is upgradeable or it's subclass
                 if (ContainerUpgradeable.class.isAssignableFrom(this.getClass())) {
                     // Check source or target
-                    if (!((d.inventory instanceof UpgradeInventory) || (clickSlot.inventory instanceof UpgradeInventory)
-                            || (d.inventory instanceof ContainerCellWorkbench.Upgrades))) {
-                        continue;
+                    if (clickSlot.inventory instanceof UpgradeInventory
+                            || clickSlot.inventory instanceof ContainerCellWorkbench.Upgrades) {
+                        if (!d.isPlayerSide() && !(clickSlot.inventory instanceof INetworkTool)) {
+                            continue;
+                        }
+                    } else {
+                        if (!(d.inventory instanceof UpgradeInventory)
+                                && !(d.inventory instanceof ContainerCellWorkbench.Upgrades)) {
+                            continue;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/23265 

Also fixes an issue introduced in https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/663 that cards in upgrade slots could not be shift-clicked to move them to player inventory