### PR TITLE
Fix importing items getting their types squashed

### DIFF
--- a/src/main/java/appeng/util/inv/AdaptorItemIO.java
+++ b/src/main/java/appeng/util/inv/AdaptorItemIO.java
@@ -78,7 +78,7 @@ public class AdaptorItemIO extends InventoryAdaptor {
 
             if (out == null) {
                 out = stack.toStack(0);
-            }
+            } else if (!stack.matches(out)) continue;
 
             int simulatedTransfer = Math.min(amount, stack.getStackSize());
 

--- a/src/main/java/appeng/util/inv/AdaptorItemIO.java
+++ b/src/main/java/appeng/util/inv/AdaptorItemIO.java
@@ -47,7 +47,7 @@ public class AdaptorItemIO extends InventoryAdaptor {
 
             if (out == null) {
                 out = immutableStack.toStack(0);
-            }
+            } else if (!immutableStack.matches(out)) continue;
 
             ItemStack extracted = iter.extract(amount, false);
 


### PR DESCRIPTION
I noticed that when an import bus (and likely some other parts) is importing from a greg output bus and has enough capacity to grab multiple types of items at a time, it will void the types besides the first one it encountered, adding their amount to the first type.