### PR TITLE
clear view helper player on each dimension change

### DIFF
--- a/src/main/java/appeng/client/render/previewBlocks/BlockRendererPreviewEvent.java
+++ b/src/main/java/appeng/client/render/previewBlocks/BlockRendererPreviewEvent.java
@@ -4,6 +4,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.event.RenderWorldLastEvent;
+import net.minecraftforge.event.world.WorldEvent;
 
 import appeng.core.AEConfig;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
@@ -28,7 +29,6 @@ public class BlockRendererPreviewEvent {
         if (AEConfig.instance.previewBlocks) {
             EntityPlayer player = Minecraft.getMinecraft().thePlayer;
             if (player == null) {
-                ViewHelper.setPlayer(null);
                 return;
             }
 
@@ -47,6 +47,14 @@ public class BlockRendererPreviewEvent {
             ViewHelper.setPlayer(player);
             ViewHelper.setCachedItemStack(currentItem);
             ViewHelper.updatePreview(player);
+        }
+    }
+
+    @SubscribeEvent
+    public void onWorldUnload(WorldEvent.Unload event) {
+        if (event.world.isRemote) {
+            ViewHelper.setPlayer(null);
+            ViewHelper.clearCache();
         }
     }
 


### PR DESCRIPTION
to prevent leaking the previous world when swaping dimensions