### PR TITLE
Adjusts ME Pick Block to prefer PickBlockEvent when appropriate

### DIFF
--- a/src/main/java/appeng/client/ClientHelper.java
+++ b/src/main/java/appeng/client/ClientHelper.java
@@ -81,6 +81,7 @@ import appeng.util.Platform;
 import cpw.mods.fml.client.registry.ClientRegistry;
 import cpw.mods.fml.client.registry.RenderingRegistry;
 import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.eventhandler.EventPriority;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 
 public class ClientHelper extends ServerHelper {
@@ -453,22 +454,19 @@ public class ClientHelper extends ServerHelper {
     }
 
     /**
-     * Do not run the vanilla pick block logic if it is double bound with the AE2 pick block keybind, and the player is
-     * not in creative mode. The vanilla pick block event should be canceled and only the AE2 pick block logic should
-     * run. This is to prevent conflicts from the client-side vanilla pick-block and the server-side AE2 pick block.
+     * Runs the pick block handler if the ME Pick Block key and the vanilla Pick Block key are the same, while
+     * respecting the {@link PickBlockEvent}'s other handlers. For all other pick block invocations, see
+     * {@link KeyBindHandler}.
      */
-    @SubscribeEvent
+    @SubscribeEvent(priority = EventPriority.LOW)
     public void onPickBlockEvent(final PickBlockEvent event) {
         var minecraft = Minecraft.getMinecraft();
         if (!minecraft.theWorld.isRemote) {
             return;
         }
 
-        var isCreative = minecraft.thePlayer.capabilities.isCreativeMode;
-        var vanillaKeybind = minecraft.gameSettings.keyBindPickBlock.getKeyCode();
-        var ae2Keybind = CommonHelper.proxy.getKeybind(ActionKey.PICK_BLOCK);
-        if (!isCreative && vanillaKeybind == ae2Keybind) {
-            event.setCanceled(true);
+        if (!minecraft.thePlayer.capabilities.isCreativeMode && KeyBindHandler.arePickBlockBindsEqual()) {
+            event.setCanceled(KeyBindHandler.handlePickBlock());
         }
     }
 

--- a/src/main/java/appeng/client/KeyBindHandler.java
+++ b/src/main/java/appeng/client/KeyBindHandler.java
@@ -7,6 +7,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.World;
 
+import com.gtnewhorizon.gtnhlib.event.PickBlockEvent;
+
 import appeng.core.CommonHelper;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketPickBlock;
@@ -15,13 +17,17 @@ import cpw.mods.fml.common.gameevent.InputEvent;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
+/**
+ * Handles the pick block feature for any case where the vanilla pick block key and the ME Pick Block key are different.
+ * For when they're the same, see {@link ClientHelper#onPickBlockEvent(PickBlockEvent)}.
+ */
 @SideOnly(Side.CLIENT)
 public class KeyBindHandler {
 
     @SideOnly(Side.CLIENT)
     @SubscribeEvent
     public void onKeyInput(InputEvent.KeyInputEvent event) {
-        if (CommonHelper.proxy.isKeyPressed(ActionKey.PICK_BLOCK)) {
+        if (CommonHelper.proxy.isKeyPressed(ActionKey.PICK_BLOCK) && !arePickBlockBindsEqual()) {
             handlePickBlock();
         }
     }
@@ -29,28 +35,33 @@ public class KeyBindHandler {
     @SideOnly(Side.CLIENT)
     @SubscribeEvent
     public void onMouseInput(InputEvent.MouseInputEvent event) {
-        if (CommonHelper.proxy.isKeyPressed(ActionKey.PICK_BLOCK)) {
+        if (CommonHelper.proxy.isKeyPressed(ActionKey.PICK_BLOCK) && !arePickBlockBindsEqual()) {
             handlePickBlock();
         }
     }
 
-    private void handlePickBlock() {
+    static boolean arePickBlockBindsEqual() {
+        return Minecraft.getMinecraft().gameSettings.keyBindPickBlock.getKeyCode()
+                == CommonHelper.proxy.getKeybind(ActionKey.PICK_BLOCK);
+    }
+
+    static boolean handlePickBlock() {
         Minecraft minecraft = Minecraft.getMinecraft();
         World world = minecraft.theWorld;
-        if (minecraft.currentScreen != null) return; // Don't act if a GUI is open
+        if (minecraft.currentScreen != null) return false; // Don't act if a GUI is open
 
         EntityClientPlayerMP player = minecraft.thePlayer;
-        if (player == null) return;
+        if (player == null) return false;
 
         // Use vanilla pick block when in creative
         if (player.capabilities.isCreativeMode) {
-            return;
+            return false;
         }
 
         // Get the block the player is currently looking at
         MovingObjectPosition target = minecraft.objectMouseOver;
         if (target == null || target.typeOfHit != MovingObjectPosition.MovingObjectType.BLOCK) {
-            return;
+            return false;
         }
 
         int x = target.blockX;
@@ -59,16 +70,17 @@ public class KeyBindHandler {
         Block block = world.getBlock(x, y, z);
 
         if (block.isAir(world, x, y, z)) {
-            return;
+            return false;
         }
 
         ItemStack pickedBlock = block.getPickBlock(target, world, x, y, z, player);
         if (pickedBlock == null) {
-            return;
+            return false;
         }
 
         final var packet = new PacketPickBlock(pickedBlock);
         NetworkHandler.instance.sendToServer(packet);
+        return true;
     }
 
 }


### PR DESCRIPTION
This fixes a problem with the ME Pick Block feature jumping ahead of the GTNHLib Pick Block event. Previously, the ME Pick Block feature fired on a mouse or key event only, and only used the GTNHLib `PickBlockEvent` to cancel the vanilla behavior. I've rigged it so that if the ME pick block and vanilla pick block keys are the same, the ME pick block will fire using the GTNHLib event rather than the lower level mouse/key events, and thus respect the GTNHLib event's cancellation.

I also lowered the event priority when using the `PickBlockEvent`. Since this feature is essentially "vanilla pick block, but it also withdraws from your ME network," it feels better to have it only happen if something isn't trying to completely stop any pick block related tasks from happening at all (like a certain toolbox or spray can.) 