### PR TITLE
avoid passing null to isItemValidForSlot

### DIFF
--- a/src/main/java/appeng/container/implementations/ContainerInterfaceTerminal.java
+++ b/src/main/java/appeng/container/implementations/ContainerInterfaceTerminal.java
@@ -166,7 +166,8 @@ public final class ContainerInterfaceTerminal extends AEBaseContainer {
                             /* Exchange is impossible, abort */
                             return;
                         }
-                        if (!inv.patterns.isItemValidForSlot(slot, handStack)) {
+                        // if exchanging, make sure the item that we're inserting is valid
+                        if (handStack != null && !inv.patterns.isItemValidForSlot(slot, handStack)) {
                             return;
                         }
                         inv.patterns.setInventorySlotContents(slot, playerHand.removeItems(1, null, null));


### PR DESCRIPTION
`null` is not valid for slots, but is used to represent an empty item