### PR TITLE
Fix config change not updating neighbors

### DIFF
--- a/src/main/java/appeng/helpers/DualityInterface.java
+++ b/src/main/java/appeng/helpers/DualityInterface.java
@@ -395,6 +395,8 @@ public class DualityInterface implements IGridTickable, IStorageMonitorable, IIn
                 // :P
             }
         }
+
+        this.notifyNeighbors();
     }
 
     public void updateCraftingList() {


### PR DESCRIPTION
When changing config the neighbors weren't getting updated. This caused for example a connected subnet's storage bus to show the outdated item contents to its network.