### PR TITLE
Fix TileIOPart crash

### DIFF
--- a/src/main/java/appeng/util/item/PrioritizedNetworkItemList.java
+++ b/src/main/java/appeng/util/item/PrioritizedNetworkItemList.java
@@ -155,6 +155,19 @@ public class PrioritizedNetworkItemList<T extends IAEStack> extends NetworkItemL
                     }
                     if (result != 0) break;
                 }
+                if (result == 0) {
+                    for (Entry<IMENetworkInventory<T>, Integer> entry : o2.networkPriority.entrySet()) {
+                        int o2Prio = entry.getValue();
+                        Integer o1Prio = o1.getNetworkPriority(entry.getKey());
+                        if (o1Prio != null) {
+                            result = Integer.compare(o1Prio, o2Prio);
+                        }
+                        if (result != 0) break;
+                    }
+                }
+                if (result == 0) {
+                    result = Integer.compare(System.identityHashCode(o1), System.identityHashCode(o2));
+                }
                 return result;
             }
         };


### PR DESCRIPTION
fix https://mclo.gs/nx7MZZx

Cause: TileIOPort.transferContents(), when handling IO port item transfers, calls PrioritizedNetworkItemList.getItems(true) and sorts the result. The Comparator in that method violates Java's transitivity contract for sorting, causing TimSort to throw an IllegalArgumentException.

The old comparator only traverses the network priorities of o1 to compare with o2, returning 0 (treating them as equal) when the two items do not share any common network. This results in a classic transitivity violation.