### PR TITLE
Add legacy type detection for level emitters

### DIFF
--- a/src/main/java/appeng/parts/automation/PartLevelEmitter.java
+++ b/src/main/java/appeng/parts/automation/PartLevelEmitter.java
@@ -78,8 +78,6 @@ import appeng.util.LevelEmitterTypeFilter;
 import appeng.util.Platform;
 import appeng.util.SettingsFrom;
 import appeng.util.item.AEFluidStackType;
-import cpw.mods.fml.common.registry.GameRegistry;
-import cpw.mods.fml.common.registry.GameRegistry.UniqueIdentifier;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import it.unimi.dsi.fastutil.objects.Reference2BooleanMap;
@@ -767,11 +765,9 @@ public class PartLevelEmitter extends PartUpgradeable implements ILevelEmitter {
         } else if (data.hasKey("TYPE_FILTER")) {
             this.applyLegacyTypeFilter(data.getString("TYPE_FILTER"));
         } else {
-            // Legacy level emitter (no type filter data): set fluid/item/essentia from part type or placing item
-            final String legacyType = this.detectLegacyEmitterType();
-            this.applyLegacyTypeFilter(legacyType);
-            this.configureWatchers();
-            this.saveChanges();
+            final Reference2BooleanMap<IAEStackType<?>> filters = this.typeFilters.getFilters();
+            final IAEStackType<?> thisType = this.getUltraLegacyType();
+            for (IAEStackType<?> type : filters.keySet()) filters.put(type, type == thisType);
         }
     }
 
@@ -859,45 +855,11 @@ public class PartLevelEmitter extends PartUpgradeable implements ILevelEmitter {
                 filters.put(type, type == ITEM_STACK_TYPE);
             } else if ("FLUIDS".equals(typeName)) {
                 filters.put(type, type == AEFluidStackType.FLUID_STACK_TYPE);
-            } else if ("ESSENTIA".equals(typeName)) {
-                final IAEStackType<?> essentiaType = AEStackTypeRegistry.getType("essentia");
-                filters.put(type, type == essentiaType);
             }
         }
     }
 
-    /**
-     * Detect legacy level emitter type from the part's item stack (used when loading with no type filter NBT). Ensures
-     * already-placed fluid/essentia/item emitters get the correct toggle state.
-     */
-    private String detectLegacyEmitterType() {
-        final ItemStack is = this.getItemStack();
-        if (is == null || is.getItem() == null) {
-            return "ITEMS";
-        }
-        try {
-            final UniqueIdentifier id = GameRegistry.findUniqueIdentifierFor(is.getItem());
-            if (id != null && id.modId != null && id.name != null) {
-                final String modId = id.modId.toLowerCase();
-                final String name = id.name.toLowerCase();
-                if (name.contains("fluid_level_emitter")) {
-                    return "FLUIDS";
-                }
-                if (modId.contains("thaumicenergistics") && is.getItemDamage() == 1) {
-                    return "ESSENTIA";
-                }
-            }
-        } catch (Exception e) {
-            AELog.debug(e);
-        }
-        return "ITEMS";
-    }
-
-    /**
-     * For subclasses to apply legacy type filter when loading already-placed level emitters that were placed before the
-     * unified fluid/item/essentia toggle (e.g. fluid or essentia level emitter).
-     */
-    protected final void applyLegacyEmitterType(final String typeName) {
-        this.applyLegacyTypeFilter(typeName);
+    protected IAEStackType<?> getUltraLegacyType() {
+        return ITEM_STACK_TYPE;
     }
 }


### PR DESCRIPTION
Don't merge without [413](https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/413)
Don't merge without [116](https://github.com/GTNewHorizons/ThaumicEnergistics/pull/116)

Enhance the PartLevelEmitter class to support legacy type filtering for fluid, item, and essentia emitters. Implemented methods to detect the legacy emitter type based on the item stack and apply the appropriate filters during loading. This ensures compatibility with previously placed emitters that lack type filter data.