### PR TITLE
Delete redundant color call from lang files

### DIFF
--- a/src/main/resources/assets/appliedenergistics2/lang/cs_CZ.lang
+++ b/src/main/resources/assets/appliedenergistics2/lang/cs_CZ.lang
@@ -389,19 +389,6 @@ gui.appliedenergistics2.BytesPerType=Bytes per type:
 gui.appliedenergistics2.SelectColor=Select a Color
 gui.appliedenergistics2.Selected=Selected
 
-# GUI Colors - ARGB
-gui.color.appliedenergistics2.SearchboxFocused=6E000000
-gui.color.appliedenergistics2.SearchboxUnfocused=00000000
-gui.color.appliedenergistics2.ItemSlotOverlayUnpowered=66111111
-gui.color.appliedenergistics2.ItemSlotOverlayInvalid=66ff6666
-gui.color.appliedenergistics2.CraftConfirmMissingItem=1AFF0000
-gui.color.appliedenergistics2.CraftingCPUActive=5A45A021
-gui.color.appliedenergistics2.CraftingCPUScheduled=FF787878
-gui.color.appliedenergistics2.InterfaceTerminalMatch=2A00FF00
-gui.color.appliedenergistics2.ProcessBarStartColor=FFE60A00
-gui.color.appliedenergistics2.ProcessBarMiddleColor=FFE6E600
-gui.color.appliedenergistics2.ProcessBarEndColor=FF0AE600
-
 # GUI Tooltips
 gui.tooltips.appliedenergistics2.Stash=Ukládá předměty
 gui.tooltips.appliedenergistics2.StashDesc=Navrátí předměty z výrobního pole zpět do síťového úložiště.

--- a/src/main/resources/assets/appliedenergistics2/lang/de_DE.lang
+++ b/src/main/resources/assets/appliedenergistics2/lang/de_DE.lang
@@ -389,19 +389,6 @@ gui.appliedenergistics2.BytesPerType=Bytes per type:
 gui.appliedenergistics2.SelectColor=Select a Color
 gui.appliedenergistics2.Selected=Selected
 
-# GUI Colors - ARGB
-gui.color.appliedenergistics2.SearchboxFocused=6E000000
-gui.color.appliedenergistics2.SearchboxUnfocused=00000000
-gui.color.appliedenergistics2.ItemSlotOverlayUnpowered=66111111
-gui.color.appliedenergistics2.ItemSlotOverlayInvalid=66ff6666
-gui.color.appliedenergistics2.CraftConfirmMissingItem=1AFF0000
-gui.color.appliedenergistics2.CraftingCPUActive=5A45A021
-gui.color.appliedenergistics2.CraftingCPUScheduled=FF787878
-gui.color.appliedenergistics2.InterfaceTerminalMatch=2A00FF00
-gui.color.appliedenergistics2.ProcessBarStartColor=FFE60A00
-gui.color.appliedenergistics2.ProcessBarMiddleColor=FFE6E600
-gui.color.appliedenergistics2.ProcessBarEndColor=FF0AE600
-
 # GUI Tooltips
 gui.tooltips.appliedenergistics2.Stash=Items lagern
 gui.tooltips.appliedenergistics2.StashDesc=Items aus dem Fertigungsgitter in Netzwerkspeicher zurücksenden.

--- a/src/main/resources/assets/appliedenergistics2/lang/en_GB.lang
+++ b/src/main/resources/assets/appliedenergistics2/lang/en_GB.lang
@@ -389,19 +389,6 @@ gui.appliedenergistics2.BytesPerType=Bytes per type:
 gui.appliedenergistics2.SelectColor=Select a Color
 gui.appliedenergistics2.Selected=Selected
 
-# GUI Colors - ARGB
-gui.color.appliedenergistics2.SearchboxFocused=6E000000
-gui.color.appliedenergistics2.SearchboxUnfocused=00000000
-gui.color.appliedenergistics2.ItemSlotOverlayUnpowered=66111111
-gui.color.appliedenergistics2.ItemSlotOverlayInvalid=66ff6666
-gui.color.appliedenergistics2.CraftConfirmMissingItem=1AFF0000
-gui.color.appliedenergistics2.CraftingCPUActive=5A45A021
-gui.color.appliedenergistics2.CraftingCPUScheduled=FF787878
-gui.color.appliedenergistics2.InterfaceTerminalMatch=2A00FF00
-gui.color.appliedenergistics2.ProcessBarStartColor=FFE60A00
-gui.color.appliedenergistics2.ProcessBarMiddleColor=FFE6E600
-gui.color.appliedenergistics2.ProcessBarEndColor=FF0AE600
-
 # GUI Tooltips
 gui.tooltips.appliedenergistics2.Stash=Store Items
 gui.tooltips.appliedenergistics2.StashDesc=Return items on the crafting grid to network storage.

