### PR TITLE
fix NPE in DualityInterface#addDrops

### DIFF
--- a/src/main/java/appeng/helpers/DualityInterface.java
+++ b/src/main/java/appeng/helpers/DualityInterface.java
@@ -944,23 +944,13 @@ public class DualityInterface implements IGridTickable, IStorageMonitorable, IIn
 
     @Override
     public IInventory getInventoryByName(final String name) {
-        if (name.equals("storage")) {
-            return this.storage;
-        }
-
-        if (name.equals("patterns")) {
-            return this.patterns;
-        }
-
-        if (name.equals("config")) {
-            return this.config;
-        }
-
-        if (name.equals("upgrades")) {
-            return this.upgrades;
-        }
-
-        return null;
+        return switch (name) {
+            case "storage" -> this.storage;
+            case "patterns" -> this.patterns;
+            case "config" -> this.config;
+            case "upgrades" -> this.upgrades;
+            default -> null;
+        };
     }
 
     public AppEngInternalInventory getStorage() {
@@ -1089,9 +1079,7 @@ public class DualityInterface implements IGridTickable, IStorageMonitorable, IIn
                         host.getInterfaceDuality().receivePatternPushedEvent();
                     }
                 }
-            } catch (final GridAccessException e) {
-                continue;
-            }
+            } catch (final GridAccessException ignored) {}
         }
     }
 
@@ -1447,7 +1435,10 @@ public class DualityInterface implements IGridTickable, IStorageMonitorable, IIn
         if (this.waitingToSend != null) {
             for (final IAEStack<?> is : this.waitingToSend) {
                 if (is != null) {
-                    drops.add(stackConvertPacket(is).getItemStack());
+                    final IAEItemStack iaeStack = stackConvertPacket(is);
+                    if (iaeStack != null) {
+                        drops.add(iaeStack.getItemStack());
+                    }
                 }
             }
         }


### PR DESCRIPTION
```
[Server thread/ERROR] [FML/]: There was a critical exception handling a packet on channel AE2
java.lang.NullPointerException: Cannot invoke "appeng.api.storage.data.IAEItemStack.getItemStack()" because the return value of "appeng.util.Platform.stackConvertPacket(appeng.api.storage.data.IAEStack)" is null
	at Launch//appeng.helpers.DualityInterface.addDrops(DualityInterface.java:1450) ~[DualityInterface.class:?]
	at Launch//appeng.parts.misc.PartInterface.getDrops(PartInterface.java:201) ~[PartInterface.class:?]
	at Launch//appeng.parts.PartPlacement.place(PartPlacement.java:113) ~[PartPlacement.class:?]
	at Launch//gregtech.common.tools.ToolWrench.onBreakBlock(ToolWrench.java:188) ~[ToolWrench.class:?]
	at Launch//gregtech.common.GTProxy.onBlockBreakingEvent(GTProxy.java:1447) ~[GTProxy.class:?]
```