### PR TITLE
Less dumb Meteorite generation

### DIFF
--- a/src/main/java/appeng/core/worlddata/IWorldSpawnData.java
+++ b/src/main/java/appeng/core/worlddata/IWorldSpawnData.java
@@ -28,4 +28,6 @@ public interface IWorldSpawnData {
     boolean addNearByMeteorites(int dim, int chunkX, int chunkZ, NBTTagCompound newData);
 
     Collection<NBTTagCompound> getNearByMeteorites(int dim, int chunkX, int chunkZ);
+
+    default void flush() {}
 }

--- a/src/main/java/appeng/core/worlddata/WorldData.java
+++ b/src/main/java/appeng/core/worlddata/WorldData.java
@@ -81,7 +81,7 @@ public final class WorldData implements IWorldData {
         final CompassService compassService = new CompassService(this.compassDirectory, compassThreadFactory);
         final CompassData compassData = new CompassData(this.compassDirectory, compassService);
 
-        final IWorldSpawnData spawnData = new SpawnData(this.spawnDirectory);
+        final SpawnData spawnData = new SpawnData(this.spawnDirectory);
 
         this.playerData = playerData;
         this.dimensionData = dimensionData;
@@ -90,7 +90,7 @@ public final class WorldData implements IWorldData {
         this.spawnData = spawnData;
 
         this.startables = Lists.newArrayList(playerData, dimensionData, storageData);
-        this.stoppables = Lists.newArrayList(playerData, dimensionData, storageData, compassData);
+        this.stoppables = Lists.newArrayList(playerData, dimensionData, storageData, compassData, spawnData);
     }
 
     /**

--- a/src/main/java/appeng/hooks/TickHandler.java
+++ b/src/main/java/appeng/hooks/TickHandler.java
@@ -38,6 +38,7 @@ import appeng.core.AEConfig;
 import appeng.core.AELog;
 import appeng.core.CommonHelper;
 import appeng.core.sync.packets.PacketPaintedEntity;
+import appeng.core.worlddata.WorldData;
 import appeng.entity.EntityFloatingItem;
 import appeng.me.Grid;
 import appeng.me.NetworkList;
@@ -138,6 +139,13 @@ public class TickHandler {
             for (final IGridNode n : toDestroy) {
                 n.destroy();
             }
+        }
+    }
+
+    @SubscribeEvent
+    public void onWorldSave(final WorldEvent.Save event) {
+        if (Platform.isServer()) {
+            WorldData.instance().spawnData().flush();
         }
     }
 


### PR DESCRIPTION
* Stop loading SpawnData on every single chunk
* Stop writing SpawnData on every single chunk and instead mark it as dirty and periodically flush it

Hopefully this nonsense:

<img width="951" height="344" alt="image" src="https://github.com/user-attachments/assets/5432d233-3408-4083-be15-fdd5ad6f2762" />


<img width="1472" height="406" alt="before" src="https://github.com/user-attachments/assets/414cef2f-f86f-42df-981f-2e5d60736b33" />

