### PR TITLE
fix GuiCraftingCPU#filteredVisual not being cleared properly

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
@@ -158,7 +158,7 @@ public class GuiCraftConfirm extends GuiSub implements ICraftingCPUTableHolder, 
     private GuiAeButton findNext;
     private GuiAeButton findPrev;
     private MEGuiTextField searchField;
-    protected List<IAEStack<?>> filteredVisual = new ArrayList<>();
+    private final List<IAEStack<?>> filteredVisual = new ArrayList<>();
     private int tooltip = -1;
     private ItemStack hoveredStack;
 

--- a/src/main/java/appeng/client/gui/implementations/GuiCraftingCPU.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCraftingCPU.java
@@ -213,6 +213,7 @@ public class GuiCraftingCPU extends AEBaseGui implements ISortSource, IGuiToolti
     }
 
     protected List<IAEStack<?>> visual = new ArrayList<>();
+    private List<IAEStack<?>> filteredVisual = new ArrayList<>();
     private GuiButton cancel;
     private GuiAeButton suspend;
     protected List<IAEStack<?>> visualHiddenStored = new ArrayList<>();
@@ -224,7 +225,6 @@ public class GuiCraftingCPU extends AEBaseGui implements ISortSource, IGuiToolti
     private NBTTagCompound hoveredStackNbt;
     private GuiImgButton changeAllow;
     private MEGuiTextField searchField;
-    protected List<IAEStack<?>> filteredVisual = new ArrayList<>();
 
     public GuiCraftingCPU(final InventoryPlayer inventoryPlayer, final Object te) {
         this(new ContainerCraftingCPU(inventoryPlayer, te));
@@ -246,6 +246,7 @@ public class GuiCraftingCPU extends AEBaseGui implements ISortSource, IGuiToolti
         this.active = AEApi.instance().storage().createAEStackList();
         this.pending = AEApi.instance().storage().createAEStackList();
         this.visual = new ArrayList<>();
+        this.filteredVisual = new ArrayList<>();
         this.visualHiddenStored = new ArrayList<>();
     }
 


### PR DESCRIPTION
bug introduced by https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/1097

this pr fixes a bug where it still shows the items from the previous CPU when cycling CPU

<img width="778" height="447" alt="image" src="https://github.com/user-attachments/assets/f1f30b77-93ac-4fba-9b8e-19caafd7dd9d" />

<img width="721" height="409" alt="image" src="https://github.com/user-attachments/assets/bd3f83aa-36cc-49ec-840a-7ec66b484db5" />