--- a/src/main/resources/assets/appliedenergistics2/lang/en_US.lang
+++ b/src/main/resources/assets/appliedenergistics2/lang/en_US.lang
@@ -504,19 +504,6 @@ gui.appliedenergistics2.itemMEStackPacketDesc2=Make sure you have free space and
 
 gui.appliedenergistics2.WirelessManagerToolTips=Network\n§6LClick§7 - Select\n §6+ WirelessExtraAction§7 - Rename\n §6+ Sneak§7 - Remove
 
-# GUI Colors - ARGB
-gui.color.appliedenergistics2.SearchboxFocused=6E000000
-gui.color.appliedenergistics2.SearchboxUnfocused=00000000
-gui.color.appliedenergistics2.ItemSlotOverlayUnpowered=66111111
-gui.color.appliedenergistics2.ItemSlotOverlayInvalid=66ff6666
-gui.color.appliedenergistics2.CraftConfirmMissingItem=1AFF0000
-gui.color.appliedenergistics2.CraftingCPUActive=5A45A021
-gui.color.appliedenergistics2.CraftingCPUScheduled=FF787878
-gui.color.appliedenergistics2.InterfaceTerminalMatch=2A00FF00
-gui.color.appliedenergistics2.ProcessBarStartColor=FFE60A00
-gui.color.appliedenergistics2.ProcessBarMiddleColor=FFE6E600
-gui.color.appliedenergistics2.ProcessBarEndColor=FF0AE600
-
 # GUI Tooltips
 gui.tooltips.appliedenergistics2.Stash=Store Items
 gui.tooltips.appliedenergistics2.StashDesc=Return items on the crafting grid to network storage.

--- a/src/main/resources/assets/appliedenergistics2/lang/es_ES.lang
+++ b/src/main/resources/assets/appliedenergistics2/lang/es_ES.lang
@@ -389,19 +389,6 @@ gui.appliedenergistics2.BytesPerType=Bytes per type:
 gui.appliedenergistics2.SelectColor=Select a Color
 gui.appliedenergistics2.Selected=Selected
 
-# GUI Colors - ARGB
-gui.color.appliedenergistics2.SearchboxFocused=6E000000
-gui.color.appliedenergistics2.SearchboxUnfocused=00000000
-gui.color.appliedenergistics2.ItemSlotOverlayUnpowered=66111111
-gui.color.appliedenergistics2.ItemSlotOverlayInvalid=66ff6666
-gui.color.appliedenergistics2.CraftConfirmMissingItem=1AFF0000
-gui.color.appliedenergistics2.CraftingCPUActive=5A45A021
-gui.color.appliedenergistics2.CraftingCPUScheduled=FF787878
-gui.color.appliedenergistics2.InterfaceTerminalMatch=2A00FF00
-gui.color.appliedenergistics2.ProcessBarStartColor=FFE60A00
-gui.color.appliedenergistics2.ProcessBarMiddleColor=FFE6E600
-gui.color.appliedenergistics2.ProcessBarEndColor=FF0AE600
-
 # GUI Tooltips
 gui.tooltips.appliedenergistics2.Stash=Objetos Almacenados
 gui.tooltips.appliedenergistics2.StashDesc=Devolver objetos al almacenamiento.

--- a/src/main/resources/assets/appliedenergistics2/lang/fr_FR.lang
+++ b/src/main/resources/assets/appliedenergistics2/lang/fr_FR.lang
@@ -389,19 +389,6 @@ gui.appliedenergistics2.BytesPerType=Bytes per type:
 gui.appliedenergistics2.SelectColor=Select a Color
 gui.appliedenergistics2.Selected=Selected
 
