### PR TITLE
Attempt to fix the tests by increasing the timeout

### DIFF
--- a/src/functionalTest/java/appeng/test/CraftingV2Tests.java
+++ b/src/functionalTest/java/appeng/test/CraftingV2Tests.java
@@ -42,7 +42,7 @@ public class CraftingV2Tests {
 
     static World dummyWorld = null;
     static boolean mixedMetalTestRecipeRegistered = false;
-    final int SIMPLE_SIMULATION_TIMEOUT_MS = 100;
+    final int SIMPLE_SIMULATION_TIMEOUT_MS = 150;
 
     final ItemStack bronzePlate, bronzeDoublePlate, bronzeIngot, gtHammer, singleUseGtHammer;
     final ItemStack ironDust, ironIngot, ironPlate, goldDust, goldIngot, goldBlock;


### PR DESCRIPTION
Hopefully fixes https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/actions/runs/27093730487/job/79961925346

I guess it timed out because reusing the tool is computationally expensive.