### PR TITLE
Fix FMP compatibility

### DIFF
--- a/src/main/java/appeng/core/sync/GuiBridge.java
+++ b/src/main/java/appeng/core/sync/GuiBridge.java
@@ -46,7 +46,6 @@ import appeng.api.parts.ICraftingTerminal;
 import appeng.api.parts.IInterfaceTerminal;
 import appeng.api.parts.ILevelEmitter;
 import appeng.api.parts.IPart;
-import appeng.api.parts.IPartHost;
 import appeng.api.parts.IPatternTerminal;
 import appeng.api.parts.IPatternTerminalEx;
 import appeng.api.parts.IStorageBus;
@@ -335,17 +334,12 @@ public enum GuiBridge implements IGuiHandler {
             }
         }
         if (ID.type.isTile()) {
-            final TileEntity TE = w.getTileEntity(x, y, z);
-            if (TE instanceof IPartHost) {
-                ((IPartHost) TE).getPart(side);
-                final IPart part = ((IPartHost) TE).getPart(side);
-                if (ID.CorrectTileOrPart(part)) {
-                    return this.updateGui(ID.ConstructContainer(player.inventory, side, part), w, x, y, z, side, part);
-                }
-            } else {
-                if (ID.CorrectTileOrPart(TE)) {
-                    return this.updateGui(ID.ConstructContainer(player.inventory, side, TE), w, x, y, z, side, TE);
-                }
+            final TileEntity te = w.getTileEntity(x, y, z);
+            IPart part = Platform.getPartFromTE(te, side);
+            if (ID.CorrectTileOrPart(part)) {
+                return this.updateGui(ID.ConstructContainer(player.inventory, side, part), w, x, y, z, side, part);
+            } else if (ID.CorrectTileOrPart(te)) {
+                return this.updateGui(ID.ConstructContainer(player.inventory, side, te), w, x, y, z, side, te);
             }
         }
         return new ContainerNull();
@@ -483,17 +477,12 @@ public enum GuiBridge implements IGuiHandler {
             }
         }
         if (ID.type.isTile() && !pastXLimit) {
-            final TileEntity TE = w.getTileEntity(x, y, z);
-            if (TE instanceof IPartHost) {
-                ((IPartHost) TE).getPart(side);
-                final IPart part = ((IPartHost) TE).getPart(side);
-                if (ID.CorrectTileOrPart(part)) {
-                    return ID.ConstructGui(player.inventory, side, part);
-                }
-            } else {
-                if (ID.CorrectTileOrPart(TE)) {
-                    return ID.ConstructGui(player.inventory, side, TE);
-                }
+            final TileEntity te = w.getTileEntity(x, y, z);
+            IPart part = Platform.getPartFromTE(te, side);
+            if (ID.CorrectTileOrPart(part)) {
+                return ID.ConstructGui(player.inventory, side, part);
+            } else if (ID.CorrectTileOrPart(te)) {
+                return ID.ConstructGui(player.inventory, side, te);
             }
         }
         return new GuiNull(new ContainerNull());
@@ -533,16 +522,11 @@ public enum GuiBridge implements IGuiHandler {
                 te != null ? new DimensionalCoord(te) : new DimensionalCoord(player.worldObj, x, y, z),
                 player)) {
             if (te != null && this.type.isTile()) {
-                if (te instanceof IPartHost host) {
-                    host.getPart(side);
-                    final IPart part = host.getPart(side);
-                    if (this.CorrectTileOrPart(part)) {
-                        return this.securityCheck(part, player);
-                    }
-                } else {
-                    if (this.CorrectTileOrPart(te)) {
-                        return this.securityCheck(te, player);
-                    }
+                IPart part = Platform.getPartFromTE(te, side);
+                if (this.CorrectTileOrPart(part)) {
+                    return this.securityCheck(part, player);
+                } else if (this.CorrectTileOrPart(te)) {
+                    return this.securityCheck(te, player);
                 }
             } else if (this.type.isItem() && slotIndex != Integer.MIN_VALUE) {
                 final ItemStack it = getItemFromPlayerInventoryBySlotIndex(player, slotIndex);

--- a/src/main/java/appeng/core/sync/packets/PacketToggleInterfaceVisibility.java
+++ b/src/main/java/appeng/core/sync/packets/PacketToggleInterfaceVisibility.java
@@ -7,13 +7,12 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import appeng.api.config.Settings;
 import appeng.api.config.YesNo;
-import appeng.api.parts.IPart;
 import appeng.container.AEBaseContainer;
 import appeng.container.implementations.ContainerInterfaceTerminal;
 import appeng.core.sync.AppEngPacket;
 import appeng.core.sync.network.INetworkInfo;
 import appeng.helpers.IInterfaceHost;
-import appeng.tile.networking.TileCableBus;
+import appeng.util.Platform;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 
@@ -58,10 +57,9 @@ public class PacketToggleInterfaceVisibility extends AppEngPacket {
 
         final TileEntity te = world.getTileEntity(this.x, this.y, this.z);
         final IInterfaceHost host;
-        if (te instanceof TileCableBus cableBus) {
-            final IPart part = cableBus.getPart(ForgeDirection.getOrientation(this.side));
-            if (!(part instanceof IInterfaceHost)) return;
-            host = (IInterfaceHost) part;
+        if (Platform
+                .getPartFromTE(te, ForgeDirection.getOrientation(this.side)) instanceof IInterfaceHost interfaceHost) {
+            host = interfaceHost;
         } else if (te instanceof IInterfaceHost) {
             host = (IInterfaceHost) te;
         } else {

--- a/src/main/java/appeng/helpers/DualityInterface.java
+++ b/src/main/java/appeng/helpers/DualityInterface.java
@@ -115,7 +115,6 @@ import appeng.tile.inventory.AppEngInternalInventory;
 import appeng.tile.inventory.IAEAppEngInventory;
 import appeng.tile.inventory.InvOperation;
 import appeng.tile.misc.TileInterface;
-import appeng.tile.networking.TileCableBus;
 import appeng.util.ConfigManager;
 import appeng.util.IConfigManagerHost;
 import appeng.util.InventoryAdaptor;
@@ -1026,8 +1025,7 @@ public class DualityInterface implements IGridTickable, IStorageMonitorable, IIn
     }
 
     private boolean shouldCheckFluid() {
-        String hostName = this.iHost.getClass().getName();
-        return hostName.contains("TileFluidInterface") || hostName.contains("PartFluidInterface");
+        return this.iHost instanceof IDualHost;
     }
 
     private boolean inventoryCountsAsEmpty(TileEntity te, InventoryAdaptor ad, ForgeDirection side) {
@@ -1046,11 +1044,17 @@ public class DualityInterface implements IGridTickable, IStorageMonitorable, IIn
             }
         }
 
-        boolean isEmpty = (name.equals("tile.interface") || name.equals("tile.blockWritingTable"))
-                && tileHasOnlyIgnoredItems(ad);
+        final boolean isInterface = ad instanceof AdaptorDualityInterface;
+
+        boolean isEmpty = (isInterface || name.equals("tile.blockWritingTable")) && tileHasOnlyIgnoredItems(ad);
+
+        if ((!isInterface && !name.equals("tile.blockWritingTable")) || !tileHasOnlyIgnoredItems(ad)) {
+            return false;
+        }
 
         if (shouldCheckFluid()) {
-            isEmpty = name.equals("tile.interface");
+            // TODO: check fluid
+            isEmpty = isInterface;
         }
 
         return isEmpty;
@@ -1078,14 +1082,11 @@ public class DualityInterface implements IGridTickable, IStorageMonitorable, IIn
                     }
                     host.getInterfaceDuality().receivePatternPushedEvent();
 
-                } else if (te instanceof TileCableBus cableBus) {
-                    IPart part = cableBus.getPart(s.getOpposite());
-                    if (part instanceof IInterfaceHost host) {
-                        if (host == pushingHost) {
-                            continue;
-                        }
-                        host.getInterfaceDuality().receivePatternPushedEvent();
+                } else if (Platform.getPartFromTE(te, s.getOpposite()) instanceof IInterfaceHost host) {
+                    if (host == pushingHost) {
+                        continue;
                     }
+                    host.getInterfaceDuality().receivePatternPushedEvent();
                 }
             } catch (final GridAccessException ignored) {}
         }
@@ -1751,17 +1752,14 @@ public class DualityInterface implements IGridTickable, IStorageMonitorable, IIn
                 } catch (GridAccessException e) {
                     // :P
                 }
