### PR TITLE
Fix StackOverflowError in P2P Interface updateCraftingList  

### DIFF
--- a/src/main/java/appeng/parts/p2p/PartP2PInterface.java
+++ b/src/main/java/appeng/parts/p2p/PartP2PInterface.java
@@ -74,10 +74,22 @@ public class PartP2PInterface extends PartP2PTunnelStatic<PartP2PInterface>
         super(is);
     }
 
+    private boolean updatingCraftingList = false;
+
     protected final DualityInterface duality = new DualityInterface(this.getProxy(), this) {
 
         @Override
         public void updateCraftingList() {
+            if (updatingCraftingList) return;
+            updatingCraftingList = true;
+            try {
+                updateCraftingListInner();
+            } finally {
+                updatingCraftingList = false;
+            }
+        }
+
+        private void updateCraftingListInner() {
             if (!isOutput()) {
                 CraftingGridCache.pauseRebuilds();
 


### PR DESCRIPTION
  ### Summary
  - Add recursion guard to `PartP2PInterface`'s overridden `updateCraftingList` to prevent StackOverflowError

  ### Problem
  When multiple P2P Interface outputs share the same frequency and are on the same ME network as the input, `updateCraftingList` can re-enter itself through the grid event bus. The input iterates all outputs, each output posts a `MENetworkCraftingPatternChange` event synchronously via `Grid.postEvent`, and
  this can trigger `updateCraftingList` again on the same or other P2P interfaces on the grid before the first call finishes. This causes infinite recursion and crashes the server with a StackOverflowError.

  This is triggered by MatterManipulator's smart copy feature (array paste with P2P interface replacement), but could happen in any setup where P2P Interface input and outputs end up on the same grid.

### Fix

  Added a `boolean updatingCraftingList` flag on `PartP2PInterface` that prevents re-entrant calls. The flag is set before calling the inner logic and cleared in a `finally` block.