### PR TITLE
Fix/merge remaining count

### DIFF
--- a/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
+++ b/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
@@ -1988,16 +1988,19 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
         public void init(IAEStack<?> originalOutput) {
             this.reset();
             this.originalOutput = originalOutput;
+            this.addOutputs(originalOutput);
+        }
 
+        private void addOutputs(IAEStack<?> output) {
             ICraftingPatternDetails details = null;
             long finalOutputPatternMultiplier = 0;
 
             out: for (final Entry<ICraftingPatternDetails, TaskProgress> t : tasks.entrySet()) {
                 for (IAEStack<?> aes : t.getKey().getCondensedAEOutputs()) {
-                    if (aes.equals(originalOutput)) {
+                    if (aes.equals(output)) {
                         details = t.getKey();
                         finalOutputPatternMultiplier = (long) Math
-                                .ceil((double) this.originalOutput.getStackSize() / aes.getStackSize());
+                                .ceil((double) output.getStackSize() / aes.getStackSize());
                         break out;
                     }
                 }
@@ -2068,7 +2071,7 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
 
         public void merge(IAEStack<?> toMerge) {
             this.originalOutput.add(toMerge);
-            this.init(this.originalOutput);
+            this.addOutputs(toMerge);
         }
 
         public void reset() {


### PR DESCRIPTION
Fixes #1160 

Preserves the existing remaining output when merging jobs. Previously, merging rebuilt outputs from the new total amount requested, which could throw away already completed progress. 

This change keeps current remaining outputs and adds merged outputs.