### PR TITLE
[Fix] cycling pattern repeaters crashing

### DIFF
--- a/src/main/java/appeng/parts/misc/PartPatternRepeater.java
+++ b/src/main/java/appeng/parts/misc/PartPatternRepeater.java
@@ -61,6 +61,7 @@ import appeng.api.util.DimensionalCoord;
 import appeng.client.texture.CableBusTextures;
 import appeng.core.localization.PlayerMessages;
 import appeng.helpers.Reflected;
+import appeng.me.Grid;
 import appeng.me.GridAccessException;
 import appeng.me.cache.CraftingGridCache;
 import appeng.me.cache.NetworkMonitor;
@@ -286,6 +287,22 @@ public class PartPatternRepeater extends PartBasicState
                 if (ppr.provider) return;
                 final IGridNode gn = tcb.getGridNode(ForgeDirection.UNKNOWN);
                 if (gn == null) return;
+
+                try {
+                    for (Grid network : ppr.getProxy().getGrid()
+                            .getAllRecursiveGridConnections(PartPatternRepeater.class)) {
+                        if (network == this.getProxy().getGrid()) {
+                            this.targetCraftingGrid = null;
+                            this.targetNetworkProxy = null;
+                            this.pairPatternRepeater = null;
+                            this.currentCraftingGrid = null;
+                            this.duringFletchPatterns = false;
+                            return;
+                        }
+                    }
+                } catch (final GridAccessException e) {
+                    // :P
+                }
 
                 this.duringFletchPatterns = true;
 


### PR DESCRIPTION
fixes 
```
java.lang.StackOverflowError
    at java.util.WeakHashMap.matchesKey(WeakHashMap.java:294)
    at java.util.WeakHashMap.put(WeakHashMap.java:466)
    at java.util.Collections$SetFromMap.add(Collections.java:5930)
    at java.util.Collections$SynchronizedCollection.add(Collections.java:2325)
    at net.glease.healer.Healer$LoggerContextFactoryProxy.invoke(Healer.java:244)
    at jdk.proxy4.$Proxy82.getContext(Unknown Source)
    at org.apache.logging.log4j.LogManager.getLogger(LogManager.java:387)
    at appeng.core.AELog.getLogger(AELog.java:46)
    at appeng.core.AELog.log(AELog.java:93)
    at appeng.core.AELog.error(AELog.java:186)
    at appeng.me.NetworkEventBus$EventMethod.invoke(NetworkEventBus.java:144)
    at appeng.me.NetworkEventBus$EventMethod.access$400(NetworkEventBus.java:128)
    at appeng.me.NetworkEventBus$MENetworkEventInfo.invoke(NetworkEventBus.java:167)
    at appeng.me.NetworkEventBus$MENetworkEventInfo.access$200(NetworkEventBus.java:157)
    at appeng.me.NetworkEventBus.postEvent(NetworkEventBus.java:86)
    at appeng.me.Grid.postEvent(Grid.java:196)
    at appeng.parts.misc.PartPatternRepeater.init(PartPatternRepeater.java:296)
    at appeng.parts.misc.PartPatternRepeater.onPostPatternChange(PartPatternRepeater.java:408)
    at appeng.me.cache.CraftingGridCache.updatePatterns(CraftingGridCache.java:279)
    at appeng.me.cache.CraftingGridCache.unpauseRebuilds(CraftingGridCache.java:241)
    at appeng.me.Grid.postEvent(Grid.java:197)
```
caused by having any cycle with pattern repeaters on the same or across several networks