### PR TITLE
Add 1-tick caching to DualityInterface.isBusy() to prevent repeated target scans within a single tick

### DIFF
--- a/src/main/java/appeng/helpers/DualityInterface.java
+++ b/src/main/java/appeng/helpers/DualityInterface.java
@@ -1362,8 +1362,11 @@ public class DualityInterface implements IGridTickable, IStorageMonitorable, IIn
         final int currentTick = getCurrentServerTick();
         if (currentTick != Integer.MIN_VALUE) {
             final long cache = this.busyCache;
-            if ((int) (cache >>> 1) == currentTick) {
-                return (cache & 1L) != 0L;
+            // we specifically only return if busy to prevent the case where multiple try to
+            // happen in a tick which may update the busy state.
+            // since this evaluation is done in onPostTick, it is highly unlikely that we become un-busy this exact tick
+            if ((int) (cache >>> 1) == currentTick && (cache & 1L) != 0L) {
+                return true;
             }
         }
 

--- a/src/main/java/appeng/helpers/DualityInterface.java
+++ b/src/main/java/appeng/helpers/DualityInterface.java
@@ -38,6 +38,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.util.Vec3;
@@ -171,6 +172,7 @@ public class DualityInterface implements IGridTickable, IStorageMonitorable, IIn
     private int lastInputHash = 0;
     private final boolean isFluidInterface;
     private ScheduledReason scheduledReason = ScheduledReason.UNDEFINED;
+    private long busyCache = Long.MIN_VALUE;
     public boolean somethingStuck = false;
 
     public DualityInterface(final AENetworkProxy networkProxy, final IInterfaceHost ih) {
@@ -1357,9 +1359,17 @@ public class DualityInterface implements IGridTickable, IStorageMonitorable, IIn
 
     @Override
     public boolean isBusy() {
+        final int currentTick = getCurrentServerTick();
+        if (currentTick != Integer.MIN_VALUE) {
+            final long cache = this.busyCache;
+            if ((int) (cache >>> 1) == currentTick) {
+                return (cache & 1L) != 0L;
+            }
+        }
+
         if (this.hasItemsToSend()) {
             scheduledReason = ScheduledReason.SOMETHING_STUCK;
-            return true;
+            return this.cacheBusyResult(currentTick, true);
         }
 
         boolean busy = false;
@@ -1399,6 +1409,21 @@ public class DualityInterface implements IGridTickable, IStorageMonitorable, IIn
             busy = true;
         }
 
+        return this.cacheBusyResult(currentTick, busy);
+    }
+
+    private static int getCurrentServerTick() {
+        final MinecraftServer server = MinecraftServer.getServer();
+        if (server == null) {
+            return Integer.MIN_VALUE;
+        }
+        return server.getTickCounter();
+    }
+
+    private boolean cacheBusyResult(final int currentTick, final boolean busy) {
+        if (currentTick != Integer.MIN_VALUE) {
+            this.busyCache = (((long) currentTick) << 1) | (busy ? 1L : 0L);
+        }
         return busy;
     }
 

--- a/src/main/java/appeng/helpers/DualityInterface.java
+++ b/src/main/java/appeng/helpers/DualityInterface.java
@@ -1409,6 +1409,21 @@ public class DualityInterface implements IGridTickable, IStorageMonitorable, IIn
             busy = true;
         }
 
+        return busy ? this.cacheBusyResult(currentTick, busy) : busy;
+    }
+
+    private static int getCurrentServerTick() {
+        final MinecraftServer server = MinecraftServer.getServer();
+        if (server == null) {
+            return Integer.MIN_VALUE;
+        }
+        return server.getTickCounter();
+    }
+
+    private boolean cacheBusyResult(final int currentTick, final boolean busy) {
+        if (currentTick != Integer.MIN_VALUE) {
+            this.busyCache = (((long) currentTick) << 1) | (busy ? 1L : 0L);
+        }
         return this.cacheBusyResult(currentTick, busy);
     }
 

--- a/src/main/java/appeng/helpers/DualityInterface.java
+++ b/src/main/java/appeng/helpers/DualityInterface.java
@@ -1427,21 +1427,6 @@ public class DualityInterface implements IGridTickable, IStorageMonitorable, IIn
         if (currentTick != Integer.MIN_VALUE) {
             this.busyCache = (((long) currentTick) << 1) | (busy ? 1L : 0L);
         }
-        return this.cacheBusyResult(currentTick, busy);
-    }
-
-    private static int getCurrentServerTick() {
-        final MinecraftServer server = MinecraftServer.getServer();
-        if (server == null) {
-            return Integer.MIN_VALUE;
-        }
-        return server.getTickCounter();
-    }
-
-    private boolean cacheBusyResult(final int currentTick, final boolean busy) {
-        if (currentTick != Integer.MIN_VALUE) {
-            this.busyCache = (((long) currentTick) << 1) | (busy ? 1L : 0L);
-        }
         return busy;
     }
 


### PR DESCRIPTION
`DualityInterface.isBusy()` is checked many times in a single tick when running multiple crafting CPU clusters. This change only caches the busy state for interfaces that are actually busy and so doesn't not return "not busy" to remove the possibility of multiple pushPattern's happening in a single tick when the interface should have been busy.


<img width="740" height="210" alt="image" src="https://github.com/user-attachments/assets/b97fa5ee-6f0e-467d-82d8-0a00d2c72a62" />

This should go down to roughly 3-5 ms for our 150k co-processors across 60 crafting CPUs all fighting for 100+ ALs