### PR TITLE
Fix crafting plan percentage rounding

### DIFF
--- a/src/main/java/appeng/container/implementations/ContainerCraftConfirm.java
+++ b/src/main/java/appeng/container/implementations/ContainerCraftConfirm.java
@@ -209,8 +209,7 @@ public class ContainerCraftConfirm extends ContainerSubGui implements ICraftingC
                                     Actionable.SIMULATE,
                                     this.getActionSource());
                             long available = (availableStack == null) ? 0 : availableStack.getStackSize();
-                            if (available > 0) toExtract.setUsedPercent(toExtract.getStackSize() / (available / 100f));
-                            else toExtract.setUsedPercent(0f);
+                            toExtract.setUsedPercent(calculateUsedPercent(toExtract.getStackSize(), available));
                         }
 
                         if (toExtract.getStackSize() > 0) {
@@ -259,6 +258,19 @@ public class ContainerCraftConfirm extends ContainerSubGui implements ICraftingC
             this.setJob(null);
         }
         this.verifyPermissions(SecurityPermissions.CRAFT, false);
+    }
+
+    private static float calculateUsedPercent(long used, long available) {
+        if (used <= 0 || available <= 0) {
+            return 0f;
+        }
+        double usedPercent = (double) used * 100.0 / (double) available;
+        usedPercent = Math.max(0.0, Math.min(100.0, usedPercent));
+        double nearestInteger = Math.rint(usedPercent);
+        if (Math.abs(usedPercent - nearestInteger) < 1.0e-6) {
+            usedPercent = nearestInteger;
+        }
+        return (float) usedPercent;
     }
 
     public IGrid getGrid() {


### PR DESCRIPTION
Fixes [#21022](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21022)

## Summary
Fix the crafting plan "From Storage" percentage calculation so exact whole-number values do not display floating-point artifacts on hover.

## Testing
- built with `./gradlew build`
- reproduced the issue in the Crafting Plan screen
- verified the hover now shows the expected rounded percentage for the reproduced case