-# GUI Colors - ARGB
-gui.color.appliedenergistics2.SearchboxFocused=6E000000
-gui.color.appliedenergistics2.SearchboxUnfocused=00000000
-gui.color.appliedenergistics2.ItemSlotOverlayUnpowered=66111111
-gui.color.appliedenergistics2.ItemSlotOverlayInvalid=66ff6666
-gui.color.appliedenergistics2.CraftConfirmMissingItem=1AFF0000
-gui.color.appliedenergistics2.CraftingCPUActive=5A45A021
-gui.color.appliedenergistics2.CraftingCPUScheduled=FF787878
-gui.color.appliedenergistics2.InterfaceTerminalMatch=2A00FF00
-gui.color.appliedenergistics2.ProcessBarStartColor=FFE60A00
-gui.color.appliedenergistics2.ProcessBarMiddleColor=FFE6E600
-gui.color.appliedenergistics2.ProcessBarEndColor=FF0AE600
-
 # GUI Tooltips
 gui.tooltips.appliedenergistics2.Stash=Stocke des objets
 gui.tooltips.appliedenergistics2.StashDesc=Renvoie les objets de la grille de fabrication dans le réseau.

--- a/src/main/resources/assets/appliedenergistics2/lang/hu_HU.lang
+++ b/src/main/resources/assets/appliedenergistics2/lang/hu_HU.lang
@@ -389,19 +389,6 @@ gui.appliedenergistics2.BytesPerType=Bytes per type:
 gui.appliedenergistics2.SelectColor=Select a Color
 gui.appliedenergistics2.Selected=Selected
 
-# GUI Colors - ARGB
-gui.color.appliedenergistics2.SearchboxFocused=6E000000
-gui.color.appliedenergistics2.SearchboxUnfocused=00000000
-gui.color.appliedenergistics2.ItemSlotOverlayUnpowered=66111111
-gui.color.appliedenergistics2.ItemSlotOverlayInvalid=66ff6666
-gui.color.appliedenergistics2.CraftConfirmMissingItem=1AFF0000
-gui.color.appliedenergistics2.CraftingCPUActive=5A45A021
-gui.color.appliedenergistics2.CraftingCPUScheduled=FF787878
-gui.color.appliedenergistics2.InterfaceTerminalMatch=2A00FF00
-gui.color.appliedenergistics2.ProcessBarStartColor=FFE60A00
-gui.color.appliedenergistics2.ProcessBarMiddleColor=FFE6E600
-gui.color.appliedenergistics2.ProcessBarEndColor=FF0AE600
-
 # GUI Tooltips
 gui.tooltips.appliedenergistics2.Stash=Tárgyak raktározása
 gui.tooltips.appliedenergistics2.StashDesc=A tárgyak barkácsfelületről való hálózatba helyezése.

--- a/src/main/resources/assets/appliedenergistics2/lang/it_IT.lang
+++ b/src/main/resources/assets/appliedenergistics2/lang/it_IT.lang
@@ -389,19 +389,6 @@ gui.appliedenergistics2.BytesPerType=Bytes per type:
 gui.appliedenergistics2.SelectColor=Select a Color
 gui.appliedenergistics2.Selected=Selected
 
-# GUI Colors - ARGB
-gui.color.appliedenergistics2.SearchboxFocused=6E000000
-gui.color.appliedenergistics2.SearchboxUnfocused=00000000
-gui.color.appliedenergistics2.ItemSlotOverlayUnpowered=66111111
-gui.color.appliedenergistics2.ItemSlotOverlayInvalid=66ff6666
-gui.color.appliedenergistics2.CraftConfirmMissingItem=1AFF0000
-gui.color.appliedenergistics2.CraftingCPUActive=5A45A021
-gui.color.appliedenergistics2.CraftingCPUScheduled=FF787878
-gui.color.appliedenergistics2.InterfaceTerminalMatch=2A00FF00
-gui.color.appliedenergistics2.ProcessBarStartColor=FFE60A00
-gui.color.appliedenergistics2.ProcessBarMiddleColor=FFE6E600
-gui.color.appliedenergistics2.ProcessBarEndColor=FF0AE600
-
 # GUI Tooltips
 gui.tooltips.appliedenergistics2.Stash=Oggetti immagazinati
 gui.tooltips.appliedenergistics2.StashDesc=Manda gli oggetti sulla griglia di fabbricazione nel deposito del sistema.

