### PR TITLE
Run ignore-missing CPUs after normal crafts

### DIFF
--- a/src/main/java/appeng/me/cache/CraftingGridCache.java
+++ b/src/main/java/appeng/me/cache/CraftingGridCache.java
@@ -102,7 +102,6 @@ public class CraftingGridCache
     private static final ExecutorService CRAFTING_POOL;
     private static final Comparator<ICraftingPatternDetails> COMPARATOR = (firstDetail,
             nextDetail) -> nextDetail.getPriority() - firstDetail.getPriority();
-
     static {
         final ThreadFactory factory = ar -> new Thread(ar, "AE Crafting Calculator");
 
@@ -155,8 +154,17 @@ public class CraftingGridCache
         this.craftingLinks.values().removeIf(craftingLinkNexus -> craftingLinkNexus.isDead(this.grid, this));
 
         for (final CraftingCPUCluster cpu : this.craftingCPUClusters) {
-            cpu.tryExtractItems();
-            cpu.updateCraftingLogic(this.grid, this.energyGrid, this);
+            if (!cpu.isMissingMode()) {
+                cpu.tryExtractItems();
+                cpu.updateCraftingLogic(this.grid, this.energyGrid, this);
+            }
+        }
+
+        for (final CraftingCPUCluster cpu : this.craftingCPUClusters) {
+            if (cpu.isMissingMode()) {
+                cpu.tryExtractItems();
+                cpu.updateCraftingLogic(this.grid, this.energyGrid, this);
+            }
         }
     }
 


### PR DESCRIPTION
When running multiple crafts at the same time, where some use `IGNORE_MISSING`, and some do not (level maintain or manual); it is possible for the IGNORE_MISSING CPUs to "steal" items being crafted which blocks standard crafts on "MISSING_INGREDIENTS"

This change simply runs item collection for ignore-missing CPUs last.