### PR TITLE
Fix pattern terminal slots sync

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiPatternTerm.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiPatternTerm.java
@@ -12,7 +12,6 @@ package appeng.client.gui.implementations;
 
 import static appeng.util.item.AEItemStackType.ITEM_STACK_TYPE;
 
-import java.io.IOException;
 import java.util.List;
 
 import net.minecraft.client.gui.GuiButton;
@@ -46,14 +45,12 @@ import appeng.client.gui.widgets.GuiTabButton;
 import appeng.container.implementations.ContainerPatternTerm;
 import appeng.container.slot.AppEngSlot;
 import appeng.container.slot.SlotRestrictedInput;
-import appeng.core.AELog;
 import appeng.core.localization.ButtonToolTips;
 import appeng.core.localization.GuiColors;
 import appeng.core.localization.GuiText;
 import appeng.core.sync.GuiBridge;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketSwitchGuis;
-import appeng.core.sync.packets.PacketValueConfig;
 
 public class GuiPatternTerm extends GuiMEMonitorable {
 
@@ -113,39 +110,26 @@ public class GuiPatternTerm extends GuiMEMonitorable {
     protected void actionPerformed(final GuiButton btn) {
         super.actionPerformed(btn);
 
-        try {
-            if (this.tabCraftButton == btn || this.tabProcessButton == btn) {
-                this.craftingMode = this.tabProcessButton == btn;
-                updateSlotVisibility();
-                NetworkHandler.instance.sendToServer(
-                        new PacketValueConfig(
-                                "PatternTerminal.CraftMode",
-                                this.tabProcessButton == btn ? CRAFTMODE_CRFTING : CRAFTMODE_PROCESSING));
-            } else if (this.encodeBtn == btn) {
-                NetworkHandler.instance.sendToServer(
-                        new PacketValueConfig(
-                                "PatternTerminal.Encode",
-                                isCtrlKeyDown() ? (isShiftKeyDown() ? "6" : "1") : (isShiftKeyDown() ? "2" : "1")));
-            } else if (this.clearBtn == btn) {
-                NetworkHandler.instance.sendToServer(new PacketValueConfig("PatternTerminal.Clear", "1"));
-            } else if (this.substitutionsEnabledBtn == btn || this.substitutionsDisabledBtn == btn) {
-                NetworkHandler.instance.sendToServer(
-                        new PacketValueConfig(
-                                "PatternTerminal.Substitute",
-                                this.substitutionsEnabledBtn == btn ? SUBSITUTION_DISABLE : SUBSITUTION_ENABLE));
-            } else if (this.beSubstitutionsEnabledBtn == btn || this.beSubstitutionsDisabledBtn == btn) {
-                NetworkHandler.instance.sendToServer(
-                        new PacketValueConfig(
-                                "PatternTerminal.BeSubstitute",
-                                this.beSubstitutionsEnabledBtn == btn ? SUBSITUTION_DISABLE : SUBSITUTION_ENABLE));
-            } else if (doubleBtn == btn) {
-                int val = Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) ? 1 : 0;
-                if (Mouse.isButtonDown(1)) val |= 0b10;
-                NetworkHandler.instance
-                        .sendToServer(new PacketValueConfig("PatternTerminal.Double", String.valueOf(val)));
+        if (this.tabCraftButton == btn || this.tabProcessButton == btn) {
+            this.craftingMode = this.tabProcessButton == btn;
+            updateSlotVisibility();
+            container.craftingModeSync.set(this.tabProcessButton == btn);
+        } else if (this.encodeBtn == btn) {
+            if (isShiftKeyDown()) {
+                this.container.encodeAndMoveToInventoryAction.send(isCtrlKeyDown());
+            } else {
+                this.container.encodeAction.send();
             }
-        } catch (final IOException e) {
-            AELog.error(e);
+        } else if (this.clearBtn == btn) {
+            this.container.clearAction.send();
+        } else if (this.substitutionsEnabledBtn == btn || this.substitutionsDisabledBtn == btn) {
+            this.container.substituteSync.set(this.substitutionsDisabledBtn == btn);
+        } else if (this.beSubstitutionsEnabledBtn == btn || this.beSubstitutionsDisabledBtn == btn) {
+            this.container.beSubstituteSync.set(this.beSubstitutionsDisabledBtn == btn);
+        } else if (doubleBtn == btn) {
+            int val = Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) ? 1 : 0;
+            if (Mouse.isButtonDown(1)) val |= 0b10;
+            this.container.doubleAction.send(val);
         }
     }
 
@@ -337,7 +321,7 @@ public class GuiPatternTerm extends GuiMEMonitorable {
             }
         }
 
-        if (this.container.substitute) {
+        if (this.container.substituteSync.get()) {
             this.substitutionsEnabledBtn.visible = true;
             this.substitutionsDisabledBtn.visible = false;
         } else {
@@ -345,8 +329,8 @@ public class GuiPatternTerm extends GuiMEMonitorable {
             this.substitutionsDisabledBtn.visible = true;
         }
 
-        this.beSubstitutionsEnabledBtn.visible = this.container.beSubstitute;
-        this.beSubstitutionsDisabledBtn.visible = !this.container.beSubstitute;
+        this.beSubstitutionsEnabledBtn.visible = this.container.beSubstituteSync.get();
+        this.beSubstitutionsDisabledBtn.visible = !this.container.beSubstituteSync.get();
     }
 
     @Override

--- a/src/main/java/appeng/client/gui/implementations/GuiPatternTerm.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiPatternTerm.java
@@ -54,7 +54,6 @@ import appeng.core.sync.GuiBridge;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketSwitchGuis;
 import appeng.core.sync.packets.PacketValueConfig;
-import appeng.tile.inventory.IAEStackInventory;
 
 public class GuiPatternTerm extends GuiMEMonitorable {
 
@@ -251,14 +250,13 @@ public class GuiPatternTerm extends GuiMEMonitorable {
         final int inputSlotPerRow = container.getPatternInputsWidth();
         final int inputPage = container.getPatternInputPages();
         this.craftingSlots = new VirtualMEPatternSlot[inputSlotPerRow * inputSlotRow * inputPage];
-        final IAEStackInventory inputInv = container.getPatternTerminal()
-                .getAEInventoryByName(StorageName.CRAFTING_INPUT);
+
         for (int y = 0; y < inputSlotRow * inputPage; y++) {
             for (int x = 0; x < inputSlotPerRow; x++) {
                 VirtualMEPatternSlot slot = new VirtualMEPatternSlot(
                         getInputSlotOffsetX() + 18 * x,
                         this.rows * 18 + getInputSlotOffsetY() + 18 * (y % (inputSlotRow)),
-                        inputInv,
+                        container.inputsSync,
                         x + y * inputSlotPerRow,
                         this::acceptType);
                 this.craftingSlots[x + y * inputSlotPerRow] = slot;
@@ -270,14 +268,13 @@ public class GuiPatternTerm extends GuiMEMonitorable {
         final int outputSlotPerRow = container.getPatternOutputsWidth();
         final int outputPage = container.getPatternOutputPages();
         this.outputSlots = new VirtualMEPatternSlot[outputSlotPerRow * outputSlotRow * outputPage];
-        final IAEStackInventory outputInv = container.getPatternTerminal()
-                .getAEInventoryByName(StorageName.CRAFTING_OUTPUT);
+
         for (int y = 0; y < outputSlotRow * outputPage; y++) {
             for (int x = 0; x < outputSlotPerRow; x++) {
                 VirtualMEPatternSlot slot = new VirtualMEPatternSlot(
                         getOutputSlotOffsetX() + 18 * x,
                         this.rows * 18 + getOutputSlotOffsetY() + 18 * (y % outputSlotRow),
-                        outputInv,
+                        container.outputsSync,
                         x + y * outputSlotPerRow,
                         this::acceptType);
                 this.outputSlots[x + y * outputSlotPerRow] = slot;

--- a/src/main/java/appeng/client/gui/implementations/GuiPatternTermEx.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiPatternTermEx.java
@@ -1,7 +1,5 @@
 package appeng.client.gui.implementations;
 
-import java.io.IOException;
-
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.entity.player.InventoryPlayer;
 
@@ -14,12 +12,9 @@ import appeng.client.gui.slots.VirtualMEPhantomSlot;
 import appeng.client.gui.widgets.GuiImgButton;
 import appeng.client.gui.widgets.GuiScrollbar;
 import appeng.container.implementations.ContainerPatternTermEx;
-import appeng.core.AELog;
 import appeng.core.AppEng;
 import appeng.core.localization.GuiColors;
 import appeng.core.localization.GuiText;
-import appeng.core.sync.network.NetworkHandler;
-import appeng.core.sync.packets.PacketValueConfig;
 
 public class GuiPatternTermEx extends GuiPatternTerm {
 
@@ -27,34 +22,34 @@ public class GuiPatternTermEx extends GuiPatternTerm {
     private GuiImgButton invertBtn;
     private final GuiScrollbar processingScrollBar = new GuiScrollbar();
 
-    private boolean isInverted;
-    private int activePage;
-
     public GuiPatternTermEx(final InventoryPlayer inventoryPlayer, final ITerminalHost te) {
         super(inventoryPlayer, te, new ContainerPatternTermEx(inventoryPlayer, te));
         this.container = (ContainerPatternTermEx) this.inventorySlots;
+
+        this.container.invertedSync.onClientChange((oldValue, newValue) -> {
+            if (oldValue != newValue) {
+                this.updateSlotVisibility();
+            }
+        });
+        this.container.activePageSync.onClientChange((oldValue, newValue) -> {
+            if (oldValue != newValue) {
+                this.updateSlotVisibility();
+            }
+        });
+
         this.setReservedSpace(81);
 
         processingScrollBar.setHeight(70).setWidth(7).setLeft(6).setRange(0, 1, 1);
         processingScrollBar.setTexture(AppEng.MOD_ID, "guis/pattern3.png", 242, 0);
-
-        this.isInverted = this.container.inverted;
-        this.activePage = this.container.activePage;
     }
 
     @Override
     protected void actionPerformed(final GuiButton btn) {
         super.actionPerformed(btn);
 
-        try {
-            if (this.invertBtn == btn) {
-                NetworkHandler.instance.sendToServer(
-                        new PacketValueConfig("PatternTerminalEx.Invert", container.inverted ? "0" : "1"));
-                container.getExPatternTerminal().setInverted(container.inverted);
-                this.updateSlotVisibility();
-            }
-        } catch (final IOException e) {
-            AELog.error(e);
+        if (this.invertBtn == btn) {
+            container.invertedSync.set(!container.invertedSync.get());
+            this.updateSlotVisibility();
         }
     }
 
@@ -66,7 +61,7 @@ public class GuiPatternTermEx extends GuiPatternTerm {
                 this.guiLeft + 87,
                 this.guiTop + this.ySize - 145,
                 Settings.ACTIONS,
-                container.inverted ? PatternSlotConfig.C_4_16 : PatternSlotConfig.C_16_4);
+                container.invertedSync.get() ? PatternSlotConfig.C_4_16 : PatternSlotConfig.C_16_4);
         invertBtn.setHalfSize(true);
         this.buttonList.add(this.invertBtn);
 
@@ -102,12 +97,12 @@ public class GuiPatternTermEx extends GuiPatternTerm {
 
     @Override
     protected String getBackground() {
-        return container.inverted ? "guis/pattern4.png" : "guis/pattern3.png";
+        return container.invertedSync.get() ? "guis/pattern4.png" : "guis/pattern3.png";
     }
 
     @Override
     public void drawScreen(final int mouseX, final int mouseY, final float btn) {
-        final int offset = container.inverted ? 18 * -3 : 0;
+        final int offset = container.invertedSync.get() ? 18 * -3 : 0;
 
         doubleBtn.xPosition = this.guiLeft + 88 + offset;
         clearBtn.xPosition = doubleBtn.xPosition;
@@ -128,13 +123,7 @@ public class GuiPatternTermEx extends GuiPatternTerm {
 
         invertBtn.yPosition = this.guiTop + this.ySize - 145;
 
-        processingScrollBar.setCurrentScroll(container.activePage);
-
-        if (this.isInverted != this.container.inverted || this.activePage != this.container.activePage) {
-            this.isInverted = this.container.inverted;
-            this.activePage = this.container.activePage;
-            this.updateSlotVisibility();
-        }
+        processingScrollBar.setCurrentScroll(container.activePageSync.get());
 
         super.drawScreen(mouseX, mouseY, btn);
     }
@@ -184,16 +173,12 @@ public class GuiPatternTermEx extends GuiPatternTerm {
     }
 
     private void changeActivePage() {
-        try {
-            NetworkHandler.instance.sendToServer(
-                    new PacketValueConfig(
-                            "PatternTerminalEx.ActivePage",
-                            String.valueOf(this.processingScrollBar.getCurrentScroll())));
-            container.activePage = this.processingScrollBar.getCurrentScroll();
-            this.updateSlotVisibility();
-        } catch (final IOException e) {
-            AELog.error(e);
-        }
+        container.activePageSync.set(this.processingScrollBar.getCurrentScroll());
+        this.updateSlotVisibility();
+    }
+
+    public void onUpdateInvertedOrActivePage() {
+        updateSlotVisibility();
     }
 
     @Override
@@ -208,10 +193,12 @@ public class GuiPatternTermEx extends GuiPatternTerm {
                     final int slotIndex = x + y * inputSlotsPerRow + page * (inputSlotsPerRow * inputSlotRows);
                     VirtualMEPhantomSlot slot = this.craftingSlots[slotIndex];
 
-                    slot.setHidden(this.isInverted ? y != this.activePage || page > 0 : page != this.activePage);
+                    slot.setHidden(
+                            container.invertedSync.get() ? y != container.activePageSync.get() || page > 0
+                                    : page != container.activePageSync.get());
 
-                    slot.setX(getInputSlotOffsetX() + 18 * (this.isInverted ? 0 : x));
-                    slot.setY(this.rows * 18 + getInputSlotOffsetY() + 18 * (this.isInverted ? x : y));
+                    slot.setX(getInputSlotOffsetX() + 18 * (container.invertedSync.get() ? 0 : x));
+                    slot.setY(this.rows * 18 + getInputSlotOffsetY() + 18 * (container.invertedSync.get() ? x : y));
                 }
             }
         }
@@ -226,10 +213,14 @@ public class GuiPatternTermEx extends GuiPatternTerm {
                     final int slotIndex = x + y * outputSlotsPerRow + page * (outputSlotsPerRow * outputSlotRows);
                     VirtualMEPhantomSlot slot = this.outputSlots[slotIndex];
 
-                    slot.setHidden(!this.isInverted ? y != this.activePage || page != 0 : page != this.activePage);
+                    slot.setHidden(
+                            !container.invertedSync.get() ? y != container.activePageSync.get() || page != 0
+                                    : page != container.activePageSync.get());
 
-                    slot.setX((this.isInverted ? getOutputSlotOffsetX() : 112) + 18 * (!this.isInverted ? 0 : x));
-                    slot.setY(this.rows * 18 + getOutputSlotOffsetY() + 18 * (!this.isInverted ? x : y));
+                    slot.setX(
+                            (container.invertedSync.get() ? getOutputSlotOffsetX() : 112)
+                                    + 18 * (!container.invertedSync.get() ? 0 : x));
+                    slot.setY(this.rows * 18 + getOutputSlotOffsetY() + 18 * (!container.invertedSync.get() ? x : y));
                 }
             }
         }

--- a/src/main/java/appeng/client/gui/slots/VirtualMEPatternSlot.java
+++ b/src/main/java/appeng/client/gui/slots/VirtualMEPatternSlot.java
@@ -6,17 +6,17 @@ import javax.annotation.Nullable;
 
 import net.minecraft.item.ItemStack;
 
+import appeng.container.sync.handlers.AEStackInventorySyncHandler;
 import appeng.core.sync.GuiBridge;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketPatternValueSet;
 import appeng.core.sync.packets.PacketSwitchGuis;
-import appeng.tile.inventory.IAEStackInventory;
 
 public class VirtualMEPatternSlot extends VirtualMEPhantomSlot {
 
-    public VirtualMEPatternSlot(int x, int y, IAEStackInventory inventory, int slotIndex,
+    public VirtualMEPatternSlot(int x, int y, AEStackInventorySyncHandler syncHandler, int slotIndex,
             TypeAcceptPredicate acceptType) {
-        super(x, y, inventory, slotIndex, acceptType);
+        super(x, y, syncHandler, slotIndex, acceptType);
         this.showAmount = true;
     }
 

--- a/src/main/java/appeng/container/implementations/ContainerPatternTerm.java
+++ b/src/main/java/appeng/container/implementations/ContainerPatternTerm.java
@@ -49,12 +49,13 @@ import appeng.container.ContainerNull;
 import appeng.container.ContainerOpenContext;
 import appeng.container.PrimaryGui;
 import appeng.container.guisync.GuiSync;
-import appeng.container.interfaces.IVirtualSlotHolder;
 import appeng.container.interfaces.IVirtualSlotSource;
 import appeng.container.slot.AppEngSlot;
 import appeng.container.slot.IOptionalSlotHost;
 import appeng.container.slot.SlotPatternTerm;
 import appeng.container.slot.SlotRestrictedInput;
+import appeng.container.sync.SyncRegistrar;
+import appeng.container.sync.handlers.AEStackInventorySyncHandler;
 import appeng.core.sync.GuiBridge;
 import appeng.core.sync.packets.PacketPatternSlot;
 import appeng.helpers.IContainerCraftingPacket;
@@ -70,10 +71,9 @@ import appeng.util.InventoryAdaptor;
 import appeng.util.Platform;
 import appeng.util.inv.AdaptorPlayerHand;
 import appeng.util.item.AEItemStack;
-import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 
-public class ContainerPatternTerm extends ContainerMEMonitorable implements IAEAppEngInventory, IOptionalSlotHost,
-        IContainerCraftingPacket, IVirtualSlotHolder, IVirtualSlotSource {
+public class ContainerPatternTerm extends ContainerMEMonitorable
+        implements IAEAppEngInventory, IOptionalSlotHost, IContainerCraftingPacket, IVirtualSlotSource {
 
     public static final int MULTIPLE_OF_BUTTON_CLICK = 2;
     public static final int MULTIPLE_OF_BUTTON_CLICK_ON_SHIFT = 8;
@@ -81,11 +81,7 @@ public class ContainerPatternTerm extends ContainerMEMonitorable implements IAEA
     private final AppEngInternalInventory cOut = new AppEngInternalInventory(null, 1);
     private final IAEStackInventory inputs;
     private final IAEStackInventory outputs;
-    public final IAEStack<?>[] craftingSlotsClient = new IAEStack<?>[getPatternInputsWidth() * getPatternInputsHeigh()
-            * getPatternOutputPages()];
     private final IInventory craftingMatrix;
-    public final IAEStack<?>[] outputSlotsClient = new IAEStack<?>[getPatternOutputsWidth() * getPatternOutputsHeigh()
-            * getPatternOutputPages()];
 
     private final SlotPatternTerm craftSlot;
     private final SlotRestrictedInput patternSlotIN;
@@ -102,6 +98,9 @@ public class ContainerPatternTerm extends ContainerMEMonitorable implements IAEA
 
     @GuiSync(95)
     public boolean beSubstitute = true;
+
+    public final AEStackInventorySyncHandler inputsSync;
+    public final AEStackInventorySyncHandler outputsSync;
 
     public ContainerPatternTerm(final InventoryPlayer ip, final ITerminalHost monitorable) {
         this(ip, monitorable, true);
@@ -173,6 +172,26 @@ public class ContainerPatternTerm extends ContainerMEMonitorable implements IAEA
         // need because InventoryBogoSorter looking for specific slot number for bind buttons
         // bindPlayerInventory in MEMonitorable break it
         this.bindPlayerInventory(ip, 0, 0);
+
+        SyncRegistrar sync = this.syncRegistrar();
+        this.inputsSync = sync.aeStackInventory("inputs", this.inputs).onServerChange((inv) -> {
+            if (this.isCraftingMode()) {
+                assert this.craftingMatrix != null;
+
+                for (int i = 0; i < inv.getSizeInventory(); i++) {
+                    IAEStack<?> stack = inv.getAEStackInSlot(i);
+                    if (stack instanceof IAEItemStack ais) {
+                        ais.setStackSize(1);
+                        this.craftingMatrix.setInventorySlotContents(i, ais.getItemStack());
+                    } else {
+                        inv.putAEStackInSlot(i, null);
+                        this.craftingMatrix.setInventorySlotContents(i, null);
+                    }
+                }
+                this.getAndUpdateOutput();
+            }
+        });
+        this.outputsSync = sync.aeStackInventory("outputs", this.outputs);
     }
 
     private void updateOrderOfOutputSlots() {
@@ -198,7 +217,7 @@ public class ContainerPatternTerm extends ContainerMEMonitorable implements IAEA
             }
         }
         this.getAndUpdateOutput();
-        this.updateVirtualSlots(StorageName.CRAFTING_INPUT, this.inputs, craftingSlotsClient);
+        this.inputsSync.markDirty();
     }
 
     @Override
@@ -511,7 +530,6 @@ public class ContainerPatternTerm extends ContainerMEMonitorable implements IAEA
 
     @Override
     public void detectAndSendChanges() {
-        super.detectAndSendChanges();
         if (isServer()) {
             if (this.isCraftingMode() != this.getPatternTerminal().isCraftingRecipe()) {
                 this.setCraftingMode(this.getPatternTerminal().isCraftingRecipe());
@@ -523,13 +541,12 @@ public class ContainerPatternTerm extends ContainerMEMonitorable implements IAEA
             if (this.isFirstUpdate) {
                 if (craftingModeSupport && isCraftingMode()) {
                     this.copyToMatrix();
-                } else {
-                    this.updateVirtualSlots(StorageName.CRAFTING_INPUT, this.inputs, craftingSlotsClient);
                 }
-                this.updateVirtualSlots(StorageName.CRAFTING_OUTPUT, this.outputs, outputSlotsClient);
                 this.isFirstUpdate = false;
             }
         }
+
+        super.detectAndSendChanges();
     }
 
     @Override
@@ -565,8 +582,8 @@ public class ContainerPatternTerm extends ContainerMEMonitorable implements IAEA
         }
 
         this.getAndUpdateOutput();
-        this.updateVirtualSlots(StorageName.CRAFTING_INPUT, this.inputs, craftingSlotsClient);
-        this.updateVirtualSlots(StorageName.CRAFTING_OUTPUT, this.outputs, outputSlotsClient);
+        this.inputsSync.markDirty();
+        this.outputsSync.markDirty();
     }
 
     @Override
@@ -777,8 +794,8 @@ public class ContainerPatternTerm extends ContainerMEMonitorable implements IAEA
                 multiplyOrDivideStacksInternal(this.inputs, multi);
                 multiplyOrDivideStacksInternal(this.outputs, multi);
 
-                this.updateVirtualSlots(StorageName.CRAFTING_INPUT, this.inputs, craftingSlotsClient);
-                this.updateVirtualSlots(StorageName.CRAFTING_OUTPUT, this.outputs, outputSlotsClient);
+                this.inputsSync.markDirty();
+                this.outputsSync.markDirty();
             }
         }
     }
@@ -815,6 +832,7 @@ public class ContainerPatternTerm extends ContainerMEMonitorable implements IAEA
         return patternOutputPages;
     }
 
+    // For PacketPatternValueSet
     @Override
     public void updateVirtualSlot(StorageName invName, int slotId, IAEStack<?> aes) {
         switch (invName) {
@@ -824,7 +842,6 @@ public class ContainerPatternTerm extends ContainerMEMonitorable implements IAEA
                 }
                 this.inputs.putAEStackInSlot(slotId, aes);
                 if (isServer()) {
-                    this.updateVirtualSlots(StorageName.CRAFTING_INPUT, this.inputs, craftingSlotsClient);
                     if (isCraftingMode()) {
                         if (aes != null) {
                             IAEItemStack ais = ((IAEItemStack) aes);
@@ -835,46 +852,11 @@ public class ContainerPatternTerm extends ContainerMEMonitorable implements IAEA
                         this.getAndUpdateOutput();
                     }
                 }
+                this.inputsSync.markDirty();
             }
             case CRAFTING_OUTPUT -> {
                 this.outputs.putAEStackInSlot(slotId, aes);
-                if (isServer()) {
-                    this.updateVirtualSlots(StorageName.CRAFTING_OUTPUT, this.outputs, outputSlotsClient);
-                }
-            }
-        }
-    }
-
-    @Override
-    public void receiveSlotStacks(StorageName invName, Int2ObjectMap<IAEStack<?>> slotStacks) {
-        switch (invName) {
-            case CRAFTING_INPUT -> {
-                for (var entry : slotStacks.int2ObjectEntrySet()) {
-                    IAEStack<?> aes = entry.getValue();
-                    if (isServer() && isCraftingMode() && aes != null) {
-                        aes.setStackSize(1);
-                    }
-                    this.inputs.putAEStackInSlot(entry.getIntKey(), aes);
-                    if (isServer() && isCraftingMode()) {
-                        this.craftingMatrix.setInventorySlotContents(
-                                entry.getIntKey(),
-                                aes != null ? ((IAEItemStack) aes).getItemStack() : null);
-                    }
-                }
-                if (isServer()) {
-                    this.updateVirtualSlots(StorageName.CRAFTING_INPUT, this.inputs, craftingSlotsClient);
-                    if (isCraftingMode()) {
-                        this.getAndUpdateOutput();
-                    }
-                }
-            }
-            case CRAFTING_OUTPUT -> {
-                for (var entry : slotStacks.int2ObjectEntrySet()) {
-                    this.outputs.putAEStackInSlot(entry.getIntKey(), entry.getValue());
-                }
-                if (isServer()) {
-                    this.updateVirtualSlots(StorageName.CRAFTING_OUTPUT, this.outputs, outputSlotsClient);
-                }
+                this.outputsSync.markDirty();
             }
         }
     }

--- a/src/main/java/appeng/container/implementations/ContainerPatternTerm.java
+++ b/src/main/java/appeng/container/implementations/ContainerPatternTerm.java
@@ -48,14 +48,16 @@ import appeng.api.storage.data.IItemList;
 import appeng.container.ContainerNull;
 import appeng.container.ContainerOpenContext;
 import appeng.container.PrimaryGui;
-import appeng.container.guisync.GuiSync;
 import appeng.container.interfaces.IVirtualSlotSource;
 import appeng.container.slot.AppEngSlot;
 import appeng.container.slot.IOptionalSlotHost;
 import appeng.container.slot.SlotPatternTerm;
 import appeng.container.slot.SlotRestrictedInput;
+import appeng.container.sync.ActionHandler;
+import appeng.container.sync.StreamCodecs;
 import appeng.container.sync.SyncRegistrar;
 import appeng.container.sync.handlers.AEStackInventorySyncHandler;
+import appeng.container.sync.handlers.BooleanSyncHandler;
 import appeng.core.sync.GuiBridge;
 import appeng.core.sync.packets.PacketPatternSlot;
 import appeng.helpers.IContainerCraftingPacket;
@@ -90,17 +92,17 @@ public class ContainerPatternTerm extends ContainerMEMonitorable
 
     boolean isFirstUpdate = true;
 
-    @GuiSync(97)
-    public boolean craftingMode = true;
-
-    @GuiSync(96)
-    public boolean substitute = false;
-
-    @GuiSync(95)
-    public boolean beSubstitute = true;
-
     public final AEStackInventorySyncHandler inputsSync;
     public final AEStackInventorySyncHandler outputsSync;
+
+    public final BooleanSyncHandler craftingModeSync;
+    public final BooleanSyncHandler substituteSync;
+    public final BooleanSyncHandler beSubstituteSync;
+
+    public final ActionHandler<Void> encodeAction;
+    public final ActionHandler<Boolean> encodeAndMoveToInventoryAction;
+    public final ActionHandler<Void> clearAction;
+    public final ActionHandler<Integer> doubleAction;
 
     public ContainerPatternTerm(final InventoryPlayer ip, final ITerminalHost monitorable) {
         this(ip, monitorable, true);
@@ -167,8 +169,6 @@ public class ContainerPatternTerm extends ContainerMEMonitorable
 
         this.patternSlotOUT.setStackLimit(1);
 
-        this.updateOrderOfOutputSlots();
-
         // need because InventoryBogoSorter looking for specific slot number for bind buttons
         // bindPlayerInventory in MEMonitorable break it
         this.bindPlayerInventory(ip, 0, 0);
@@ -192,6 +192,28 @@ public class ContainerPatternTerm extends ContainerMEMonitorable
             }
         });
         this.outputsSync = sync.aeStackInventory("outputs", this.outputs);
+
+        this.craftingModeSync = sync.booleanSync("craftingMode")
+                .onServerChange((oldValue, newValue) -> setCraftingMode(newValue))
+                .onClientChange((oldValue, newValue) -> this.updateOrderOfOutputSlots());
+        if (Platform.isServer()) {
+            this.craftingModeSync.set(true);
+        } else {
+            this.craftingModeSync.setLocalValue(true);
+        }
+
+        this.substituteSync = sync.booleanSync("substitute")
+                .onServerChange((oldValue, newValue) -> getPatternTerminal().setSubstitution(newValue));
+        this.beSubstituteSync = sync.booleanSync("beSubstitute")
+                .onServerChange((oldValue, newValue) -> getPatternTerminal().setCanBeSubstitution(newValue));
+
+        this.encodeAction = sync.actionC2S("encode").onServerAction(this::encode);
+        this.encodeAndMoveToInventoryAction = sync.actionC2S("encodeAndMove", StreamCodecs.booleanValue())
+                .onServerAction(this::encodeAndMoveToInventory);
+        this.clearAction = sync.actionC2S("clear").onServerAction(this::clear);
+        this.doubleAction = sync.actionC2S("double", StreamCodecs.intValue()).onServerAction(this::doubleStacks);
+
+        this.updateOrderOfOutputSlots();
     }
 
     private void updateOrderOfOutputSlots() {
@@ -257,7 +279,7 @@ public class ContainerPatternTerm extends ContainerMEMonitorable
     public void onChangeInventory(final IInventory inv, final int slot, final InvOperation mc,
             final ItemStack removedStack, final ItemStack newStack) {}
 
-    public void encodeAndMoveToInventory(boolean encodeWholeStack) {
+    private void encodeAndMoveToInventory(boolean encodeWholeStack) {
         encode();
         ItemStack output = this.patternSlotOUT.getStack();
         if (output != null) {
@@ -273,7 +295,7 @@ public class ContainerPatternTerm extends ContainerMEMonitorable
         }
     }
 
-    public void encode() {
+    private void encode() {
         ItemStack output = this.patternSlotOUT.getStack();
 
         final IAEStack<?>[] in = this.getInputs();
@@ -351,8 +373,8 @@ public class ContainerPatternTerm extends ContainerMEMonitorable
         encodedValue.setTag("in", tagIn);
         encodedValue.setTag("out", tagOut);
         if (isCraftingMode()) encodedValue.setBoolean("crafting", this.isCraftingMode());
-        encodedValue.setBoolean("substitute", this.isSubstitute());
-        encodedValue.setBoolean("beSubstitute", this.canBeSubstitute());
+        encodedValue.setBoolean("substitute", this.substituteSync.get());
+        encodedValue.setBoolean("beSubstitute", this.beSubstituteSync.get());
         if (inputOnly) {
             final UUID uuid = inputOnlyUuid != null ? inputOnlyUuid : UUID.randomUUID();
             ItemTunnelPattern.writeTunnelUuid(encodedValue, uuid);
@@ -535,8 +557,8 @@ public class ContainerPatternTerm extends ContainerMEMonitorable
                 this.setCraftingMode(this.getPatternTerminal().isCraftingRecipe());
             }
 
-            this.substitute = this.patternTerminal.isSubstitution();
-            this.beSubstitute = this.patternTerminal.canBeSubstitution();
+            this.substituteSync.set(this.patternTerminal.isSubstitution());
+            this.beSubstituteSync.set(this.patternTerminal.canBeSubstitution());
 
             if (this.isFirstUpdate) {
                 if (craftingModeSupport && isCraftingMode()) {
@@ -550,16 +572,6 @@ public class ContainerPatternTerm extends ContainerMEMonitorable
     }
 
     @Override
-    public void onUpdate(final String field, final Object oldValue, final Object newValue) {
-        super.onUpdate(field, oldValue, newValue);
-
-        if (field.equals("craftingMode")) {
-            this.getAndUpdateOutput();
-            this.updateOrderOfOutputSlots();
-        }
-    }
-
-    @Override
     public void onSlotChange(final Slot s) {
         if (!isServer()) return;
         if (s == this.patternSlotOUT) {
@@ -568,6 +580,7 @@ public class ContainerPatternTerm extends ContainerMEMonitorable
         }
     }
 
+    // Used from NEE
     public void clear() {
         for (int i = 0; i < this.inputs.getSizeInventory(); ++i) {
             this.inputs.putAEStackInSlot(i, null);
@@ -691,19 +704,13 @@ public class ContainerPatternTerm extends ContainerMEMonitorable
         return false;
     }
 
-    public void toggleSubstitute() {
-        this.substitute = !this.substitute;
-
-        this.detectAndSendChanges();
-        this.getAndUpdateOutput();
-    }
-
     public boolean isCraftingMode() {
-        return this.craftingModeSupport && this.craftingMode;
+        return this.craftingModeSupport && this.craftingModeSync.get();
     }
 
+    // Used from NEE
     public void setCraftingMode(final boolean craftingMode) {
-        this.craftingMode = craftingMode;
+        this.craftingModeSync.set(craftingMode);
         this.patternTerminal.setCraftingRecipe(craftingMode);
         if (craftingMode && craftingModeSupport) copyToMatrix();
         this.updateOrderOfOutputSlots();
@@ -713,23 +720,7 @@ public class ContainerPatternTerm extends ContainerMEMonitorable
         return this.patternTerminal;
     }
 
-    private boolean isSubstitute() {
-        return this.substitute;
-    }
-
-    private boolean canBeSubstitute() {
-        return this.beSubstitute;
-    }
-
-    public void setSubstitute(final boolean substitute) {
-        this.substitute = substitute;
-    }
-
-    public void setCanBeSubstitute(final boolean beSubstitute) {
-        this.beSubstitute = beSubstitute;
-    }
-
-    public void doubleStacks(int val) {
+    private void doubleStacks(int val) {
         multiplyOrDivideStacks(
                 ((val & 1) != 0 ? MULTIPLE_OF_BUTTON_CLICK_ON_SHIFT : MULTIPLE_OF_BUTTON_CLICK)
                         * ((val & 2) != 0 ? -1 : 1));

--- a/src/main/java/appeng/container/implementations/ContainerPatternTerm.java
+++ b/src/main/java/appeng/container/implementations/ContainerPatternTerm.java
@@ -196,11 +196,7 @@ public class ContainerPatternTerm extends ContainerMEMonitorable
         this.craftingModeSync = sync.booleanSync("craftingMode")
                 .onServerChange((oldValue, newValue) -> setCraftingMode(newValue))
                 .onClientChange((oldValue, newValue) -> this.updateOrderOfOutputSlots());
-        if (Platform.isServer()) {
-            this.craftingModeSync.set(true);
-        } else {
-            this.craftingModeSync.setLocalValue(true);
-        }
+        this.craftingModeSync.setLocalValue(this.patternTerminal.isCraftingRecipe());
 
         this.substituteSync = sync.booleanSync("substitute")
                 .onServerChange((oldValue, newValue) -> getPatternTerminal().setSubstitution(newValue));

--- a/src/main/java/appeng/container/implementations/ContainerPatternTermEx.java
+++ b/src/main/java/appeng/container/implementations/ContainerPatternTermEx.java
@@ -24,8 +24,6 @@ public class ContainerPatternTermEx extends ContainerPatternTerm {
 
     @Override
     public void detectAndSendChanges() {
-        super.detectAndSendChanges();
-
         if (Platform.isServer()) {
             final IPatternTerminalEx temp = getExPatternTerminal();
             substitute = temp.isSubstitution();
@@ -33,6 +31,8 @@ public class ContainerPatternTermEx extends ContainerPatternTerm {
             inverted = temp.isInverted();
             activePage = temp.getActivePage();
         }
+
+        super.detectAndSendChanges();
     }
 
     public IPatternTerminalEx getExPatternTerminal() {

--- a/src/main/java/appeng/container/implementations/ContainerPatternTermEx.java
+++ b/src/main/java/appeng/container/implementations/ContainerPatternTermEx.java
@@ -48,9 +48,6 @@ public class ContainerPatternTermEx extends ContainerPatternTerm {
     public void detectAndSendChanges() {
         if (Platform.isServer()) {
             final IPatternTerminalEx temp = getExPatternTerminal();
-            substitute = temp.isSubstitution();
-            beSubstitute = temp.canBeSubstitution();
-
             this.invertedSync.set(temp.isInverted());
             this.activePageSync.set(temp.getActivePage());
         }

--- a/src/main/java/appeng/container/implementations/ContainerPatternTermEx.java
+++ b/src/main/java/appeng/container/implementations/ContainerPatternTermEx.java
@@ -2,24 +2,46 @@ package appeng.container.implementations;
 
 import static appeng.parts.reporting.PartPatternTerminalEx.*;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.InventoryPlayer;
 
 import appeng.api.parts.IPatternTerminalEx;
 import appeng.api.storage.ITerminalHost;
-import appeng.container.guisync.GuiSync;
+import appeng.client.gui.implementations.GuiPatternTermEx;
+import appeng.container.sync.SyncRegistrar;
+import appeng.container.sync.handlers.BooleanSyncHandler;
+import appeng.container.sync.handlers.IntSyncHandler;
 import appeng.util.Platform;
 
 public class ContainerPatternTermEx extends ContainerPatternTerm {
 
-    @GuiSync(96 + (17 - 9) + 16)
-    public boolean inverted;
-
-    @GuiSync(96 + (17 - 9) + 17)
-    public int activePage = 0;
+    public BooleanSyncHandler invertedSync;
+    public IntSyncHandler activePageSync;
 
     public ContainerPatternTermEx(final InventoryPlayer ip, final ITerminalHost monitorable) {
         super(ip, monitorable, false);
-        inverted = getExPatternTerminal().isInverted();
+
+        SyncRegistrar sync = this.syncRegistrar();
+        this.invertedSync = sync.booleanSync("inverted")
+                .onServerChange((oldValue, newValue) -> this.getExPatternTerminal().setInverted(newValue))
+                .onClientChange((oldValue, newValue) -> {
+                    if (oldValue != newValue
+                            && Minecraft.getMinecraft().currentScreen instanceof GuiPatternTermEx gui) {
+                        gui.onUpdateInvertedOrActivePage();
+                    }
+                });
+        this.activePageSync = sync.intSync("activePage")
+                .onServerChange((oldValue, newValue) -> this.getExPatternTerminal().setActivePage(newValue))
+                .onClientChange((oldValue, newValue) -> {
+                    if (oldValue != newValue
+                            && Minecraft.getMinecraft().currentScreen instanceof GuiPatternTermEx gui) {
+                        gui.onUpdateInvertedOrActivePage();
+                    }
+                });
+
+        if (Platform.isServer()) {
+            this.invertedSync.set(getExPatternTerminal().isInverted());
+        }
     }
 
     @Override
@@ -28,8 +50,9 @@ public class ContainerPatternTermEx extends ContainerPatternTerm {
             final IPatternTerminalEx temp = getExPatternTerminal();
             substitute = temp.isSubstitution();
             beSubstitute = temp.canBeSubstitution();
-            inverted = temp.isInverted();
-            activePage = temp.getActivePage();
+
+            this.invertedSync.set(temp.isInverted());
+            this.activePageSync.set(temp.getActivePage());
         }
 
         super.detectAndSendChanges();

--- a/src/main/java/appeng/core/sync/packets/PacketValueConfig.java
+++ b/src/main/java/appeng/core/sync/packets/PacketValueConfig.java
@@ -35,7 +35,6 @@ import appeng.container.implementations.ContainerInterface;
 import appeng.container.implementations.ContainerNetworkStatus;
 import appeng.container.implementations.ContainerNetworkTool;
 import appeng.container.implementations.ContainerOreFilter;
-import appeng.container.implementations.ContainerPatternTerm;
 import appeng.container.implementations.ContainerPriority;
 import appeng.container.implementations.ContainerQuartzKnife;
 import appeng.container.implementations.ContainerRenamer;
@@ -141,20 +140,6 @@ public class PacketValueConfig extends AppEngPacket {
             pc.setPriority(Integer.parseInt(this.Value), player);
         } else if (this.Name.equals("OreFilter") && c instanceof ContainerOreFilter fc) {
             fc.setFilter(this.Value);
-        } else if (this.Name.startsWith("PatternTerminal.") && c instanceof final ContainerPatternTerm cpt) {
-            switch (this.Name) {
-                case "PatternTerminal.CraftMode" -> cpt.getPatternTerminal().setCraftingRecipe(this.Value.equals("1"));
-                case "PatternTerminal.Encode" -> {
-                    if (this.Value.equals("2")) cpt.encodeAndMoveToInventory(false);
-                    else if (this.Value.equals("6")) cpt.encodeAndMoveToInventory(true);
-                    else cpt.encode();
-                }
-                case "PatternTerminal.Clear" -> cpt.clear();
-                case "PatternTerminal.Substitute" -> cpt.getPatternTerminal().setSubstitution(this.Value.equals("1"));
-                case "PatternTerminal.BeSubstitute" -> cpt.getPatternTerminal()
-                        .setCanBeSubstitution(this.Value.equals("1"));
-                case "PatternTerminal.Double" -> cpt.doubleStacks(Integer.parseInt(this.Value));
-            }
         } else if (this.Name.startsWith("StorageBus.") && c instanceof final ContainerStorageBus ccw) {
             if (this.Name.equals("StorageBus.Action")) {
                 switch (this.Value) {

--- a/src/main/java/appeng/core/sync/packets/PacketValueConfig.java
+++ b/src/main/java/appeng/core/sync/packets/PacketValueConfig.java
@@ -36,7 +36,6 @@ import appeng.container.implementations.ContainerNetworkStatus;
 import appeng.container.implementations.ContainerNetworkTool;
 import appeng.container.implementations.ContainerOreFilter;
 import appeng.container.implementations.ContainerPatternTerm;
-import appeng.container.implementations.ContainerPatternTermEx;
 import appeng.container.implementations.ContainerPriority;
 import appeng.container.implementations.ContainerQuartzKnife;
 import appeng.container.implementations.ContainerRenamer;
@@ -155,11 +154,6 @@ public class PacketValueConfig extends AppEngPacket {
                 case "PatternTerminal.BeSubstitute" -> cpt.getPatternTerminal()
                         .setCanBeSubstitution(this.Value.equals("1"));
                 case "PatternTerminal.Double" -> cpt.doubleStacks(Integer.parseInt(this.Value));
-            }
-        } else if (this.Name.startsWith("PatternTerminalEx.") && c instanceof final ContainerPatternTermEx cpt) {
-            switch (this.Name) {
-                case "PatternTerminalEx.Invert" -> cpt.getExPatternTerminal().setInverted(Value.equals("1"));
-                case "PatternTerminalEx.ActivePage" -> cpt.getExPatternTerminal().setActivePage(Integer.parseInt(Value));
             }
         } else if (this.Name.startsWith("StorageBus.") && c instanceof final ContainerStorageBus ccw) {
             if (this.Name.equals("StorageBus.Action")) {


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25172

The first updateVirtualSlots performs a full sync, but subsequent calls only send diffs.
As a result, only the inputs were fully synced while the outputs were not, so items loaded from the client-side old NBT were being displayed.
It seems that items in Baubles slots are not immediately synced to the client when their NBT changes.