### PR TITLE
fix NPE in AEFluidStackType#drainStackFromContainer

### DIFF
--- a/src/main/java/appeng/util/item/AEFluidStackType.java
+++ b/src/main/java/appeng/util/item/AEFluidStackType.java
@@ -110,10 +110,14 @@ public class AEFluidStackType implements IAEStackType<IAEFluidStack> {
         itemStack.stackSize = 1;
         if (itemStack.getItem() instanceof IFluidContainerItem container) {
             FluidStack fluid = container.getFluid(itemStack);
-            if (fluid == null || !stack.getFluidStack().isFluidEqual(fluid))
+            if (fluid == null || !stack.getFluidStack().isFluidEqual(fluid)) {
                 return new ObjectLongImmutablePair<>(itemStack, 0);
+            }
             FluidStack drained = container
                     .drain(itemStack, (int) Math.min(stack.getStackSize(), Integer.MAX_VALUE), true);
+            if (drained == null) {
+                return new ObjectLongImmutablePair<>(itemStack, 0);
+            }
             return new ObjectLongImmutablePair<>(itemStack, drained.amount);
         } else if (FluidContainerRegistry.isContainer(itemStack)) {
             FluidStack fluid = FluidContainerRegistry.getFluidForFilledItem(itemStack);


### PR DESCRIPTION
```
[Server thread/ERROR] [FML/]: Exception caught during firing event cpw.mods.fml.common.network.FMLNetworkEvent$ServerCustomPacketEvent@71dd7508:
java.lang.NullPointerException: Cannot read field "amount" because "drained" is null
	at Launch//appeng.util.item.AEFluidStackType.drainStackFromContainer(AEFluidStackType.java:117) ~[AEFluidStackType.class:?]
	at Launch//appeng.util.item.AEFluidStackType.drainStackFromContainer(AEFluidStackType.java:32) ~[AEFluidStackType.class:?]
	at Launch//appeng.container.implementations.ContainerMEMonitorable.extractFromSingleFluidContainer(ContainerMEMonitorable.java:1041) ~[ContainerMEMonitorable.class:?]
	at Launch//appeng.container.implementations.ContainerMEMonitorable.doMonitorableAction(ContainerMEMonitorable.java:807) ~[ContainerMEMonitorable.class:?]
	at Launch//appeng.core.sync.packets.PacketMonitorableAction.serverPacketData(PacketMonitorableAction.java:73) ~[PacketMonitorableAction.class:?]
	at Launch//appeng.core.sync.network.AppEngServerPacketHandler.onPacketData(AppEngServerPacketHandler.java:32) ~[AppEngServerPacketHandler.class:?]
	at Launch//appeng.core.sync.network.NetworkHandler.serverPacket(NetworkHandler.java:78) ~[NetworkHandler.class:?]
	at cpw.mods.fml.common.eventhandler.ASMEventHandler_2135_NetworkHandler_serverPacket_ServerCustomPacketEvent.invoke(.dynamic) ~[?:?]
	at Launch//cpw.mods.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:54) ~[ASMEventHandler.class:?]
	at Launch//cpw.mods.fml.common.eventhandler.EventBus.post(EventBus.java:140) [EventBus.class:?]
	at Launch//cpw.mods.fml.common.network.FMLEventChannel.fireRead(FMLEventChannel.java:103) [FMLEventChannel.class:?]
	at Launch//cpw.mods.fml.common.network.NetworkEventFiringHandler.channelRead0(NetworkEventFiringHandler.java:30) [NetworkEventFiringHandler.class:?]
	at Launch//cpw.mods.fml.common.network.NetworkEventFiringHandler.channelRead0(NetworkEventFiringHandler.java:18) [NetworkEventFiringHandler.class:?]
	at Launch//io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:98) [netty-all-4.0.10.Final.jar:?]
	at Launch//io.netty.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:337) [netty-all-4.0.10.Final.jar:?]
	at Launch//io.netty.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:323) [netty-all-4.0.10.Final.jar:?]
	at Launch//io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:785) [netty-all-4.0.10.Final.jar:?]
	at Launch//io.netty.channel.embedded.EmbeddedChannel.writeInbound(EmbeddedChannel.java:169) [netty-all-4.0.10.Final.jar:?]
	at Launch//cpw.mods.fml.common.network.internal.FMLProxyPacket.func_148833_a(FMLProxyPacket.java:77) [FMLProxyPacket.class:?]
	at Launch//net.minecraft.network.NetworkManager.func_74428_b(NetworkManager.java:212) [ej.class:?]
	at Launch//net.minecraft.network.NetworkSystem.func_151269_c(NetworkSystem.java:165) [nc.class:?]
	at Launch//net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:659) [MinecraftServer.class:?]
	at Launch//net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:547) [MinecraftServer.class:?]
	at Launch//net.minecraft.server.integrated.IntegratedServer.func_71217_p(IntegratedServer.java:111) [bsx.class:?]
	at Launch//net.minecraft.server.MinecraftServer.run(MinecraftServer.java:427) [MinecraftServer.class:?]
	at Launch//net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:685) [?:?]
```

fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/23922