### PR TITLE
Improve copying via memory card

### DIFF
--- a/src/main/java/appeng/block/AEBaseTileBlock.java
+++ b/src/main/java/appeng/block/AEBaseTileBlock.java
@@ -283,7 +283,8 @@ public abstract class AEBaseTileBlock extends AEBaseBlock implements IAEFeature,
                                 ToolMemoryCard.insertUpgrades(data, player, up);
                             }
 
-                            // Apply settings after insertUpgrades to preserve upgrade-gated settings, such as ore filters.
+                            // Apply settings after insertUpgrades to preserve upgrade-gated settings, such as ore
+                            // filters.
                             t.uploadSettings(SettingsFrom.MEMORY_CARD, data);
 
                             memoryCard.notifyUser(player, MemoryCardMessages.SETTINGS_LOADED);

--- a/src/main/java/appeng/block/AEBaseTileBlock.java
+++ b/src/main/java/appeng/block/AEBaseTileBlock.java
@@ -277,12 +277,14 @@ public abstract class AEBaseTileBlock extends AEBaseBlock implements IAEFeature,
                         final NBTTagCompound data = memoryCard.getData(is);
                         if (this.getUnlocalizedName().equals(name)) {
                             final AEBaseTile t = this.getTileEntity(w, x, y, z);
-                            t.uploadSettings(SettingsFrom.MEMORY_CARD, data);
 
                             if (t instanceof IUpgradeableHost iuh && data.hasKey("upgradesList")) {
                                 UpgradeInventory up = (UpgradeInventory) iuh.getInventoryByName("upgrades");
                                 ToolMemoryCard.insertUpgrades(data, player, up);
                             }
+
+                            // Apply settings after insertUpgrades to preserve upgrade-gated settings, such as ore filters.
+                            t.uploadSettings(SettingsFrom.MEMORY_CARD, data);
 
                             memoryCard.notifyUser(player, MemoryCardMessages.SETTINGS_LOADED);
                         } else {

--- a/src/main/java/appeng/items/tools/ToolMemoryCard.java
+++ b/src/main/java/appeng/items/tools/ToolMemoryCard.java
@@ -11,19 +11,22 @@
 package appeng.items.tools;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.Objects;
 
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.Constants.NBT;
+import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.event.ForgeEventFactory;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import com.gtnewhorizon.gtnhlib.item.ItemStackNBT;
 
@@ -36,8 +39,8 @@ import appeng.core.localization.GuiText;
 import appeng.core.localization.PlayerMessages;
 import appeng.items.AEBaseItem;
 import appeng.items.contents.NetworkToolViewer;
-import appeng.items.materials.ItemMultiMaterial;
 import appeng.parts.automation.UpgradeInventory;
+import appeng.util.InventoryAdaptor;
 import appeng.util.Platform;
 
 public class ToolMemoryCard extends AEBaseItem implements IMemoryCard {
@@ -164,61 +167,133 @@ public class ToolMemoryCard extends AEBaseItem implements IMemoryCard {
         }
     }
 
-    public static void insertUpgrades(final NBTTagCompound data, EntityPlayer player, UpgradeInventory up) {
-        NBTTagList tagList = data.getTagList("upgradesList", NBT.TAG_COMPOUND);
-        List<ItemStack> memoryList = new ArrayList<>(Collections.nCopies(tagList.tagCount(), null)); // Preserve order
+    public static void insertUpgrades(final NBTTagCompound data, final EntityPlayer player, final UpgradeInventory up) {
+        if (up == null) {
+            return;
+        }
 
-        for (int i = 0; i < tagList.tagCount(); i++) {
-            if (up.getStackInSlot(i) == null) {
-                ItemStack item = ItemStack.loadItemStackFromNBT(tagList.getCompoundTagAt(i));
-                memoryList.set(i, item);
+        final List<ItemStack> existingUpgrades = takeExistingUpgrades(up);
+
+        try {
+            final NBTTagList tagList = data.getTagList("upgradesList", NBT.TAG_COMPOUND);
+            final int slots = Math.min(tagList.tagCount(), up.getSizeInventory());
+
+            for (int i = 0; i < slots; i++) {
+                final ItemStack requested = ItemStack.loadItemStackFromNBT(tagList.getCompoundTagAt(i));
+                if (requested == null) {
+                    continue;
+                }
+
+                ItemStack resolved = extractUpgrade(existingUpgrades, requested);
+                if (resolved == null) {
+                    resolved = extractUpgradeFromPlayer(player, requested);
+                }
+
+                if (resolved != null) {
+                    up.setInventorySlotContents(i, resolved);
+                }
+            }
+        } finally {
+            for (final ItemStack upgrade : existingUpgrades) {
+                final ItemStack leftOver = insertIntoNetworkTools(player, upgrade);
+                Platform.addToPlayerInvOrDrop(player, leftOver);
+            }
+        }
+    }
+
+    private static List<ItemStack> takeExistingUpgrades(final IInventory upgrades) {
+        final List<ItemStack> existingUpgrades = new ArrayList<>();
+
+        for (int i = 0; i < upgrades.getSizeInventory(); i++) {
+            final ItemStack existing = upgrades.getStackInSlot(i);
+            if (existing == null) {
+                continue;
+            }
+
+            upgrades.setInventorySlotContents(i, null);
+            existingUpgrades.add(existing);
+        }
+
+        return existingUpgrades;
+    }
+
+    @Nullable
+    private static ItemStack insertIntoNetworkTools(final EntityPlayer player, @Nullable ItemStack stack) {
+        for (int i = 0; stack != null && i < player.inventory.getSizeInventory(); i++) {
+            final ItemStack toolStack = player.inventory.getStackInSlot(i);
+            if (toolStack != null && toolStack.getItem() instanceof INetworkToolItem networkTool) {
+                final NetworkToolViewer networkToolInventory = new NetworkToolViewer(
+                        toolStack,
+                        null,
+                        networkTool.getInventorySize());
+                final InventoryAdaptor adaptor = InventoryAdaptor
+                        .getAdaptor(networkToolInventory, ForgeDirection.UNKNOWN);
+                if (adaptor != null) {
+                    stack = adaptor.addItems(stack);
+                }
             }
         }
 
-        if (!memoryList.stream().allMatch(Objects::isNull)) {
-            int resolved = 0;
-            for (int j = 0; j < player.inventory.getSizeInventory(); j++) {
-                ItemStack pi = player.inventory.getStackInSlot(j);
-                if (pi != null) {
-                    if (pi.getItem() instanceof ItemMultiMaterial) {
-                        for (ItemStack is : memoryList) {
-                            if (is != null && is.stackSize > 0 && is.isItemEqual(pi)) {
-                                is.stackSize = 0;
-                                player.inventory.decrStackSize(j, 1);
-                                player.onUpdate();
-                                resolved++;
-                            }
-                        }
+        return stack;
+    }
 
-                        if (resolved == memoryList.size()) break;
-                    } else if (pi.getItem() instanceof INetworkToolItem inti) {
-                        NetworkToolViewer ntv = new NetworkToolViewer(pi, null, inti.getInventorySize());
-                        for (int k = 0; k < ntv.getSizeInventory(); k++) {
-                            ItemStack isv = ntv.getStackInSlot(k);
-                            if (isv != null) {
-                                for (ItemStack is : memoryList) {
-                                    if (is != null && is.stackSize > 0 && is.isItemEqual(isv)) {
-                                        is.stackSize = 0;
-                                        resolved++;
-                                        ntv.decrStackSize(k, 1);
-                                        ntv.markDirty();
-                                    }
-                                }
-
-                                if (resolved == memoryList.size()) break;
-                            }
-                        }
-                    }
-                }
+    @Nullable
+    private static ItemStack extractUpgrade(final List<ItemStack> upgrades, @NotNull final ItemStack requested) {
+        for (int i = 0; i < upgrades.size(); i++) {
+            final ItemStack upgrade = upgrades.get(i);
+            if (isMatchingUpgrade(requested, upgrade)) {
+                upgrades.remove(i);
+                return upgrade;
             }
+        }
 
-            for (int i = 0; i < memoryList.size(); i++) {
-                ItemStack is = memoryList.get(i);
-                if (is != null && is.stackSize == 0) {
-                    is.stackSize = 1;
-                    up.setInventorySlotContents(i, is);
+        return null;
+    }
+
+    @Nullable
+    private static ItemStack extractUpgradeFromPlayer(final EntityPlayer player, @NotNull final ItemStack requested) {
+        for (int i = 0; i < player.inventory.getSizeInventory(); i++) {
+            final ItemStack stack = player.inventory.getStackInSlot(i);
+            if (isMatchingUpgrade(requested, stack)) {
+                final ItemStack extracted = player.inventory.decrStackSize(i, 1);
+                player.inventory.markDirty();
+                player.onUpdate();
+                if (extracted != null) {
+                    return extracted;
+                }
+            } else if (stack != null && stack.getItem() instanceof INetworkToolItem networkTool) {
+                final ItemStack extracted = extractUpgradeFromNetworkTool(stack, networkTool, requested);
+                if (extracted != null) {
+                    return extracted;
                 }
             }
         }
+
+        return null;
+    }
+
+    @Nullable
+    private static ItemStack extractUpgradeFromNetworkTool(@NotNull final ItemStack toolStack,
+            @NotNull final INetworkToolItem networkTool, @NotNull final ItemStack requested) {
+        final NetworkToolViewer networkToolInventory = new NetworkToolViewer(
+                toolStack,
+                null,
+                networkTool.getInventorySize());
+
+        for (int i = 0; i < networkToolInventory.getSizeInventory(); i++) {
+            if (isMatchingUpgrade(requested, networkToolInventory.getStackInSlot(i))) {
+                final ItemStack extracted = networkToolInventory.decrStackSize(i, 1);
+                networkToolInventory.markDirty();
+                if (extracted != null) {
+                    return extracted;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static boolean isMatchingUpgrade(@NotNull final ItemStack requested, @Nullable final ItemStack candidate) {
+        return candidate != null && candidate.stackSize > 0 && requested.isItemEqual(candidate);
     }
 }

--- a/src/main/java/appeng/parts/AEBasePart.java
+++ b/src/main/java/appeng/parts/AEBasePart.java
@@ -29,6 +29,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
+import net.minecraftforge.common.util.Constants.NBT;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
@@ -59,6 +60,7 @@ import appeng.api.util.DimensionalCoord;
 import appeng.api.util.IConfigManager;
 import appeng.core.sync.GuiBridge;
 import appeng.helpers.ICustomNameObject;
+import appeng.helpers.IOreFilterable;
 import appeng.helpers.IPriorityHost;
 import appeng.items.tools.ToolMemoryCard;
 import appeng.items.tools.ToolPriorityCard;
@@ -321,7 +323,14 @@ public abstract class AEBasePart implements IPart, IGridProxyable, IActionHost, 
      * @param from     source of settings
      * @param compound compound of source
      */
-    protected void uploadSettings(@NotNull final SettingsFrom from, @NotNull final NBTTagCompound compound) {
+    public void uploadSettings(@NotNull final SettingsFrom from, @NotNull final NBTTagCompound compound) {
+        if (compound.hasKey("display", NBT.TAG_COMPOUND)) {
+            NBTTagCompound display = compound.getCompoundTag("display");
+            if (display.hasKey("Name", NBT.TAG_STRING)) {
+                this.setCustomName(display.getString("Name"));
+            }
+        }
+
         final IConfigManager cm = this.getConfigManager();
         if (cm != null) {
             cm.readFromNBT(compound);
@@ -333,7 +342,9 @@ public abstract class AEBasePart implements IPart, IGridProxyable, IActionHost, 
 
         if (this instanceof IIAEStackInventory iiaeStackInventory) {
             IAEStackInventory inv = iiaeStackInventory.getAEInventoryByName(StorageName.CONFIG);
-            inv.readFromNBT(compound, "config");
+            if (inv != null) {
+                inv.readFromNBT(compound, "config");
+            }
         } else {
             final IInventory inv = this.getInventoryByName("config");
             if (inv instanceof AppEngInternalAEInventory target) {
@@ -344,6 +355,10 @@ public abstract class AEBasePart implements IPart, IGridProxyable, IActionHost, 
                 }
             }
         }
+
+        if (this instanceof IOreFilterable oreFilterable && compound.hasKey("filter", NBT.TAG_STRING)) {
+            oreFilterable.setFilter(compound.getString("filter"));
+        }
     }
 
     /**
@@ -352,8 +367,15 @@ public abstract class AEBasePart implements IPart, IGridProxyable, IActionHost, 
      * @param from source of settings
      * @return compound of source
      */
-    protected NBTTagCompound downloadSettings(final SettingsFrom from) {
+    @NotNull
+    public NBTTagCompound downloadSettings(@NotNull final SettingsFrom from) {
         final NBTTagCompound output = new NBTTagCompound();
+
+        if (this.hasCustomName()) {
+            final NBTTagCompound dsp = new NBTTagCompound();
+            dsp.setString("Name", this.getCustomName());
+            output.setTag("display", dsp);
+        }
 
         final IConfigManager cm = this.getConfigManager();
         if (cm != null) {
@@ -366,12 +388,19 @@ public abstract class AEBasePart implements IPart, IGridProxyable, IActionHost, 
 
         if (this instanceof IIAEStackInventory iiaeStackInventory) {
             IAEStackInventory inv = iiaeStackInventory.getAEInventoryByName(StorageName.CONFIG);
-            inv.writeToNBT(output, "config");
+            if (inv != null) {
+                inv.writeToNBT(output, "config");
+            }
         } else {
             final IInventory inv = this.getInventoryByName("config");
             if (inv instanceof AppEngInternalAEInventory) {
                 ((AppEngInternalAEInventory) inv).writeToNBT(output, "config");
             }
+        }
+
+        if (this instanceof IOreFilterable oreFilterable) {
+            String filter = oreFilterable.getFilter();
+            output.setString("filter", filter == null ? "" : filter);
         }
 
         return output;

--- a/src/main/java/appeng/parts/AEBasePart.java
+++ b/src/main/java/appeng/parts/AEBasePart.java
@@ -442,12 +442,13 @@ public abstract class AEBasePart implements IPart, IGridProxyable, IActionHost, 
                 final String storedName = memoryCard.getSettingsName(memCardIS);
                 final NBTTagCompound data = memoryCard.getData(memCardIS);
                 if (name.equals(storedName)) {
-                    this.uploadSettings(SettingsFrom.MEMORY_CARD, data);
-
                     if (data.hasKey("upgradesList")) {
                         UpgradeInventory up = (UpgradeInventory) getInventoryByName("upgrades");
                         ToolMemoryCard.insertUpgrades(data, player, up);
                     }
+
+                    // Apply settings after insertUpgrades to preserve upgrade-gated settings, such as ore filters.
+                    this.uploadSettings(SettingsFrom.MEMORY_CARD, data);
 
                     memoryCard.notifyUser(player, MemoryCardMessages.SETTINGS_LOADED);
                 } else {

--- a/src/main/java/appeng/parts/automation/PartLevelEmitter.java
+++ b/src/main/java/appeng/parts/automation/PartLevelEmitter.java
@@ -777,7 +777,7 @@ public class PartLevelEmitter extends PartUpgradeable implements ILevelEmitter {
     }
 
     @Override
-    protected void uploadSettings(@NotNull SettingsFrom from, @NotNull NBTTagCompound compound) {
+    public void uploadSettings(@NotNull SettingsFrom from, @NotNull NBTTagCompound compound) {
         super.uploadSettings(from, compound);
         this.reportingValue = compound.getLong("reportingValue");
         this.typeFilters.readFromNBT(compound);
@@ -785,7 +785,8 @@ public class PartLevelEmitter extends PartUpgradeable implements ILevelEmitter {
     }
 
     @Override
-    protected NBTTagCompound downloadSettings(SettingsFrom from) {
+    @NotNull
+    public NBTTagCompound downloadSettings(@NotNull SettingsFrom from) {
         NBTTagCompound nbt = super.downloadSettings(from);
         nbt.setLong("reportingValue", this.reportingValue);
         this.typeFilters.writeToNBT(nbt);

--- a/src/main/java/appeng/parts/misc/PartStorageBus.java
+++ b/src/main/java/appeng/parts/misc/PartStorageBus.java
@@ -636,7 +636,10 @@ public class PartStorageBus extends PartUpgradeable implements IStorageBus {
                         this.handler.setSticky(true);
                     }
 
-                    if (this.oreFilterString.isEmpty()) {
+                    final boolean useOreFilter = this.getInstalledUpgrades(Upgrades.ORE_FILTER) > 0
+                            && !this.oreFilterString.isEmpty();
+
+                    if (!useOreFilter) {
                         final IItemList priorityList = getItemList();
 
                         final int slotsToUse = 18 + this.getInstalledUpgrades(Upgrades.CAPACITY) * 9;

--- a/src/main/java/appeng/parts/misc/PartStorageBus.java
+++ b/src/main/java/appeng/parts/misc/PartStorageBus.java
@@ -783,7 +783,9 @@ public class PartStorageBus extends PartUpgradeable implements IStorageBus {
     }
 
     @Override
-    public void saveAEStackInv() {}
+    public void saveAEStackInv() {
+        this.saveChanges();
+    }
 
     @Override
     public IAEStackInventory getAEInventoryByName(StorageName name) {

--- a/src/main/java/appeng/parts/p2p/PartP2PInterface.java
+++ b/src/main/java/appeng/parts/p2p/PartP2PInterface.java
@@ -55,6 +55,7 @@ import appeng.helpers.IPriorityHost;
 import appeng.helpers.Reflected;
 import appeng.me.GridAccessException;
 import appeng.me.cache.CraftingGridCache;
+import appeng.tile.inventory.AppEngInternalAEInventory;
 import appeng.tile.inventory.AppEngInternalInventory;
 import appeng.tile.inventory.IAEAppEngInventory;
 import appeng.tile.inventory.InvOperation;
@@ -256,6 +257,10 @@ public class PartP2PInterface extends PartP2PTunnelStatic<PartP2PInterface>
     public NBTTagCompound getMemoryCardData() {
         final NBTTagCompound output = super.getMemoryCardData();
         this.duality.getConfigManager().writeToNBT(output);
+        if (this.duality.getInventoryByName("config") instanceof AppEngInternalAEInventory config) {
+            config.writeToNBT(output, "config");
+        }
+        output.setInteger("priority", this.getPriority());
         return output;
     }
 
@@ -266,6 +271,14 @@ public class PartP2PInterface extends PartP2PTunnelStatic<PartP2PInterface>
         NBTTagCompound data = memoryCard.getData(is);
         if (newTunnel instanceof PartP2PInterface p2PInterface) {
             p2PInterface.duality.getConfigManager().readFromNBT(data);
+            if (p2PInterface.duality.getInventoryByName("config") instanceof AppEngInternalAEInventory config) {
+                config.readFromNBT(data, "config");
+                p2PInterface.duality.readConfig();
+                p2PInterface.duality.saveChanges();
+            }
+            if (data.hasKey("priority")) {
+                p2PInterface.setPriority(data.getInteger("priority"));
+            }
         }
         return newTunnel;
     }


### PR DESCRIPTION
- Make downloadSettings and uploadSettings public so they can be used from MM
- Allow to copy the Custom Name, Ore Filter, P2P Interface priority, and config to the Memory Card
- Remove existing cards first when pasting