### PR TITLE
Fix item insertion into parts on different sides

### DIFF
--- a/src/main/java/appeng/util/InventoryAdaptor.java
+++ b/src/main/java/appeng/util/InventoryAdaptor.java
@@ -176,14 +176,12 @@ public abstract class InventoryAdaptor implements Iterable<ItemSlot> {
             
             if (invs && sided.getSizeInventory() > 0 && slots != null && slots.length > 0) {
                 return new AdaptorIInventory(new WrapperMCISidedInventory(sided, d));
+            } else {
+                return null;
             }
         }
 
-        if (tanks && te instanceof IFluidHandler tank && !(tank.getTankInfo(d) == null || !(tank.getTankInfo(d).length > 0))) {
-            return new AdaptorFluidHandler(tank, d);
-        }
-
-        if (invs && !(te instanceof ISidedInventory) && te instanceof IInventory i && i.getSizeInventory() > 0) {
+        if (invs && te instanceof IInventory i && i.getSizeInventory() > 0) {
             return new AdaptorIInventory(i);
         }
         // spotless:on

--- a/src/main/java/appeng/util/InventoryAdaptor.java
+++ b/src/main/java/appeng/util/InventoryAdaptor.java
@@ -132,6 +132,10 @@ public abstract class InventoryAdaptor implements Iterable<ItemSlot> {
 
             if (te instanceof TileCableBus cableBus) {
                 IPart part = cableBus.getPart(d);
+                if (part == null) {
+                    return null;
+                }
+
                 if (invs && part instanceof IInterfaceHost host) {
                     return new AdaptorDualityInterface(new WrapperMCISidedInventory(sided, d), host);
                 }
@@ -179,7 +183,7 @@ public abstract class InventoryAdaptor implements Iterable<ItemSlot> {
             return new AdaptorFluidHandler(tank, d);
         }
 
-        if (invs && te instanceof IInventory i && i.getSizeInventory() > 0) {
+        if (invs && !(te instanceof ISidedInventory) && te instanceof IInventory i && i.getSizeInventory() > 0) {
             return new AdaptorIInventory(i);
         }
         // spotless:on


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/issues/1249

This method should return null when getAccessibleSlotsFromSide returns an empty array, but it was continuing so that IFluidHandler could still be handled.
As a result, AdaptorIInventory was returned, but it ignores getAccessibleSlotsFromSide, which allowed items to be inserted into parts on the wrong side.

Also, since TileCableBus does not have an inventory itself, this PR now returns null immediately when there is no part on that side.