-            } else if (te instanceof TileCableBus cableBus) {
-                IPart part = cableBus.getPart(s);
-                if (part instanceof IInterfaceHost oppositeHost) {
-                    try {
-                        if (oppositeHost.getInstalledUpgrades(Upgrades.ADVANCED_BLOCKING) > 0) {
-                            oppositeHost.getInterfaceDuality().gridProxy.getGrid()
-                                    .postEvent(new MENetworkCraftingPushedPattern(this.iHost));
-                        }
-                    } catch (GridAccessException e) {
-                        // :P
+            } else if (Platform.getPartFromTE(te, s) instanceof IInterfaceHost oppositeHost) {
+                try {
+                    if (oppositeHost.getInstalledUpgrades(Upgrades.ADVANCED_BLOCKING) > 0) {
+                        oppositeHost.getInterfaceDuality().gridProxy.getGrid()
+                                .postEvent(new MENetworkCraftingPushedPattern(this.iHost));
                     }
+                } catch (GridAccessException e) {
+                    // :P
                 }
             }
         }

--- a/src/main/java/appeng/helpers/DualityInterface.java
+++ b/src/main/java/appeng/helpers/DualityInterface.java
@@ -1024,10 +1024,6 @@ public class DualityInterface implements IGridTickable, IStorageMonitorable, IIn
         return true;
     }
 
