### PR TITLE
fix crafting order chat notification showing item name in wrong locale

### DIFF
--- a/src/main/java/appeng/util/item/AEItemStack.java
+++ b/src/main/java/appeng/util/item/AEItemStack.java
@@ -30,11 +30,11 @@ import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.entity.item.EntityItem;
+import net.minecraft.event.HoverEvent;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompressedStreamTools;
-import net.minecraft.event.HoverEvent;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.ChatComponentTranslation;
@@ -570,7 +570,8 @@ public final class AEItemStack extends AEStack<IAEItemStack> implements IAEItemS
         result.appendSibling(nameComponent);
         result.appendText("]");
         result.getChatStyle().setChatHoverEvent(
-                new HoverEvent(HoverEvent.Action.SHOW_ITEM,
+                new HoverEvent(
+                        HoverEvent.Action.SHOW_ITEM,
                         new ChatComponentText(itemStack.writeToNBT(new NBTTagCompound()).toString())));
         return result;
     }

--- a/src/main/java/appeng/util/item/AEItemStack.java
+++ b/src/main/java/appeng/util/item/AEItemStack.java
@@ -34,7 +34,10 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompressedStreamTools;
+import net.minecraft.event.HoverEvent;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.IChatComponent;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
@@ -558,7 +561,18 @@ public final class AEItemStack extends AEStack<IAEItemStack> implements IAEItemS
 
     @Override
     public IChatComponent getChatComponent() {
-        return this.getItemStack().func_151000_E();
+        final ItemStack itemStack = this.getItemStack();
+        // Use ChatComponentTranslation so the client translates the name in their own locale.
+        // Wrap in brackets and attach hover event (shows item tooltip) like vanilla func_151000_E().
+        final String translationKey = itemStack.getItem().getUnlocalizedName(itemStack) + ".name";
+        final IChatComponent nameComponent = new ChatComponentTranslation(translationKey);
+        final ChatComponentText result = new ChatComponentText("[");
+        result.appendSibling(nameComponent);
+        result.appendText("]");
+        result.getChatStyle().setChatHoverEvent(
+                new HoverEvent(HoverEvent.Action.SHOW_ITEM,
+                        new ChatComponentText(itemStack.writeToNBT(new NBTTagCompound()).toString())));
+        return result;
     }
 
     // addon...


### PR DESCRIPTION
item name in crafting completion chat message was resolved server-side via `func_151000_E()`, which always produces English text on a dedicated server. replaced with `ChatComponentTranslation` so the client translates it in their own locale, preserving `[...]` brackets and hover tooltip.