### PR TITLE
Fix buffered leading spaces in terminal search

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
@@ -196,7 +196,7 @@ public class GuiMEMonitorable extends AEBaseGui
             @Override
             public void onTextChange(final String oldText) {
                 final String text = getText();
-                repo.setSearchString(text);
+                repo.setSearchString(text.trim());
                 repo.updateView();
                 setScrollBar();
             }
@@ -944,10 +944,6 @@ public class GuiMEMonitorable extends AEBaseGui
         if (searchField.isFocused() && (key == Keyboard.KEY_RETURN || key == Keyboard.KEY_NUMPADENTER)) {
             searchField.setFocused(false);
             isAutoFocused = false;
-            return;
-        }
-
-        if (character == ' ' && searchField.getText().isEmpty()) {
             return;
         }
 


### PR DESCRIPTION
Previously, if the field was empty, no space was entered. However, because enableRepeatEvents is true, buffering occurs, and when something other than a space is entered, all the spaces up to that point are entered.
This PR removes that behavior and trims it when setting it to ItemRepo.