### PR TITLE
Fixes Interface Terminal hover highlight box

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiInterfaceTerminal.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiInterfaceTerminal.java
@@ -970,7 +970,7 @@ public class GuiInterfaceTerminal extends AEBaseGui
                     // overlay highlight
                     GL11.glDisable(GL11.GL_LIGHTING);
                     GL11.glTranslatef(0.0f, 0.0f, SLOT_HOVER_Z);
-                    drawRect(colLeft, viewY + 1 + rowYTop, -2 + colRight, viewY - 1 + rowYBot, 0x77FFFFFF);
+                    drawRect(colLeft, viewY + 1 + rowYTop, -3 + colRight, viewY - 1 + rowYBot, 0x77FFFFFF);
                     GL11.glTranslatef(0.0f, 0.0f, -SLOT_HOVER_Z);
                     masterList.hoveredEntry = entry;
                     entry.hoveredSlotIdx = slotIdx;


### PR DESCRIPTION
This is mostly invisible with normal gui, so here is example with darker ui resource pack:

Expected hover:
<img width="97" height="82" alt="Pre Normal Hover" src="https://github.com/user-attachments/assets/13b5292a-f042-4f2d-8460-f3ece46888b2" />

Current hover:
<img width="88" height="79" alt="PreBroken" src="https://github.com/user-attachments/assets/00ab778b-ee0b-4d16-b248-3fb5a300230a" />

Fixed hover:
<img width="89" height="75" alt="Pre fix" src="https://github.com/user-attachments/assets/e897734f-2b3d-477d-b05d-58137289b9d3" />

(The line far right)