### PR TITLE
Fix pattern repeater CME

### DIFF
--- a/src/main/java/appeng/me/cache/CraftingGridCache.java
+++ b/src/main/java/appeng/me/cache/CraftingGridCache.java
@@ -275,7 +275,8 @@ public class CraftingGridCache
             this.storageGrid.postAlterationOfStoredItems(type, list, new BaseActionSource());
         }
 
-        for (final ICraftingPostPatternChangeListener listener : this.postPatternChangeListeners) {
+        for (final ICraftingPostPatternChangeListener listener : ImmutableList
+                .copyOf(this.postPatternChangeListeners)) {
             listener.onPostPatternChange();
         }
     }

--- a/src/main/java/appeng/parts/misc/PartPatternRepeater.java
+++ b/src/main/java/appeng/parts/misc/PartPatternRepeater.java
@@ -265,11 +265,11 @@ public class PartPatternRepeater extends PartBasicState
 
     public void init() {
         if (this.duringFletchPatterns) return;
+        this.unregisterPostPatternChangeListener();
         this.craftingList.clear();
         this.targetCraftingGrid = null;
         this.targetNetworkProxy = null;
         this.pairPatternRepeater = null;
-        this.currentCraftingGrid = null;
 
         final TileEntity self = this.getHost().getTile();
         final TileEntity target = self.getWorldObj().getTileEntity(
@@ -422,7 +422,7 @@ public class PartPatternRepeater extends PartBasicState
 
     @Override
     public void getDrops(List<ItemStack> drops, boolean wrenched) {
-        if (this.currentCraftingGrid != null) this.currentCraftingGrid.removePostPatternChangeListeners(this);
+        this.unregisterPostPatternChangeListener();
         if (this.targetNetworkProxy != null) try {
             if (this.targetNetworkProxy.getStorage().getItemInventory() instanceof NetworkMonitor<?>nm) {
                 nm.removeStorageInterceptor(this);
@@ -433,6 +433,13 @@ public class PartPatternRepeater extends PartBasicState
         } catch (GridAccessException ignored) {}
 
         super.getDrops(drops, wrenched);
+    }
+
+    private void unregisterPostPatternChangeListener() {
+        if (this.currentCraftingGrid != null) {
+            this.currentCraftingGrid.removePostPatternChangeListeners(this);
+            this.currentCraftingGrid = null;
+        }
     }
 
     public boolean isProvider() {


### PR DESCRIPTION
Fixes 
<img width="984" height="207" alt="image" src="https://github.com/user-attachments/assets/c85693cf-0598-4a9d-af39-bd91296334df" />

How to reproduce:
1. Create a new ME network.
2. Place one Pattern Repeater P.
    - Do not place another Pattern Repeater in front of it yet.
3. Use a wrench on P to switch it to Provider mode.
    - This is important: switch it to Provider while it has no paired repeater.
    - This keeps P from being registered as a listener beforehand.
4. Place another Pattern Repeater A directly in front of P.
    - A should remain in the default Accessor mode.
    - P and A must be on the same ME network.
5. Add several more Pattern Repeater pairs on the same ME network where the Accessor side is already registered.
    - In practice, create multiple pairs like Accessor <-> Provider.
    - More registered Accessors makes the crash easier to trigger.
6. Use a wrench on P to switch it from Provider mode back to Accessor mode.