### PR TITLE
Fix crafting completion sound broadcasting to all nearby players

### DIFF
--- a/src/main/java/appeng/hooks/CraftingNotificationManager.java
+++ b/src/main/java/appeng/hooks/CraftingNotificationManager.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.network.play.server.S29PacketSoundEffect;
 
 import appeng.core.AELog;
 import appeng.core.sync.network.NetworkHandler;
@@ -36,7 +37,8 @@ public class CraftingNotificationManager {
 
                     player.addChatMessage(notification.createMessage());
                 }
-                player.worldObj.playSoundAtEntity(player, "random.levelup", 1f, 1f);
+                ((EntityPlayerMP) player).playerNetServerHandler.sendPacket(
+                        new S29PacketSoundEffect("random.levelup", player.posX, player.posY, player.posZ, 1f, 1f));
             }
         }
     }

--- a/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
+++ b/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
@@ -46,6 +46,7 @@ import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.nbt.NBTTagString;
+import net.minecraft.network.play.server.S29PacketSoundEffect;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ChatComponentText;
@@ -199,7 +200,14 @@ public final class CraftingCPUCluster implements IAECluster, ICraftingCPU {
                             }
 
                             player.addChatMessage(notification.createMessage());
-                            player.worldObj.playSoundAtEntity(player, "random.levelup", 1f, 1f);
+                            ((EntityPlayerMP) player).playerNetServerHandler.sendPacket(
+                                    new S29PacketSoundEffect(
+                                            "random.levelup",
+                                            player.posX,
+                                            player.posY,
+                                            player.posZ,
+                                            1f,
+                                            1f));
                         } else {
                             this.unreadNotifications.computeIfAbsent(playerName, name -> new ArrayList<>())
                                     .add(notification);


### PR DESCRIPTION
## Problem
When a crafting job completes, the `random.levelup` sound was played via `World.playSoundAtEntity()`, which on the server side broadcasts the sound packet to all players within hearing range — not just the one who requested the craft.

## Fix
Replace the world-level sound call with a direct `S29PacketSoundEffect`
packet sent only to the specific player's connection, so only the requester
hears the notification sound.