### PR TITLE
Disable integration when gt6 is present instead of failing loudly

### DIFF
--- a/src/main/java/appeng/integration/modules/GT.java
+++ b/src/main/java/appeng/integration/modules/GT.java
@@ -3,6 +3,7 @@ package appeng.integration.modules;
 import net.minecraft.tileentity.TileEntity;
 
 import appeng.api.AEApi;
+import appeng.api.exceptions.ModNotInstalled;
 import appeng.helpers.Reflected;
 import appeng.integration.IIntegrationModule;
 import appeng.integration.IntegrationHelper;
@@ -10,6 +11,7 @@ import appeng.integration.IntegrationRegistry;
 import appeng.integration.IntegrationType;
 import appeng.integration.abstraction.IGT;
 import appeng.spatial.NBTSpatialHandler;
+import cpw.mods.fml.common.Loader;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 
 public class GT implements IIntegrationModule, IGT {
@@ -20,6 +22,8 @@ public class GT implements IIntegrationModule, IGT {
     @Reflected
     public GT() throws Throwable {
         IntegrationHelper.testClassExistence(this, gregtech.api.interfaces.tileentity.IEnergyConnected.class);
+        String ver = Loader.instance().getIndexedModList().get("gregtech").getVersion();
+        if (ver.contains("GT6-MC1710")) throw new ModNotInstalled("gregtech");
     }
 
     @Override


### PR DESCRIPTION
Followup to #1348: This PR explicitly disables GT integration if GT6 is loaded and allows any other gregtech versions.