### PR TITLE
Fix gui closed when inv keybind pressed while text field in focus

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiAmount.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiAmount.java
@@ -183,9 +183,7 @@ public abstract class GuiAmount extends GuiSub {
         if (!this.checkHotbarKeys(key)) {
             if (key == Keyboard.KEY_RETURN || key == Keyboard.KEY_NUMPADENTER) {
                 this.actionPerformed(this.nextBtn);
-            }
-            this.amountTextField.textboxKeyTyped(character, key);
-            super.keyTyped(character, key);
+            } else if (!this.amountTextField.textboxKeyTyped(character, key)) super.keyTyped(character, key);
         }
     }
 


### PR DESCRIPTION
Seems only this gui affected
Closes: https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/issues/1133