--- a/src/main/resources/assets/appliedenergistics2/lang/ja_JP.lang
+++ b/src/main/resources/assets/appliedenergistics2/lang/ja_JP.lang
@@ -389,19 +389,6 @@ gui.appliedenergistics2.BytesPerType=Bytes per type:
 gui.appliedenergistics2.SelectColor=Select a Color
 gui.appliedenergistics2.Selected=Selected
 
-# GUI Colors - ARGB
-gui.color.appliedenergistics2.SearchboxFocused=6E000000
-gui.color.appliedenergistics2.SearchboxUnfocused=00000000
-gui.color.appliedenergistics2.ItemSlotOverlayUnpowered=66111111
-gui.color.appliedenergistics2.ItemSlotOverlayInvalid=66ff6666
-gui.color.appliedenergistics2.CraftConfirmMissingItem=1AFF0000
-gui.color.appliedenergistics2.CraftingCPUActive=5A45A021
-gui.color.appliedenergistics2.CraftingCPUScheduled=FF787878
-gui.color.appliedenergistics2.InterfaceTerminalMatch=2A00FF00
-gui.color.appliedenergistics2.ProcessBarStartColor=FFE60A00
-gui.color.appliedenergistics2.ProcessBarMiddleColor=FFE6E600
-gui.color.appliedenergistics2.ProcessBarEndColor=FF0AE600
-
 # GUI Tooltips
 gui.tooltips.appliedenergistics2.Stash=Store Items
 gui.tooltips.appliedenergistics2.StashDesc=Return items on the crafting grid to network storage.

--- a/src/main/resources/assets/appliedenergistics2/lang/ko_KR.lang
+++ b/src/main/resources/assets/appliedenergistics2/lang/ko_KR.lang
@@ -389,19 +389,6 @@ gui.appliedenergistics2.BytesPerType=Bytes per type:
 gui.appliedenergistics2.SelectColor=Select a Color
 gui.appliedenergistics2.Selected=Selected
 
-# GUI Colors - ARGB
-gui.color.appliedenergistics2.SearchboxFocused=6E000000
-gui.color.appliedenergistics2.SearchboxUnfocused=00000000
-gui.color.appliedenergistics2.ItemSlotOverlayUnpowered=66111111
-gui.color.appliedenergistics2.ItemSlotOverlayInvalid=66ff6666
-gui.color.appliedenergistics2.CraftConfirmMissingItem=1AFF0000
-gui.color.appliedenergistics2.CraftingCPUActive=5A45A021
-gui.color.appliedenergistics2.CraftingCPUScheduled=FF787878
-gui.color.appliedenergistics2.InterfaceTerminalMatch=2A00FF00
-gui.color.appliedenergistics2.ProcessBarStartColor=FFE60A00
-gui.color.appliedenergistics2.ProcessBarMiddleColor=FFE6E600
-gui.color.appliedenergistics2.ProcessBarEndColor=FF0AE600
-
 # GUI Tooltips
 gui.tooltips.appliedenergistics2.Stash=Store Items
 gui.tooltips.appliedenergistics2.StashDesc=Return items on the crafting grid to network storage.

--- a/src/main/resources/assets/appliedenergistics2/lang/pt_BR.lang
+++ b/src/main/resources/assets/appliedenergistics2/lang/pt_BR.lang
@@ -389,19 +389,6 @@ gui.appliedenergistics2.BytesPerType=Bytes per type:
 gui.appliedenergistics2.SelectColor=Select a Color
 gui.appliedenergistics2.Selected=Selected
 
-# GUI Colors - ARGB
-gui.color.appliedenergistics2.SearchboxFocused=6E000000
-gui.color.appliedenergistics2.SearchboxUnfocused=00000000
-gui.color.appliedenergistics2.ItemSlotOverlayUnpowered=66111111
-gui.color.appliedenergistics2.ItemSlotOverlayInvalid=66ff6666
-gui.color.appliedenergistics2.CraftConfirmMissingItem=1AFF0000
-gui.color.appliedenergistics2.CraftingCPUActive=5A45A021
-gui.color.appliedenergistics2.CraftingCPUScheduled=FF787878
-gui.color.appliedenergistics2.InterfaceTerminalMatch=2A00FF00
-gui.color.appliedenergistics2.ProcessBarStartColor=FFE60A00
-gui.color.appliedenergistics2.ProcessBarMiddleColor=FFE6E600
-gui.color.appliedenergistics2.ProcessBarEndColor=FF0AE600
-
 # GUI Tooltips
 gui.tooltips.appliedenergistics2.Stash=Armazenar Itens
 gui.tooltips.appliedenergistics2.StashDesc=Retorna itens na grade de fabricação à rede de armazenamento.

