### PR TITLE
Fix config copy for IO Bus, Storage Bus, and Level Emitter via memory card

### DIFF
--- a/src/main/java/appeng/api/storage/StorageName.java
+++ b/src/main/java/appeng/api/storage/StorageName.java
@@ -5,7 +5,8 @@ public enum StorageName {
     NONE(""),
     CRAFTING_INPUT("crafting"),
     CRAFTING_OUTPUT("output"),
-    CRAFTING_PATTERN("pattern");
+    CRAFTING_PATTERN("pattern"),
+    CONFIG("config");
 
     private final String name;
 

--- a/src/main/java/appeng/client/gui/implementations/GuiBusIO.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiBusIO.java
@@ -38,7 +38,7 @@ public class GuiBusIO extends GuiUpgradeable {
     }
 
     private void initVirtualSlots() {
-        final IAEStackInventory inputInv = this.bus.getAEInventoryByName(StorageName.NONE);
+        final IAEStackInventory inputInv = this.bus.getAEInventoryByName(StorageName.CONFIG);
         for (int y = 0; y < 3; y++) {
             for (int x = 0; x < 3; x++) {
                 VirtualMEPhantomSlot slot = new VirtualMEPhantomSlot(

--- a/src/main/java/appeng/client/gui/implementations/GuiLevelEmitter.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiLevelEmitter.java
@@ -81,7 +81,7 @@ public class GuiLevelEmitter extends GuiUpgradeable {
         this.config = new VirtualMEPhantomSlot(
                 17,
                 42,
-                ((ContainerLevelEmitter) inventorySlots).getLvlEmitter().getAEInventoryByName(StorageName.NONE),
+                ((ContainerLevelEmitter) inventorySlots).getLvlEmitter().getAEInventoryByName(StorageName.CONFIG),
                 0);
         this.registerVirtualSlots(this.config);
     }

--- a/src/main/java/appeng/container/implementations/ContainerBusIO.java
+++ b/src/main/java/appeng/container/implementations/ContainerBusIO.java
@@ -24,12 +24,15 @@ public class ContainerBusIO extends ContainerUpgradeable implements IVirtualSlot
     @Override
     public void detectAndSendChanges() {
         super.detectAndSendChanges();
-        this.updateVirtualSlots(StorageName.NONE, this.bus.getAEInventoryByName(StorageName.NONE), virtualSlotsClient);
+        this.updateVirtualSlots(
+                StorageName.CONFIG,
+                this.bus.getAEInventoryByName(StorageName.CONFIG),
+                virtualSlotsClient);
     }
 
     @Override
     public void receiveSlotStacks(StorageName invName, Int2ObjectMap<IAEStack<?>> slotStacks) {
-        final IAEStackInventory storage = this.bus.getAEInventoryByName(StorageName.NONE);
+        final IAEStackInventory storage = this.bus.getAEInventoryByName(StorageName.CONFIG);
         for (var entry : slotStacks.int2ObjectEntrySet()) {
             storage.putAEStackInSlot(entry.getIntKey(), entry.getValue());
         }

--- a/src/main/java/appeng/container/implementations/ContainerLevelEmitter.java
+++ b/src/main/java/appeng/container/implementations/ContainerLevelEmitter.java
@@ -151,8 +151,8 @@ public class ContainerLevelEmitter extends ContainerUpgradeable implements IVirt
             this.setRedStoneMode(
                     (RedstoneMode) this.getUpgradeable().getConfigManager().getSetting(Settings.REDSTONE_EMITTER));
             this.updateVirtualSlots(
-                    StorageName.NONE,
-                    this.lvlEmitter.getAEInventoryByName(StorageName.NONE),
+                    StorageName.CONFIG,
+                    this.lvlEmitter.getAEInventoryByName(StorageName.CONFIG),
                     this.configClientSlot);
         }
 
@@ -205,14 +205,14 @@ public class ContainerLevelEmitter extends ContainerUpgradeable implements IVirt
     @Override
     public void receiveSlotStacks(StorageName invName, Int2ObjectMap<IAEStack<?>> slotStacks) {
         for (var entry : slotStacks.int2ObjectEntrySet()) {
-            this.lvlEmitter.getAEInventoryByName(StorageName.NONE)
+            this.lvlEmitter.getAEInventoryByName(StorageName.CONFIG)
                     .putAEStackInSlot(entry.getIntKey(), entry.getValue());
         }
 
         if (isServer()) {
             this.updateVirtualSlots(
-                    StorageName.NONE,
-                    this.lvlEmitter.getAEInventoryByName(StorageName.NONE),
+                    StorageName.CONFIG,
+                    this.lvlEmitter.getAEInventoryByName(StorageName.CONFIG),
                     this.configClientSlot);
         }
     }

--- a/src/main/java/appeng/container/implementations/ContainerStorageBus.java
+++ b/src/main/java/appeng/container/implementations/ContainerStorageBus.java
@@ -146,8 +146,8 @@ public class ContainerStorageBus extends ContainerUpgradeable implements IVirtua
             this.setExtractionMode(
                     (ExtractionMode) this.getUpgradeable().getConfigManager().getSetting(Settings.EXTRACTION_MODE));
 
-            final IAEStackInventory config = this.storageBus.getAEInventoryByName(StorageName.NONE);
-            this.updateVirtualSlots(StorageName.NONE, config, this.configClientSlot);
+            final IAEStackInventory config = this.storageBus.getAEInventoryByName(StorageName.CONFIG);
+            this.updateVirtualSlots(StorageName.CONFIG, config, this.configClientSlot);
         }
 
         this.standardDetectAndSendChanges();
@@ -163,7 +163,7 @@ public class ContainerStorageBus extends ContainerUpgradeable implements IVirtua
     }
 
     public void clear() {
-        final IAEStackInventory inv = this.storageBus.getAEInventoryByName(StorageName.NONE);
+        final IAEStackInventory inv = this.storageBus.getAEInventoryByName(StorageName.CONFIG);
         for (int x = 0; x < inv.getSizeInventory(); x++) {
             inv.putAEStackInSlot(x, null);
         }
@@ -181,7 +181,7 @@ public class ContainerStorageBus extends ContainerUpgradeable implements IVirtua
             clearPartitionIterator(player);
             return;
         }
-        final IAEStackInventory inv = this.storageBus.getAEInventoryByName(StorageName.NONE);
+        final IAEStackInventory inv = this.storageBus.getAEInventoryByName(StorageName.CONFIG);
 
         final MEInventoryHandler cellInv = this.storageBus.getInternalHandler();
 
@@ -290,13 +290,13 @@ public class ContainerStorageBus extends ContainerUpgradeable implements IVirtua
 
     @Override
     public void receiveSlotStacks(StorageName invName, Int2ObjectMap<IAEStack<?>> slotStacks) {
-        final IAEStackInventory config = this.storageBus.getAEInventoryByName(StorageName.NONE);
+        final IAEStackInventory config = this.storageBus.getAEInventoryByName(StorageName.CONFIG);
         for (var entry : slotStacks.int2ObjectEntrySet()) {
             config.putAEStackInSlot(entry.getIntKey(), entry.getValue());
         }
 
         if (isServer()) {
-            this.updateVirtualSlots(StorageName.NONE, config, this.configClientSlot);
+            this.updateVirtualSlots(StorageName.CONFIG, config, this.configClientSlot);
         }
     }
 
@@ -305,6 +305,6 @@ public class ContainerStorageBus extends ContainerUpgradeable implements IVirtua
     }
 
     public IAEStackInventory getConfig() {
-        return this.storageBus.getAEInventoryByName(StorageName.NONE);
+        return this.storageBus.getAEInventoryByName(StorageName.CONFIG);
     }
 }

--- a/src/main/java/appeng/parts/automation/PartBaseExportBus.java
+++ b/src/main/java/appeng/parts/automation/PartBaseExportBus.java
@@ -95,7 +95,7 @@ public abstract class PartBaseExportBus<StackType extends IAEStack<StackType>> e
                     for (x = 0; x < this.availableSlots() && this.itemToSend > 0; x++) {
                         final int slotToExport = this.getStartingSlot(schedulingMode, x);
 
-                        final StackType aes = (StackType) this.getAEInventoryByName(StorageName.NONE)
+                        final StackType aes = (StackType) this.getAEInventoryByName(StorageName.CONFIG)
                                 .getAEStackInSlot(slotToExport);
 
                         if (aes == null || this.itemToSend <= 0 || this.craftOnly()) {

--- a/src/main/java/appeng/parts/automation/PartBaseImportBus.java
+++ b/src/main/java/appeng/parts/automation/PartBaseImportBus.java
@@ -131,7 +131,7 @@ public abstract class PartBaseImportBus<StackType extends IAEStack<StackType>> e
                 boolean configured = false;
                 if (this.getInstalledUpgrades(Upgrades.ORE_FILTER) == 0) {
                     for (int x = 0; x < this.availableSlots(); x++) {
-                        final StackType ais = (StackType) this.getAEInventoryByName(StorageName.NONE)
+                        final StackType ais = (StackType) this.getAEInventoryByName(StorageName.CONFIG)
                                 .getAEStackInSlot(x);
                         if (ais != null && this.itemToSend > 0) {
                             configured = true;

--- a/src/main/java/appeng/parts/automation/PartLevelEmitter.java
+++ b/src/main/java/appeng/parts/automation/PartLevelEmitter.java
@@ -26,6 +26,8 @@ import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import org.jetbrains.annotations.NotNull;
+
 import appeng.api.config.FuzzyMode;
 import appeng.api.config.LevelType;
 import appeng.api.config.RedstoneMode;
@@ -71,6 +73,7 @@ import appeng.helpers.Reflected;
 import appeng.me.GridAccessException;
 import appeng.tile.inventory.IAEStackInventory;
 import appeng.util.Platform;
+import appeng.util.SettingsFrom;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
@@ -732,6 +735,20 @@ public class PartLevelEmitter extends PartUpgradeable implements ILevelEmitter {
     }
 
     @Override
+    protected void uploadSettings(@NotNull SettingsFrom from, @NotNull NBTTagCompound compound) {
+        super.uploadSettings(from, compound);
+        this.reportingValue = compound.getLong("reportingValue");
+        this.configureWatchers();
+    }
+
+    @Override
+    protected NBTTagCompound downloadSettings(SettingsFrom from) {
+        NBTTagCompound nbt = super.downloadSettings(from);
+        nbt.setLong("reportingValue", this.reportingValue);
+        return nbt;
+    }
+
+    @Override
     public boolean pushPattern(final ICraftingPatternDetails patternDetails, final InventoryCrafting table) {
         return false;
     }
@@ -771,6 +788,9 @@ public class PartLevelEmitter extends PartUpgradeable implements ILevelEmitter {
 
     @Override
     public IAEStackInventory getAEInventoryByName(StorageName name) {
-        return this.config;
+        if (name == StorageName.CONFIG) {
+            return this.config;
+        }
+        return null;
     }
 }

--- a/src/main/java/appeng/parts/automation/PartSharedItemBus.java
+++ b/src/main/java/appeng/parts/automation/PartSharedItemBus.java
@@ -229,7 +229,10 @@ public abstract class PartSharedItemBus<StackType extends IAEStack<StackType>> e
 
     @Override
     public IAEStackInventory getAEInventoryByName(StorageName name) {
-        return this.config;
+        if (name == StorageName.CONFIG) {
+            return this.config;
+        }
+        return null;
     }
 
     public StorageChannel getStorageChannel() {

--- a/src/main/java/appeng/parts/misc/PartStorageBus.java
+++ b/src/main/java/appeng/parts/misc/PartStorageBus.java
@@ -97,7 +97,7 @@ import cpw.mods.fml.relauncher.SideOnly;
 public class PartStorageBus extends PartUpgradeable implements IStorageBus {
 
     private final BaseActionSource mySrc;
-    private final IAEStackInventory Config = new IAEStackInventory(this, 63) {
+    private final IAEStackInventory config = new IAEStackInventory(this, 63) {
 
         @Override
         public void putAEStackInSlot(int n, IAEStack<?> aes) {
@@ -144,7 +144,7 @@ public class PartStorageBus extends PartUpgradeable implements IStorageBus {
                 priority = tag.getInteger("priority");
             }
             if (tag.hasKey("config")) {
-                Config.readFromNBT(tag, "config");
+                config.readFromNBT(tag, "config");
             }
             if (tag.hasKey("filter")) {
                 previousOreFilterString = tag.getString("filter");
@@ -172,7 +172,7 @@ public class PartStorageBus extends PartUpgradeable implements IStorageBus {
         if (type == PartItemStack.Wrench) {
             final NBTTagCompound tag = new NBTTagCompound();
 
-            if (!this.Config.isEmpty()) this.Config.writeToNBT(tag, "config");
+            if (!this.config.isEmpty()) this.config.writeToNBT(tag, "config");
             if (this.priority != 0) tag.setInteger("priority", this.priority);
             if (!this.oreFilterString.isEmpty()) tag.setString("filter", this.oreFilterString);
 
@@ -244,7 +244,7 @@ public class PartStorageBus extends PartUpgradeable implements IStorageBus {
 
         for (int x = 0; x < (this.getInstalledUpgrades(Upgrades.CAPACITY) * 9); x++) {
             final IAEStack<?> aes = filterCache[x];
-            if (aes != null) this.Config.putAEStackInSlot(x + 18, aes);
+            if (aes != null) this.config.putAEStackInSlot(x + 18, aes);
         }
         needSyncGUI = true;
 
@@ -285,7 +285,7 @@ public class PartStorageBus extends PartUpgradeable implements IStorageBus {
     @Override
     public void readFromNBT(final NBTTagCompound data) {
         super.readFromNBT(data);
-        this.Config.readFromNBT(data, "config");
+        this.config.readFromNBT(data, "config");
         this.priority = data.getInteger("priority");
         this.oreFilterString = data.getString("filter");
         final NBTTagCompound filterCacheTag = data.getCompoundTag("filterCache");
@@ -296,7 +296,7 @@ public class PartStorageBus extends PartUpgradeable implements IStorageBus {
     @Override
     public void writeToNBT(final NBTTagCompound data) {
         super.writeToNBT(data);
-        this.Config.writeToNBT(data, "config");
+        this.config.writeToNBT(data, "config");
         data.setInteger("priority", this.priority);
         data.setString("filter", this.oreFilterString);
         final NBTTagCompound tagCompound = new NBTTagCompound();
@@ -641,8 +641,8 @@ public class PartStorageBus extends PartUpgradeable implements IStorageBus {
                         final IItemList priorityList = getItemList();
 
                         final int slotsToUse = 18 + this.getInstalledUpgrades(Upgrades.CAPACITY) * 9;
-                        for (int x = 0; x < this.Config.getSizeInventory() && x < slotsToUse; x++) {
-                            IAEStack<?> is = this.Config.getAEStackInSlot(x);
+                        for (int x = 0; x < this.config.getSizeInventory() && x < slotsToUse; x++) {
+                            IAEStack<?> is = this.config.getAEStackInSlot(x);
 
                             if (getStorageChannel() == StorageChannel.FLUIDS && isAE2FCLoaded && is instanceof IAEItemStack ais && ais.getItem() instanceof ItemFluidPacket) {
                                 is = ItemFluidPacket.getFluidAEStack(ais);
@@ -784,6 +784,9 @@ public class PartStorageBus extends PartUpgradeable implements IStorageBus {
 
     @Override
     public IAEStackInventory getAEInventoryByName(StorageName name) {
-        return this.Config;
+        if (name == StorageName.CONFIG) {
+            return this.config;
+        }
+        return null;
     }
 }


### PR DESCRIPTION
- Memory card read/write to support IAEStackInventory config for IO Bus/Storage Bus/Level Emitter
- Include Level Emitter reportingValue in memory card save/restore