### PR TITLE
Fix Multiplier&Divider infinite loop

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiOptimizePatterns.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiOptimizePatterns.java
@@ -366,7 +366,7 @@ public class GuiOptimizePatterns extends GuiSub implements IGuiTooltipHandler {
                                 stack.getCountRequestableCrafts(),
                                 stack.getCountRequestable(),
                                 amountToCraftI),
-                        (int) (stack.getStackSize() & 0b11111));
+                        (int) (stack.getStackSize() & PacketOptimizePatterns.MULTIPLIER_BIT_MASK));
                 if (v > 0) multiplierMap.put(stack, v);
             }
         }

--- a/src/main/java/appeng/container/implementations/ContainerOptimizePatterns.java
+++ b/src/main/java/appeng/container/implementations/ContainerOptimizePatterns.java
@@ -97,11 +97,13 @@ public class ContainerOptimizePatterns extends ContainerSubGui {
                     stack.setCountRequestableCrafts(entry.getValue().requestedCrafts);
                     long perCraft = entry.getValue().getCraftAmountForItem(stack);
                     long hash = entry.getKey().hashCode();
+                    // max multi is 62, that's 6 bits MAX!!
                     long multiplier = entry.getValue().getMaxBitMultiplier()
                             & PacketOptimizePatterns.MULTIPLIER_BIT_MASK;
-                    // max multi is 62, that's 6 bits MAX!! + 1 bit to store sign of the hash
-                    long highbits = ((Math.abs(hash) << 1) | ((hash < 0) ? 1 : 0))
-                            << PacketOptimizePatterns.MULTIPLIER_BITS;
+                    // lowest bit is sign, the rest bits are magnitude
+                    long highbits = (Math.abs(hash) << 1) | ((hash < 0) ? 1 : 0);
+                    // Then shift it left by 6 bits
+                    highbits = highbits << PacketOptimizePatterns.MULTIPLIER_BITS;
                     stack.setStackSize(highbits | multiplier);
                     stack.setCountRequestable(perCraft);
                     patternsUpdate.appendItem(stack);

--- a/src/main/java/appeng/container/implementations/ContainerOptimizePatterns.java
+++ b/src/main/java/appeng/container/implementations/ContainerOptimizePatterns.java
@@ -97,10 +97,11 @@ public class ContainerOptimizePatterns extends ContainerSubGui {
                     stack.setCountRequestableCrafts(entry.getValue().requestedCrafts);
                     long perCraft = entry.getValue().getCraftAmountForItem(stack);
                     long hash = entry.getKey().hashCode();
-                    long multiplier=entry.getValue().getMaxBitMultiplier()&PacketOptimizePatterns.MULTIPLIER_BIT_MASK;
-                     // max multi is 62, that's 6 bits MAX!! + 1 bit to store sign of the hash
-                    long highbits=((hash<<1)|((hash < 0)?1:0)) << PacketOptimizePatterns.MULTIPLIER_BITS;
-                    stack.setStackSize(highbits|multiplier);
+                    long multiplier = entry.getValue().getMaxBitMultiplier()
+                            & PacketOptimizePatterns.MULTIPLIER_BIT_MASK;
+                    // max multi is 62, that's 6 bits MAX!! + 1 bit to store sign of the hash
+                    long highbits = ((hash << 1) | ((hash < 0) ? 1 : 0)) << PacketOptimizePatterns.MULTIPLIER_BITS;
+                    stack.setStackSize(highbits | multiplier);
                     stack.setCountRequestable(perCraft);
                     patternsUpdate.appendItem(stack);
                 }

--- a/src/main/java/appeng/container/implementations/ContainerOptimizePatterns.java
+++ b/src/main/java/appeng/container/implementations/ContainerOptimizePatterns.java
@@ -100,7 +100,8 @@ public class ContainerOptimizePatterns extends ContainerSubGui {
                     long multiplier = entry.getValue().getMaxBitMultiplier()
                             & PacketOptimizePatterns.MULTIPLIER_BIT_MASK;
                     // max multi is 62, that's 6 bits MAX!! + 1 bit to store sign of the hash
-                    long highbits = ((hash << 1) | ((hash < 0) ? 1 : 0)) << PacketOptimizePatterns.MULTIPLIER_BITS;
+                    long highbits = ((Math.abs(hash) << 1) | ((hash < 0) ? 1 : 0))
+                            << PacketOptimizePatterns.MULTIPLIER_BITS;
                     stack.setStackSize(highbits | multiplier);
                     stack.setCountRequestable(perCraft);
                     patternsUpdate.appendItem(stack);

--- a/src/main/java/appeng/container/implementations/ContainerOptimizePatterns.java
+++ b/src/main/java/appeng/container/implementations/ContainerOptimizePatterns.java
@@ -30,6 +30,7 @@ import appeng.core.AELog;
 import appeng.core.features.registries.InterfaceTerminalRegistry;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketMEInventoryUpdate;
+import appeng.core.sync.packets.PacketOptimizePatterns;
 import appeng.crafting.v2.CraftingContext;
 import appeng.crafting.v2.CraftingJobV2;
 import appeng.crafting.v2.resolvers.CraftableItemResolver.CraftFromPatternTask;
@@ -95,10 +96,11 @@ public class ContainerOptimizePatterns extends ContainerSubGui {
                     IAEStack<?> stack = entry.getKey().copy();
                     stack.setCountRequestableCrafts(entry.getValue().requestedCrafts);
                     long perCraft = entry.getValue().getCraftAmountForItem(stack);
-                    int hash = entry.getKey().hashCode();
-                    if (hash < 0) // max multi is 30, that's 5 bits MAX!! + 1 bit to store sign of the hash
-                        stack.setStackSize((long) (-hash) << 6 | 0b100000 | entry.getValue().getMaxBitMultiplier());
-                    else stack.setStackSize((long) hash << 6 | entry.getValue().getMaxBitMultiplier());
+                    long hash = entry.getKey().hashCode();
+                    long multiplier=entry.getValue().getMaxBitMultiplier()&PacketOptimizePatterns.MULTIPLIER_BIT_MASK;
+                     // max multi is 62, that's 6 bits MAX!! + 1 bit to store sign of the hash
+                    long highbits=((hash<<1)|((hash < 0)?1:0)) << PacketOptimizePatterns.MULTIPLIER_BITS;
+                    stack.setStackSize(highbits|multiplier);
                     stack.setCountRequestable(perCraft);
                     patternsUpdate.appendItem(stack);
                 }

--- a/src/main/java/appeng/core/sync/packets/PacketOptimizePatterns.java
+++ b/src/main/java/appeng/core/sync/packets/PacketOptimizePatterns.java
@@ -13,11 +13,11 @@ import io.netty.buffer.Unpooled;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 
 public class PacketOptimizePatterns extends AppEngPacket {
-	static public final int MULTIPLIER_BITS = 6;// multiplier <= (0b111110), take 6 bits
-	static public final long MULTIPLIER_BIT_MASK=(1L << MULTIPLIER_BITS) - 1;// low 6 bits = 1
-	static public final long HASH_SIGN_BIT_MASK=1L << MULTIPLIER_BITS;// 7th bit = 1
-	
-	
+
+    static public final int MULTIPLIER_BITS = 6;// multiplier <= (0b111110), take 6 bits
+    static public final long MULTIPLIER_BIT_MASK = (1L << MULTIPLIER_BITS) - 1;// low 6 bits = 1
+    static public final long HASH_SIGN_BIT_MASK = 1L << MULTIPLIER_BITS;// 7th bit = 1
+
     HashMap<Integer, Integer> hashCodeToMultiplier = new HashMap<>();
 
     // automatic
@@ -37,7 +37,7 @@ public class PacketOptimizePatterns extends AppEngPacket {
         data.writeInt(multipliersMap.size());
         for (var entry : multipliersMap.object2IntEntrySet()) {
             long encoded = entry.getKey().getStackSize();
-            data.writeInt((int) (encoded >> (MULTIPLIER_BITS+1)) * ((encoded & HASH_SIGN_BIT_MASK) == 0 ? 1 : -1));
+            data.writeInt((int) (encoded >> (MULTIPLIER_BITS + 1)) * ((encoded & HASH_SIGN_BIT_MASK) == 0 ? 1 : -1));
             data.writeInt(entry.getIntValue());
         }
 

--- a/src/main/java/appeng/core/sync/packets/PacketOptimizePatterns.java
+++ b/src/main/java/appeng/core/sync/packets/PacketOptimizePatterns.java
@@ -13,7 +13,11 @@ import io.netty.buffer.Unpooled;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 
 public class PacketOptimizePatterns extends AppEngPacket {
-
+	static public final int MULTIPLIER_BITS = 6;// multiplier <= (0b111110), take 6 bits
+	static public final long MULTIPLIER_BIT_MASK=(1L << MULTIPLIER_BITS) - 1;// low 6 bits = 1
+	static public final long HASH_SIGN_BIT_MASK=1L << MULTIPLIER_BITS;// 7th bit = 1
+	
+	
     HashMap<Integer, Integer> hashCodeToMultiplier = new HashMap<>();
 
     // automatic
@@ -33,7 +37,7 @@ public class PacketOptimizePatterns extends AppEngPacket {
         data.writeInt(multipliersMap.size());
         for (var entry : multipliersMap.object2IntEntrySet()) {
             long encoded = entry.getKey().getStackSize();
-            data.writeInt((int) (encoded >> 6) * ((encoded & 0b100000) == 0 ? 1 : -1));
+            data.writeInt((int) (encoded >> (MULTIPLIER_BITS+1)) * ((encoded & HASH_SIGN_BIT_MASK) == 0 ? 1 : -1));
             data.writeInt(entry.getIntValue());
         }
 

--- a/src/main/java/appeng/util/PatternMultiplierHelper.java
+++ b/src/main/java/appeng/util/PatternMultiplierHelper.java
@@ -10,13 +10,13 @@ import appeng.api.storage.data.IAEStack;
 public class PatternMultiplierHelper {
 
     public static int getMaxBitMultiplier(ICraftingPatternDetails details) {
-        int maxMulti = 30;
+        int maxMulti = 62;
         for (IAEStack<?> input : details.getAEInputs()) {
             if (input == null) continue;
             long size = input.getStackSize();
             if (size <= 0) continue;
             int highestBit = 63 - Long.numberOfLeadingZeros(size);
-            int max = 30 - highestBit;
+            int max = 62 - highestBit;
             if (max < 0) max = 0;
             if (max < maxMulti) maxMulti = max;
         }
@@ -25,7 +25,7 @@ public class PatternMultiplierHelper {
             long size = out.getStackSize();
             if (size <= 0) continue;
             int highestBit = 63 - Long.numberOfLeadingZeros(size);
-            int max = 30 - highestBit;
+            int max = 62 - highestBit;
             if (max < 0) max = 0;
             if (max < maxMulti) maxMulti = max;
         }
@@ -33,19 +33,19 @@ public class PatternMultiplierHelper {
     }
 
     public static int getMaxBitDivider(ICraftingPatternDetails details) {
-        int maxDiv = 30;
+        int maxDiv = 62;
         for (IAEStack<?> input : details.getAEInputs()) {
             if (input == null) continue;
             long size = input.getStackSize();
             if (size <= 0) continue;
-            int tz = Math.min(Long.numberOfTrailingZeros(size), 30);
+            int tz = Math.min(Long.numberOfTrailingZeros(size), 62);
             if (tz < maxDiv) maxDiv = tz;
         }
         for (IAEStack<?> out : details.getAEOutputs()) {
             if (out == null) continue;
             long size = out.getStackSize();
             if (size <= 0) continue;
-            int tz = Math.min(Long.numberOfTrailingZeros(size), 30);
+            int tz = Math.min(Long.numberOfTrailingZeros(size), 62);
             if (tz < maxDiv) maxDiv = tz;
         }
         return maxDiv;

--- a/src/main/java/appeng/util/PatternMultiplierHelper.java
+++ b/src/main/java/appeng/util/PatternMultiplierHelper.java
@@ -9,59 +9,45 @@ import appeng.api.storage.data.IAEStack;
 
 public class PatternMultiplierHelper {
 
-    private static final int FINAL_BIT = 1 << 30; // 1 bit before integer overflow
-
     public static int getMaxBitMultiplier(ICraftingPatternDetails details) {
-        // limit to 2B per item in pattern
         int maxMulti = 30;
         for (IAEStack<?> input : details.getAEInputs()) {
             if (input == null) continue;
             long size = input.getStackSize();
-            int max = 0;
-            while ((size & FINAL_BIT) == 0) {
-                size <<= 1;
-                max++;
-            }
+            if (size <= 0) continue;
+            int highestBit = 63 - Long.numberOfLeadingZeros(size);
+            int max = 30 - highestBit;
+            if (max < 0) max = 0;
             if (max < maxMulti) maxMulti = max;
         }
         for (IAEStack<?> out : details.getAEOutputs()) {
             if (out == null) continue;
             long size = out.getStackSize();
-            int max = 0;
-            while ((size & FINAL_BIT) == 0) {
-                size <<= 1;
-                max++;
-            }
+            if (size <= 0) continue;
+            int highestBit = 63 - Long.numberOfLeadingZeros(size);
+            int max = 30 - highestBit;
+            if (max < 0) max = 0;
             if (max < maxMulti) maxMulti = max;
         }
-
         return maxMulti;
     }
 
     public static int getMaxBitDivider(ICraftingPatternDetails details) {
-        // limit to 2B per item in pattern
         int maxDiv = 30;
         for (IAEStack<?> input : details.getAEInputs()) {
             if (input == null) continue;
             long size = input.getStackSize();
-            int max = 0;
-            while ((size & 1) == 0) {
-                size >>= 1;
-                max++;
-            }
-            if (max < maxDiv) maxDiv = max;
+            if (size <= 0) continue;
+            int tz = Math.min(Long.numberOfTrailingZeros(size), 30);
+            if (tz < maxDiv) maxDiv = tz;
         }
         for (IAEStack<?> out : details.getAEOutputs()) {
             if (out == null) continue;
             long size = out.getStackSize();
-            int max = 0;
-            while ((size & 1) == 0) {
-                size >>= 1;
-                max++;
-            }
-            if (max < maxDiv) maxDiv = max;
+            if (size <= 0) continue;
+            int tz = Math.min(Long.numberOfTrailingZeros(size), 30);
+            if (tz < maxDiv) maxDiv = tz;
         }
-
         return maxDiv;
     }
 


### PR DESCRIPTION
Fix Multiplier&Divider infinite loop when size is 0 or greater than int.max (with low 32bits==0).
Also optimize it with `numberOfLeadingZeros`&`numberOfTrailingZeros`