--- a/src/main/resources/assets/appliedenergistics2/lang/ro_RO.lang
+++ b/src/main/resources/assets/appliedenergistics2/lang/ro_RO.lang
@@ -389,19 +389,6 @@ gui.appliedenergistics2.BytesPerType=Bytes per type:
 gui.appliedenergistics2.SelectColor=Select a Color
 gui.appliedenergistics2.Selected=Selected
 
-# GUI Colors - ARGB
-gui.color.appliedenergistics2.SearchboxFocused=6E000000
-gui.color.appliedenergistics2.SearchboxUnfocused=00000000
-gui.color.appliedenergistics2.ItemSlotOverlayUnpowered=66111111
-gui.color.appliedenergistics2.ItemSlotOverlayInvalid=66ff6666
-gui.color.appliedenergistics2.CraftConfirmMissingItem=1AFF0000
-gui.color.appliedenergistics2.CraftingCPUActive=5A45A021
-gui.color.appliedenergistics2.CraftingCPUScheduled=FF787878
-gui.color.appliedenergistics2.InterfaceTerminalMatch=2A00FF00
-gui.color.appliedenergistics2.ProcessBarStartColor=FFE60A00
-gui.color.appliedenergistics2.ProcessBarMiddleColor=FFE6E600
-gui.color.appliedenergistics2.ProcessBarEndColor=FF0AE600
-
 # GUI Tooltips
 gui.tooltips.appliedenergistics2.Stash=Store Items
 gui.tooltips.appliedenergistics2.StashDesc=Return items on the crafting grid to network storage.

--- a/src/main/resources/assets/appliedenergistics2/lang/ru_RU.lang
+++ b/src/main/resources/assets/appliedenergistics2/lang/ru_RU.lang
@@ -393,19 +393,6 @@ gui.appliedenergistics2.BytesPerType=Байтов на тип:
 gui.appliedenergistics2.SelectColor=Select a Color
 gui.appliedenergistics2.Selected=Selected
 
-# GUI Colors - ARGB
-gui.color.appliedenergistics2.SearchboxFocused=6E000000
-gui.color.appliedenergistics2.SearchboxUnfocused=00000000
-gui.color.appliedenergistics2.ItemSlotOverlayUnpowered=66111111
-gui.color.appliedenergistics2.ItemSlotOverlayInvalid=66ff6666
-gui.color.appliedenergistics2.CraftConfirmMissingItem=1AFF0000
-gui.color.appliedenergistics2.CraftingCPUActive=5A45A021
-gui.color.appliedenergistics2.CraftingCPUScheduled=FF787878
-gui.color.appliedenergistics2.InterfaceTerminalMatch=2A00FF00
-gui.color.appliedenergistics2.ProcessBarStartColor=FFE60A00
-gui.color.appliedenergistics2.ProcessBarMiddleColor=FFE6E600
-gui.color.appliedenergistics2.ProcessBarEndColor=FF0AE600
-
 # GUI Tooltips
 gui.tooltips.appliedenergistics2.Stash=Хранить предметы
 gui.tooltips.appliedenergistics2.StashDesc=Возвращает предметы на сетку создания, в сетевое хранилище.

--- a/src/main/resources/assets/appliedenergistics2/lang/uk_UA.lang
+++ b/src/main/resources/assets/appliedenergistics2/lang/uk_UA.lang
@@ -389,19 +389,6 @@ gui.appliedenergistics2.BytesPerType=Байтів на тип:
 gui.appliedenergistics2.SelectColor=Оберіть колір
 gui.appliedenergistics2.Selected=Обрано
 