-    private boolean shouldCheckFluid() {
-        return this.iHost instanceof IDualHost;
-    }
-
     private boolean inventoryCountsAsEmpty(TileEntity te, InventoryAdaptor ad, ForgeDirection side) {
         String name = te.getBlockType().getUnlocalizedName();
 
@@ -1044,20 +1040,19 @@ public class DualityInterface implements IGridTickable, IStorageMonitorable, IIn
             }
         }
 
-        final boolean isInterface = ad instanceof AdaptorDualityInterface;
+        if (name.equals("tile.blockWritingTable") && tileHasOnlyIgnoredItems(ad)) return true;
 
-        boolean isEmpty = (isInterface || name.equals("tile.blockWritingTable")) && tileHasOnlyIgnoredItems(ad);
+        if (ad instanceof AdaptorDualityInterface adaptorDualityInterface) {
+            boolean isEmpty = tileHasOnlyIgnoredItems(ad);
 
-        if ((!isInterface && !name.equals("tile.blockWritingTable")) || !tileHasOnlyIgnoredItems(ad)) {
-            return false;
+            if (this.isFluidInterface && isEmpty) {
+                return adaptorDualityInterface.isEmpty(FLUID_STACK_TYPE);
+            }
+
+            return isEmpty;
         }
 
-        if (shouldCheckFluid()) {
-            // TODO: check fluid
-            isEmpty = isInterface;
-        }
-
-        return isEmpty;
+        return false;
     }
 
     public void notifyPushedPattern(IInterfaceHost pushingHost) {

--- a/src/main/java/appeng/integration/modules/FMP.java
+++ b/src/main/java/appeng/integration/modules/FMP.java
@@ -18,7 +18,6 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.common.util.ForgeDirection;
 
 import com.google.common.collect.Lists;
 
@@ -36,8 +35,6 @@ import appeng.integration.IIntegrationModule;
 import appeng.integration.abstraction.IFMP;
 import appeng.integration.modules.helpers.FMPPacketEvent;
 import appeng.parts.CableBusContainer;
-import appeng.parts.PartBasicState;
-import appeng.tile.networking.TileCableBus;
 import codechicken.lib.vec.BlockCoord;
 import codechicken.microblock.BlockMicroMaterial;
 import codechicken.multipart.MultiPartRegistry;
@@ -71,14 +68,6 @@ public class FMP implements IIntegrationModule, IPartFactory, IPartConverter, IF
 
         final TMultiPart part = PartRegistry.getPartByBlock(blk, meta);
         if (part instanceof CableBusPart cbp) {
-            if (world.getTileEntity(pos.x, pos.y, pos.z) instanceof TileCableBus tcb) {
-                for (ForgeDirection fd : ForgeDirection.VALID_DIRECTIONS) {
-                    if (tcb.getPart(fd) instanceof PartBasicState) {
-                        return null;
-                    }
-                }
-
-            }
             cbp.convertFromTile(world.getTileEntity(pos.x, pos.y, pos.z));
         }
 

--- a/src/main/java/appeng/integration/modules/Waila.java
+++ b/src/main/java/appeng/integration/modules/Waila.java
@@ -13,6 +13,8 @@ package appeng.integration.modules;
 import appeng.helpers.Reflected;
 import appeng.integration.IIntegrationModule;
 import appeng.integration.IntegrationHelper;
+import appeng.integration.IntegrationRegistry;
+import appeng.integration.IntegrationType;
 import appeng.integration.modules.waila.PartWailaDataProvider;
 import appeng.integration.modules.waila.TileWailaDataProvider;
 import appeng.tile.AEBaseTile;
@@ -37,14 +39,25 @@ public class Waila implements IIntegrationModule {
     public static void register(final IWailaRegistrar registrar) {
         final IWailaDataProvider partHost = new PartWailaDataProvider();
 
-        registrar.registerStackProvider(partHost, AEBaseTile.class);
-        registrar.registerBodyProvider(partHost, AEBaseTile.class);
-        registrar.registerNBTProvider(partHost, AEBaseTile.class);
+        registerPartProvider(registrar, partHost, AEBaseTile.class);
+
+        if (IntegrationRegistry.INSTANCE.isEnabled(IntegrationType.FMP)) {
+            try {
+                registerPartProvider(registrar, partHost, Class.forName("codechicken.multipart.TileMultipart"));
+            } catch (final ClassNotFoundException ignored) {}
+        }
 
         final IWailaDataProvider tile = new TileWailaDataProvider();
 
         registrar.registerBodyProvider(tile, AEBaseTile.class);
         registrar.registerNBTProvider(tile, AEBaseTile.class);
+    }
+
+    private static void registerPartProvider(final IWailaRegistrar registrar, final IWailaDataProvider provider,
+            final Class<?> tileClass) {
+        registrar.registerStackProvider(provider, tileClass);
+        registrar.registerBodyProvider(provider, tileClass);
+        registrar.registerNBTProvider(provider, tileClass);
     }
 
     @Override

--- a/src/main/java/appeng/integration/modules/waila/part/PartAccessor.java
+++ b/src/main/java/appeng/integration/modules/waila/part/PartAccessor.java
@@ -17,8 +17,8 @@ import net.minecraft.util.Vec3;
 import com.google.common.base.Optional;
 
 import appeng.api.parts.IPart;
-import appeng.api.parts.IPartHost;
 import appeng.api.parts.SelectedPart;
+import appeng.util.Platform;
 
 /**
  * Accessor to access specific parts for WAILA
@@ -30,7 +30,7 @@ import appeng.api.parts.SelectedPart;
 public final class PartAccessor {
 
     /**
-     * Hits a {@link appeng.api.parts.IPartHost} with {@link net.minecraft.util.MovingObjectPosition}.
+     * Hits an AE2 cable bus with {@link net.minecraft.util.MovingObjectPosition}.
      * <p/>
      * You can derive the looked at {@link appeng.api.parts.IPart} by doing that. If a facade is being looked at, it is
      * defined as being absent.
@@ -40,13 +40,11 @@ public final class PartAccessor {
      * @return maybe the looked at {@link appeng.api.parts.IPart}
      */
     public Optional<IPart> getMaybePart(final TileEntity te, final MovingObjectPosition mop) {
-        if (te instanceof IPartHost host) {
-            final Vec3 position = mop.hitVec.addVector(-mop.blockX, -mop.blockY, -mop.blockZ);
-            final SelectedPart sp = host.selectPart(position);
+        final Vec3 position = mop.hitVec.addVector(-mop.blockX, -mop.blockY, -mop.blockZ);
+        final SelectedPart sp = Platform.selectPartFromTE(te, position);
 
-            if (sp.part != null) {
-                return Optional.of(sp.part);
-            }
+        if (sp != null && sp.part != null) {
+            return Optional.of(sp.part);
         }
 
         return Optional.absent();

--- a/src/main/java/appeng/items/materials/ItemMultiMaterial.java
+++ b/src/main/java/appeng/items/materials/ItemMultiMaterial.java
@@ -47,7 +47,6 @@ import appeng.api.implementations.items.IStorageComponent;
 import appeng.api.implementations.items.IUpgradeModule;
 import appeng.api.implementations.tiles.IChestOrDrive;
 import appeng.api.implementations.tiles.ISegmentedInventory;
-import appeng.api.parts.IPartHost;
 import appeng.api.parts.SelectedPart;
 import appeng.client.texture.MissingIcon;
 import appeng.core.AEConfig;
@@ -289,8 +288,8 @@ public final class ItemMultiMaterial extends AEBaseItem implements IStorageCompo
             }
             IInventory upgrades = null;
 
-            if (te instanceof IPartHost) {
-                final SelectedPart sp = ((IPartHost) te).selectPart(Vec3.createVectorHelper(hitX, hitY, hitZ));
+            final SelectedPart sp = Platform.selectPartFromTE(te, Vec3.createVectorHelper(hitX, hitY, hitZ));
+            if (sp != null) {
                 if (sp.part instanceof IUpgradeableHost) {
                     upgrades = ((ISegmentedInventory) sp.part).getInventoryByName("upgrades");
                 }

--- a/src/main/java/appeng/items/tools/ToolNetworkTool.java
+++ b/src/main/java/appeng/items/tools/ToolNetworkTool.java
@@ -32,7 +32,6 @@ import appeng.api.implementations.guiobjects.IGuiItemObject;
 import appeng.api.implementations.items.IAEWrench;
 import appeng.api.implementations.items.INetworkToolItem;
 import appeng.api.networking.IGridHost;
-import appeng.api.parts.IPartHost;
 import appeng.api.parts.SelectedPart;
 import appeng.api.util.DimensionalCoord;
 import appeng.api.util.INetworkToolAgent;
@@ -119,8 +118,8 @@ public class ToolNetworkTool extends AEBaseItem
                 Vec3.createVectorHelper(hitX, hitY, hitZ));
         final TileEntity te = world.getTileEntity(x, y, z);
 
-        if (te instanceof IPartHost host) {
-            final SelectedPart part = host.selectPart(mop.hitVec);
+        final SelectedPart part = Platform.selectPartFromTE(te, mop.hitVec);
+        if (part != null) {
             if (part.part instanceof INetworkToolAgent nta && !nta.showNetworkInfo(mop)) {
                 return false;
 

--- a/src/main/java/appeng/parts/CableBusContainer.java
+++ b/src/main/java/appeng/parts/CableBusContainer.java
@@ -54,7 +54,6 @@ import appeng.facade.FacadeContainer;
 import appeng.helpers.AEMultiTile;
 import appeng.me.GridConnection;
 import appeng.util.Platform;
-import codechicken.multipart.TileMultipart;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import io.netty.buffer.ByteBuf;
@@ -136,11 +135,6 @@ public class CableBusContainer extends CableBusStorage implements AEMultiTile, I
                 } else if (!(bp instanceof IPartCable) && side != ForgeDirection.UNKNOWN) {
                     final IPart cable = this.getPart(ForgeDirection.UNKNOWN);
                     if (cable != null && !bp.canBePlacedOn(((IPartCable) cable).supportsBuses())) {
-                        return false;
-                    }
-
-                    if (Platform.isMultiPartLoaded && bp instanceof PartBasicState
-                            && this.getTile() instanceof TileMultipart) {
                         return false;
                     }
 

--- a/src/main/java/appeng/parts/PartPlacement.java
+++ b/src/main/java/appeng/parts/PartPlacement.java
@@ -31,6 +31,8 @@ import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent.Action;
 import net.minecraftforge.event.world.BlockEvent;
 
+import org.jetbrains.annotations.Nullable;
+
 import com.google.common.base.Optional;
 
 import appeng.api.AEApi;
@@ -78,11 +80,7 @@ public class PartPlacement {
 
             final Block block = world.getBlock(x, y, z);
             final TileEntity tile = world.getTileEntity(x, y, z);
-            IPartHost host = null;
-
-            if (tile instanceof IPartHost) {
-                host = (IPartHost) tile;
-            }
+            final IPartHost host = getExistingHost(tile);
 
             if (host != null) {
                 if (!world.isRemote) {
@@ -139,11 +137,7 @@ public class PartPlacement {
         }
 
         TileEntity tile = world.getTileEntity(x, y, z);
-        IPartHost host = null;
-
-        if (tile instanceof IPartHost) {
-            host = (IPartHost) tile;
-        }
+        IPartHost host = getExistingHost(tile);
 
         if (held != null) {
             final IFacadePart fp = isFacade(held, side);
@@ -178,14 +172,8 @@ public class PartPlacement {
             }
         }
 
-        if (host == null && tile != null && IntegrationRegistry.INSTANCE.isEnabled(IntegrationType.FMP)) {
-            host = ((IFMP) IntegrationRegistry.INSTANCE.getInstance(IntegrationType.FMP)).getOrCreateHost(tile);
-        }
-
-        if (host == null && tile != null
-                && IntegrationRegistry.INSTANCE.isEnabled(IntegrationType.ImmibisMicroblocks)) {
-            host = ((IImmibisMicroblocks) IntegrationRegistry.INSTANCE.getInstance(IntegrationType.ImmibisMicroblocks))
-                    .getOrCreateHost(player, face, tile);
+        if (host == null) {
+            host = getOrCreateHost(tile, player, face);
         }
 
         // if ( held == null )
@@ -235,19 +223,7 @@ public class PartPlacement {
             te_z = z + offset.offsetZ;
 
             tile = world.getTileEntity(te_x, te_y, te_z);
-            if (tile instanceof IPartHost) {
-                host = (IPartHost) tile;
-            }
-
-            if (host == null && tile != null && IntegrationRegistry.INSTANCE.isEnabled(IntegrationType.FMP)) {
-                host = ((IFMP) IntegrationRegistry.INSTANCE.getInstance(IntegrationType.FMP)).getOrCreateHost(tile);
-            }
-
-            if (host == null && tile != null
-                    && IntegrationRegistry.INSTANCE.isEnabled(IntegrationType.ImmibisMicroblocks)) {
-                host = ((IImmibisMicroblocks) IntegrationRegistry.INSTANCE
-                        .getInstance(IntegrationType.ImmibisMicroblocks)).getOrCreateHost(player, face, tile);
-            }
+            host = getOrCreateHost(tile, player, face);
 
             final Optional<ItemStack> maybeMultiPartStack = multiPart.maybeStack(1);
             final Optional<Block> maybeMultiPartBlock = multiPart.maybeBlock();
@@ -274,10 +250,7 @@ public class PartPlacement {
                             0)) {
                 if (!world.isRemote) {
                     tile = world.getTileEntity(te_x, te_y, te_z);
-
-                    if (tile instanceof IPartHost) {
-                        host = (IPartHost) tile;
-                    }
+                    host = getExistingHost(tile);
 
                     pass = PlaceType.INTERACT_SECOND_PASS;
                 } else {
@@ -302,10 +275,7 @@ public class PartPlacement {
 
                 final Block blkID = world.getBlock(te_x, te_y, te_z);
                 tile = world.getTileEntity(te_x, te_y, te_z);
-
-                if (tile != null && IntegrationRegistry.INSTANCE.isEnabled(IntegrationType.FMP)) {
-                    host = ((IFMP) IntegrationRegistry.INSTANCE.getInstance(IntegrationType.FMP)).getOrCreateHost(tile);
-                }
+                host = getOrCreateHost(tile, player, face);
 
                 if ((blkID == null || blkID.isReplaceable(world, te_x, te_y, te_z) || host != null)
                         && side != ForgeDirection.UNKNOWN) {
@@ -443,7 +413,7 @@ public class PartPlacement {
             if (mop != null && mop.hitVec.distanceTo(vec3) < d0) {
                 final World w = event.entity.worldObj;
                 final TileEntity te = w.getTileEntity(mop.blockX, mop.blockY, mop.blockZ);
-                if (te instanceof IPartHost && this.wasCanceled) {
+                if (getExistingHost(te) != null && this.wasCanceled) {
                     event.setCanceled(true);
                 }
             } else {
@@ -482,6 +452,47 @@ public class PartPlacement {
 
             this.placing.set(null);
         }
+    }
+
+    @Nullable
+    private static IPartHost getExistingHost(@Nullable final TileEntity tile) {
+        if (tile == null) {
+            return null;
+        }
+
+        if (tile instanceof IPartHost host) {
+            return host;
+        }
+
+        final IFMP fmp = IntegrationRegistry.INSTANCE.getInstanceIfEnabled(IntegrationType.FMP);
+        if (fmp != null && fmp.getCableContainer(tile) != null) {
+            return fmp.getOrCreateHost(tile);
+        }
+
+        return null;
+    }
+
+    @Nullable
+    private static IPartHost getOrCreateHost(@Nullable final TileEntity tile, final EntityPlayer player,
+            final int face) {
+        IPartHost host = getExistingHost(tile);
+
+        if (host == null && tile != null) {
+            final IFMP fmp = IntegrationRegistry.INSTANCE.getInstanceIfEnabled(IntegrationType.FMP);
+            if (fmp != null) {
+                host = fmp.getOrCreateHost(tile);
+            }
+        }
+
+        if (host == null && tile != null) {
+            final IImmibisMicroblocks immibis = IntegrationRegistry.INSTANCE
+                    .getInstanceIfEnabled(IntegrationType.ImmibisMicroblocks);
+            if (immibis != null) {
+                host = immibis.getOrCreateHost(player, face, tile);
+            }
+        }
+
+        return host;
     }
 
     public enum PlaceType {

--- a/src/main/java/appeng/parts/automation/PartBaseAnnihilationPlane.java
+++ b/src/main/java/appeng/parts/automation/PartBaseAnnihilationPlane.java
@@ -9,12 +9,12 @@ import net.minecraftforge.common.util.ForgeDirection;
 import appeng.api.networking.events.MENetworkChannelsChanged;
 import appeng.api.networking.events.MENetworkEventSubscribe;
 import appeng.api.networking.events.MENetworkPowerStatusChange;
-import appeng.api.parts.IPart;
 import appeng.api.parts.IPartCollisionHelper;
 import appeng.api.parts.IPartHost;
 import appeng.api.parts.IPartRenderHelper;
 import appeng.client.texture.CableBusTextures;
 import appeng.parts.PartBasicState;
+import appeng.util.Platform;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
@@ -164,12 +164,8 @@ public abstract class PartBaseAnnihilationPlane extends PartBasicState {
         return 1;
     }
 
-    protected boolean isAnnihilationPlane(final TileEntity blockTileEntity, final ForgeDirection side) {
-        if (blockTileEntity instanceof IPartHost iph) {
-            final IPart p = iph.getPart(side);
-            return p instanceof PartBaseAnnihilationPlane;
-        }
-        return false;
+    protected boolean isAnnihilationPlane(final TileEntity te, final ForgeDirection side) {
+        return Platform.getPartFromTE(te, side) instanceof PartBaseAnnihilationPlane;
     }
 
     @Override

--- a/src/main/java/appeng/parts/automation/PartBaseFormationPlane.java
+++ b/src/main/java/appeng/parts/automation/PartBaseFormationPlane.java
@@ -14,7 +14,6 @@ import net.minecraftforge.common.util.ForgeDirection;
 import appeng.api.networking.events.MENetworkChannelsChanged;
 import appeng.api.networking.events.MENetworkEventSubscribe;
 import appeng.api.networking.events.MENetworkPowerStatusChange;
-import appeng.api.parts.IPart;
 import appeng.api.parts.IPartCollisionHelper;
 import appeng.api.parts.IPartHost;
 import appeng.api.parts.IPartRenderHelper;
@@ -283,12 +282,8 @@ public abstract class PartBaseFormationPlane extends PartUpgradeable
         this.blocked = !w.getBlock(x, y, z).isReplaceable(w, x, y, z);
     }
 
-    protected boolean isTransitionPlane(final TileEntity blockTileEntity, final ForgeDirection side) {
-        if (blockTileEntity instanceof IPartHost) {
-            final IPart p = ((IPartHost) blockTileEntity).getPart(side);
-            return p instanceof PartBaseFormationPlane;
-        }
-        return false;
+    protected boolean isTransitionPlane(final TileEntity te, final ForgeDirection side) {
+        return (Platform.getPartFromTE(te, side) instanceof PartBaseFormationPlane);
     }
 
     @Override

--- a/src/main/java/appeng/parts/misc/PartPatternRepeater.java
+++ b/src/main/java/appeng/parts/misc/PartPatternRepeater.java
@@ -68,7 +68,6 @@ import appeng.me.helpers.AENetworkProxy;
 import appeng.me.storage.MEMonitorPassThrough;
 import appeng.me.storage.NullInventory;
 import appeng.parts.PartBasicState;
-import appeng.tile.networking.TileCableBus;
 import appeng.util.Platform;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -298,14 +297,13 @@ public class PartPatternRepeater extends PartBasicState
                 self.yCoord + this.getSide().offsetY,
                 self.zCoord + this.getSide().offsetZ);
 
-        if (target instanceof TileCableBus tcb
-                && tcb.getPart(this.getSide().getOpposite()) instanceof PartPatternRepeater ppr) {
+        if (Platform.getPartFromTE(target, this.getSide().getOpposite()) instanceof PartPatternRepeater ppr) {
             this.pairPatternRepeater = ppr;
             this.targetNetworkProxy = ppr.getProxy();
 
             if (this.provider) {
                 if (ppr.provider) return;
-                final IGridNode gn = tcb.getGridNode(ForgeDirection.UNKNOWN);
+                final IGridNode gn = ppr.getGridNode(ForgeDirection.UNKNOWN);
                 if (gn == null) return;
 
                 this.duringFletchPatterns = true;

--- a/src/main/java/appeng/parts/misc/PartStorageBus.java
+++ b/src/main/java/appeng/parts/misc/PartStorageBus.java
@@ -712,11 +712,8 @@ public class PartStorageBus extends PartUpgradeable implements IStorageBus {
             achievement = (IInterfaceHost) target;
         }
 
-        if (target instanceof IPartHost) {
-            final Object part = ((IPartHost) target).getPart(side);
-            if (part instanceof IInterfaceHost) {
-                achievement = (IInterfaceHost) part;
-            }
+        if (Platform.getPartFromTE(target, side) instanceof IInterfaceHost host) {
+            achievement = host;
         }
 
         if (achievement != null && achievement.getActionableNode() != null) {

--- a/src/main/java/appeng/util/InventoryAdaptor.java
+++ b/src/main/java/appeng/util/InventoryAdaptor.java
@@ -19,6 +19,7 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.ISidedInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityChest;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.IFluidHandler;
@@ -43,7 +44,6 @@ import appeng.integration.abstraction.IThaumicTinkerer;
 import appeng.parts.p2p.PartP2PItems;
 import appeng.parts.p2p.PartP2PLiquids;
 import appeng.tile.misc.TileInterface;
-import appeng.tile.networking.TileCableBus;
 import appeng.tile.storage.TileChest;
 import appeng.util.inv.AdaptorConduitBandle;
 import appeng.util.inv.AdaptorDualityInterface;
@@ -232,11 +232,8 @@ public abstract class InventoryAdaptor implements Iterable<ItemSlot> {
                 return new AdaptorDualityInterface(new WrapperMCISidedInventory(sided, d), (IInterfaceHost) te);
             }
 
-            if (te instanceof TileCableBus cableBus) {
-                IPart part = cableBus.getPart(d);
-                if (part == null) {
-                    return null;
-                }
+            if (te instanceof TileEntity tile) {
+                IPart part = Platform.getPartFromTE(tile, d);
 
                 if (invs && part instanceof IInterfaceHost host) {
                     return new AdaptorDualityInterface(new WrapperMCISidedInventory(sided, d), host);

--- a/src/main/java/appeng/util/Platform.java
+++ b/src/main/java/appeng/util/Platform.java
@@ -183,7 +183,6 @@ public class Platform {
     private static final DecimalFormat df = new DecimalFormat("#.##");
     public static final boolean isAE2FCLoaded = Loader.isModLoaded("ae2fc");
     public static final boolean isEIOLoaded = Loader.isModLoaded("EnderIO");
-    public static final boolean isMultiPartLoaded = Loader.isModLoaded("ForgeMultipart");
     public static final boolean isBaublesLoaded = Loader.isModLoaded("Baubles|Expanded");
     public static final boolean isBackhandLoaded = Loader.isModLoaded("backhand");
     public static final boolean isPosteaLoaded = Loader.isModLoaded("postea");

--- a/src/main/java/appeng/util/Platform.java
+++ b/src/main/java/appeng/util/Platform.java
@@ -102,6 +102,9 @@ import appeng.api.networking.security.ISecurityGrid;
 import appeng.api.networking.security.MachineSource;
 import appeng.api.networking.security.PlayerSource;
 import appeng.api.networking.storage.IStorageGrid;
+import appeng.api.parts.IPart;
+import appeng.api.parts.IPartHost;
+import appeng.api.parts.SelectedPart;
 import appeng.api.storage.IMEInventory;
 import appeng.api.storage.IMEMonitor;
 import appeng.api.storage.IMEMonitorHandlerReceiver;
@@ -126,10 +129,12 @@ import appeng.core.sync.GuiHostType;
 import appeng.hooks.TickHandler;
 import appeng.integration.IntegrationRegistry;
 import appeng.integration.IntegrationType;
+import appeng.integration.abstraction.IFMP;
 import appeng.integration.abstraction.IGT;
 import appeng.me.GridAccessException;
 import appeng.me.GridNode;
 import appeng.me.helpers.AENetworkProxy;
+import appeng.parts.CableBusContainer;
 import appeng.util.item.AEFluidStack;
 import appeng.util.item.AEItemStack;
 import appeng.util.item.AESharedNBT;
@@ -2191,5 +2196,38 @@ public class Platform {
         final ItemStack container = AEApi.instance().definitions().items().itemMEStackPacket().maybeStack(1).get();
         Platform.writeStackNBT(aes, ItemStackNBT.get(container));
         addToPlayerInvOrDrop(p, container);
+    }
+
+    /**
+     * Finds the AE2 part on the requested side of a cable bus tile.
+     * <p>
+     * Normal cable buses expose {@link IPartHost} directly, while ForgeMultipart stores the AE2 cable bus inside a
+     * {@link CableBusContainer} owned by a multipart tile entity.
+     */
+    @Nullable
+    public static IPart getPartFromTE(@Nullable final TileEntity te, @NotNull final ForgeDirection side) {
+        if (te == null) return null;
+        if (te instanceof IPartHost host) return host.getPart(side);
+
+        IFMP fmp = IntegrationRegistry.INSTANCE.getInstanceIfEnabled(IntegrationType.FMP);
+        CableBusContainer cb = fmp != null ? fmp.getCableContainer(te) : null;
+        return cb != null ? cb.getPart(side) : null;
+    }
+
+    /**
+     * Selects the AE2 part hit inside a cable bus tile.
+     * <p>
+     * The position must be block-local, matching {@link IPartHost#selectPart(Vec3)} and
+     * {@link CableBusContainer#selectPart(Vec3)}. This preserves normal facade handling for both standard cable buses
+     * and ForgeMultipart cable bus parts.
+     */
+    @Nullable
+    public static SelectedPart selectPartFromTE(@Nullable final TileEntity te, @NotNull final Vec3 pos) {
+        if (te == null) return null;
+        if (te instanceof IPartHost host) return host.selectPart(pos);
+
+        IFMP fmp = IntegrationRegistry.INSTANCE.getInstanceIfEnabled(IntegrationType.FMP);
+        CableBusContainer cb = fmp != null ? fmp.getCableContainer(te) : null;
+        return cb != null ? cb.selectPart(pos) : null;
     }
 }

--- a/src/main/java/appeng/util/inv/AdaptorDualityInterface.java
+++ b/src/main/java/appeng/util/inv/AdaptorDualityInterface.java
@@ -89,4 +89,10 @@ public class AdaptorDualityInterface extends AdaptorIInventory {
         }
         return super.containsItems();
     }
+
+    public boolean isEmpty(IAEStackType<?> type) {
+        IMEMonitor<?> monitor = interfaceHost.getInterfaceDuality().getMEMonitor(type);
+        if (monitor == null) return true;
+        return monitor.getStorageList().isEmpty();
+    }
 }


### PR DESCRIPTION
Actually fixes:
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17039
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18673
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19852
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/23471

And revert https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/977

In the Multipart case, the tile entity is `TileMultipart`, not `CableBusPart`.
This means `CableBusPart` has to be retrieved from inside the `TileMultipart`, and a simple `instanceof` check is not enough to get the part.