### PR TITLE
Fix crafting status tooltip

### DIFF
--- a/src/main/java/appeng/client/gui/widgets/GuiCraftingCPUTable.java
+++ b/src/main/java/appeng/client/gui/widgets/GuiCraftingCPUTable.java
@@ -280,10 +280,10 @@ public class GuiCraftingCPUTable {
                 tooltip.append(GuiText.Progress.getLocal());
                 tooltip.append(reset);
                 tooltip.append(": ");
-                tooltip.append(NumberFormat.getInstance().format(hoveredCpu.getTotalItems()));
-                tooltip.append(" / ");
                 tooltip.append(
                         NumberFormat.getInstance().format(hoveredCpu.getTotalItems() - hoveredCpu.getRemainingItems()));
+                tooltip.append(" / ");
+                tooltip.append(NumberFormat.getInstance().format(hoveredCpu.getTotalItems()));
                 tooltip.append(" (");
                 tooltip.append(gold);
                 tooltip.append(String.format("%02.2f%%", craftingPercentage));


### PR DESCRIPTION
Fixes progress being inverted

|before | after |
|-----|-----|
| <img width="275" height="175" alt="image" src="https://github.com/user-attachments/assets/460e08ae-b10f-4e63-83c4-acaab4443813" />| <img width="268" height="172" alt="image" src="https://github.com/user-attachments/assets/3511feca-8a42-4ba4-a755-304e9a610092" />|