### PR TITLE
Fix sync condition

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
@@ -239,7 +239,8 @@ public class GuiMEMonitorable extends AEBaseGui
                 this.repo.updateView();
 
                 try {
-                    NetworkHandler.instance.sendToServer(new PacketMonitorableTypeFilter(this.typeFilters));
+                    NetworkHandler.instance
+                            .sendToServer(new PacketMonitorableTypeFilter(this.typeFilters, this.inventorySlots.windowId));
                 } catch (final IOException e) {
                     AELog.debug(e);
                 }

--- a/src/main/java/appeng/core/sync/packets/PacketMonitorableTypeFilter.java
+++ b/src/main/java/appeng/core/sync/packets/PacketMonitorableTypeFilter.java
@@ -20,12 +20,18 @@ import it.unimi.dsi.fastutil.objects.Reference2BooleanOpenHashMap;
 public class PacketMonitorableTypeFilter extends AppEngPacket {
 
     public final Reference2BooleanMap<IAEStackType<?>> map;
+    // windowId is used to validate that a client->server packet belongs to the
+    // currently open container, preventing stale packets from a previously open
+    // terminal from corrupting a different terminal's type filter data.
+    public final int windowId;
 
     public PacketMonitorableTypeFilter(final ByteBuf buf) throws IOException {
         map = new Reference2BooleanOpenHashMap<>();
         for (IAEStackType<?> type : AEStackTypeRegistry.getAllTypes()) {
             this.map.put(type, true);
         }
+
+        this.windowId = buf.readInt();
 
         final int size = buf.readInt();
         for (int i = 0; i < size; i++) {
@@ -38,12 +44,20 @@ public class PacketMonitorableTypeFilter extends AppEngPacket {
         }
     }
 
+    // Constructor used by server->client (no windowId needed; windowId=-1 is a sentinel)
     public PacketMonitorableTypeFilter(Reference2BooleanMap<IAEStackType<?>> map) throws IOException {
+        this(map, -1);
+    }
+
+    // Constructor used by client->server (includes windowId for validation)
+    public PacketMonitorableTypeFilter(Reference2BooleanMap<IAEStackType<?>> map, int windowId) throws IOException {
         this.map = null;
+        this.windowId = -1;
 
         final ByteBuf buf = Unpooled.buffer();
 
         buf.writeInt(this.getPacketID());
+        buf.writeInt(windowId);
         buf.writeInt(map.size());
         for (Reference2BooleanMap.Entry<IAEStackType<?>> entry : map.reference2BooleanEntrySet()) {
             ByteBufUtils.writeUTF8String(buf, entry.getKey().getId());
@@ -63,6 +77,11 @@ public class PacketMonitorableTypeFilter extends AppEngPacket {
     @Override
     public void serverPacketData(INetworkInfo manager, AppEngPacket packet, EntityPlayer player) {
         if (player.openContainer instanceof ContainerMEMonitorable container) {
+            // Reject stale packets: if the windowId doesn't match the current container,
+            // the packet was sent while a different terminal was open and must be discarded.
+            if (this.windowId != -1 && this.windowId != player.openContainer.windowId) {
+                return;
+            }
             container.updateTypeFilters(this.map);
         }
     }


### PR DESCRIPTION
When we use the left button to switch the View Mode, if we switch terminals too quickly, outdated packets may be synced to the new terminal, causing synchronization issues. I wrote a PR to fix this.