-# GUI Colors - ARGB
-gui.color.appliedenergistics2.SearchboxFocused=6E000000
-gui.color.appliedenergistics2.SearchboxUnfocused=00000000
-gui.color.appliedenergistics2.ItemSlotOverlayUnpowered=66111111
-gui.color.appliedenergistics2.ItemSlotOverlayInvalid=66ff6666
-gui.color.appliedenergistics2.CraftConfirmMissingItem=1AFF0000
-gui.color.appliedenergistics2.CraftingCPUActive=5A45A021
-gui.color.appliedenergistics2.CraftingCPUScheduled=FF787878
-gui.color.appliedenergistics2.InterfaceTerminalMatch=2A00FF00
-gui.color.appliedenergistics2.ProcessBarStartColor=FFE60A00
-gui.color.appliedenergistics2.ProcessBarMiddleColor=FFE6E600
-gui.color.appliedenergistics2.ProcessBarEndColor=FF0AE600
-
 # GUI Tooltips
 gui.tooltips.appliedenergistics2.Stash=Зберегти предмети
 gui.tooltips.appliedenergistics2.StashDesc=Повернути предмети на сітці створення до мережевого сховища.

--- a/src/main/resources/assets/appliedenergistics2/lang/zh_CN.lang
+++ b/src/main/resources/assets/appliedenergistics2/lang/zh_CN.lang
@@ -391,19 +391,6 @@ gui.appliedenergistics2.BytesPerType=Bytes per type:
 gui.appliedenergistics2.SelectColor=Select a Color
 gui.appliedenergistics2.Selected=Selected
 
-# GUI Colors - ARGB
-gui.color.appliedenergistics2.SearchboxFocused=6E000000
-gui.color.appliedenergistics2.SearchboxUnfocused=00000000
-gui.color.appliedenergistics2.ItemSlotOverlayUnpowered=66111111
-gui.color.appliedenergistics2.ItemSlotOverlayInvalid=66ff6666
-gui.color.appliedenergistics2.CraftConfirmMissingItem=1AFF0000
-gui.color.appliedenergistics2.CraftingCPUActive=5A45A021
-gui.color.appliedenergistics2.CraftingCPUScheduled=FF787878
-gui.color.appliedenergistics2.InterfaceTerminalMatch=2A00FF00
-gui.color.appliedenergistics2.ProcessBarStartColor=FFE60A00
-gui.color.appliedenergistics2.ProcessBarMiddleColor=FFE6E600
-gui.color.appliedenergistics2.ProcessBarEndColor=FF0AE600
-
 # GUI Tooltips
 gui.tooltips.appliedenergistics2.Stash=存储物品
 gui.tooltips.appliedenergistics2.StashDesc=将合成槽的物品返回网络

--- a/src/main/resources/assets/appliedenergistics2/lang/zh_TW.lang
+++ b/src/main/resources/assets/appliedenergistics2/lang/zh_TW.lang
@@ -389,19 +389,6 @@ gui.appliedenergistics2.BytesPerType=Bytes per type:
 gui.appliedenergistics2.SelectColor=Select a Color
 gui.appliedenergistics2.Selected=Selected
 
-# GUI Colors - ARGB
-gui.color.appliedenergistics2.SearchboxFocused=6E000000
-gui.color.appliedenergistics2.SearchboxUnfocused=00000000
-gui.color.appliedenergistics2.ItemSlotOverlayUnpowered=66111111
-gui.color.appliedenergistics2.ItemSlotOverlayInvalid=66ff6666
-gui.color.appliedenergistics2.CraftConfirmMissingItem=1AFF0000
-gui.color.appliedenergistics2.CraftingCPUActive=5A45A021
-gui.color.appliedenergistics2.CraftingCPUScheduled=FF787878
-gui.color.appliedenergistics2.InterfaceTerminalMatch=2A00FF00
-gui.color.appliedenergistics2.ProcessBarStartColor=FFE60A00
-gui.color.appliedenergistics2.ProcessBarMiddleColor=FFE6E600
-gui.color.appliedenergistics2.ProcessBarEndColor=FF0AE600
-
 # GUI Tooltips
 gui.tooltips.appliedenergistics2.Stash=存儲物品
 gui.tooltips.appliedenergistics2.StashDesc=將合成槽的物品返回網絡


### PR DESCRIPTION
They are already loaded from code
Fixes https://github.com/GTNewHorizons/GTNH-Translations/issues/50

Reference:
https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/blob/6b16f9682cf28ef02d922d06b80c5a18b183fef5/src/main/java/appeng/core/localization/GuiColors.java