### PR TITLE
Fix multi-type storage cells not showing contents in tooltip

### DIFF
--- a/src/main/java/appeng/core/localization/GuiText.java
+++ b/src/main/java/appeng/core/localization/GuiText.java
@@ -408,7 +408,9 @@ public enum GuiText implements Localization {
     itemMEStackPacketDesc1,
     itemMEStackPacketDesc2,
 
-    WirelessManagerToolTips;
+    WirelessManagerToolTips,
+
+    HoldCtrlForContents;
 
     private final String root;
 

--- a/src/main/java/appeng/items/AEBaseCell.java
+++ b/src/main/java/appeng/items/AEBaseCell.java
@@ -34,6 +34,7 @@ import appeng.api.implementations.items.IUpgradeModule;
 import appeng.api.storage.ICellHandler;
 import appeng.api.storage.ICellInventoryHandler;
 import appeng.api.storage.IMEInventoryHandler;
+import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.storage.data.IAEStack;
 import appeng.api.storage.data.IAEStackType;
 import appeng.api.storage.data.IItemList;
@@ -52,6 +53,7 @@ import appeng.tile.inventory.IAEStackInventory;
 import appeng.util.InventoryAdaptor;
 import appeng.util.IterationCounter;
 import appeng.util.Platform;
+import appeng.util.ReadableNumberConverter;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
@@ -163,9 +165,10 @@ public abstract class AEBaseCell extends AEBaseItem implements IStorageCell, IIt
                 IAEStack<?> aes = contents.getFirstItem();
                 lines.add(GuiText.Contains.getLocal() + ": " + aes.getDisplayName());
             } else if (GuiScreen.isCtrlKeyDown()) {
-                final NumberFormat nf = NumberFormat.getInstance(Locale.ENGLISH);
                 for (IAEStack<?> aeStack : contents) {
-                    lines.add("  " + aeStack.getDisplayName() + " x" + nf.format(aeStack.getStackSize()));
+                    String amount = ReadableNumberConverter.INSTANCE.toWideReadableForm(aeStack.getStackSize());
+                    String suffix = aeStack instanceof IAEFluidStack ? " mB" : "";
+                    lines.add("  " + aeStack.getDisplayName() + " x" + amount + suffix);
                 }
             } else {
                 lines.add(EnumChatFormatting.GRAY + GuiText.HoldCtrlForContents.getLocal());

--- a/src/main/java/appeng/items/AEBaseCell.java
+++ b/src/main/java/appeng/items/AEBaseCell.java
@@ -155,11 +155,21 @@ public abstract class AEBaseCell extends AEBaseItem implements IStorageCell, IIt
                         + EnumChatFormatting.GRAY
                         + GuiText.Types.getLocal());
 
-        if (cellInventory.getTotalItemTypes() == 1 && cellInventory.getStoredItemTypes() != 0) {
-            IAEStack<?> aes = handler.getAvailableItems(
+        if (cellInventory.getStoredItemTypes() != 0) {
+            IItemList<?> contents = handler.getAvailableItems(
                     cellInventory.getStackType().createPrimitiveList(),
-                    IterationCounter.fetchNewId()).getFirstItem();
-            lines.add(GuiText.Contains.getLocal() + ": " + aes.getDisplayName());
+                    IterationCounter.fetchNewId());
+            if (cellInventory.getTotalItemTypes() == 1) {
+                IAEStack<?> aes = contents.getFirstItem();
+                lines.add(GuiText.Contains.getLocal() + ": " + aes.getDisplayName());
+            } else if (GuiScreen.isCtrlKeyDown()) {
+                final NumberFormat nf = NumberFormat.getInstance(Locale.ENGLISH);
+                for (IAEStack<?> aeStack : contents) {
+                    lines.add("  " + aeStack.getDisplayName() + " x" + nf.format(aeStack.getStackSize()));
+                }
+            } else {
+                lines.add(EnumChatFormatting.GRAY + GuiText.HoldCtrlForContents.getLocal());
+            }
         }
 
         if (handler.isPreformatted()) {

--- a/src/main/java/appeng/items/AEBaseCell.java
+++ b/src/main/java/appeng/items/AEBaseCell.java
@@ -34,7 +34,6 @@ import appeng.api.implementations.items.IUpgradeModule;
 import appeng.api.storage.ICellHandler;
 import appeng.api.storage.ICellInventoryHandler;
 import appeng.api.storage.IMEInventoryHandler;
-import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.storage.data.IAEStack;
 import appeng.api.storage.data.IAEStackType;
 import appeng.api.storage.data.IItemList;
@@ -167,7 +166,8 @@ public abstract class AEBaseCell extends AEBaseItem implements IStorageCell, IIt
             } else if (GuiScreen.isCtrlKeyDown()) {
                 for (IAEStack<?> aeStack : contents) {
                     String amount = ReadableNumberConverter.INSTANCE.toWideReadableForm(aeStack.getStackSize());
-                    String suffix = aeStack instanceof IAEFluidStack ? " mB" : "";
+                    String unit = cellInventory.getStackType().getDisplayUnit();
+                    String suffix = unit.isEmpty() ? "" : " " + unit;
                     lines.add("  " + aeStack.getDisplayName() + " x" + amount + suffix);
                 }
             } else {

--- a/src/main/resources/assets/appliedenergistics2/lang/en_US.lang
+++ b/src/main/resources/assets/appliedenergistics2/lang/en_US.lang
@@ -517,6 +517,7 @@ gui.appliedenergistics2.itemMEStackPacketDesc1=Leftover after inject in system o
 gui.appliedenergistics2.itemMEStackPacketDesc2=Make sure you have free space and then put this item in ME Terminal
 
 gui.appliedenergistics2.WirelessManagerToolTips=Network\n§6LClick§7 - Select\n §6+ WirelessExtraAction§7 - Rename\n §6+ Sneak§7 - Remove
+gui.appliedenergistics2.HoldCtrlForContents=Hold Ctrl for cell contents
 
 # GUI Tooltips
 gui.tooltips.appliedenergistics2.Stash=Store Items


### PR DESCRIPTION
AE2FluidCraft-Rework's Universal GUI refactor removed the fluid cell tooltip override and started relying on AEBaseCell.addCheckedInformation(), which only showed contents for single-type cells. Multi-type cells (like multi-fluid storage cells) never displayed their stored items.

Cell tooltips now show stored contents for multi-type cells while Ctrl is held, matching the old AE2FC behavior.
<img width="1147" height="415" alt="image" src="https://github.com/user-attachments/assets/a527a2e9-7baf-475f-997c-a720e0074895" />

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25397