### PR TITLE
prevent gl color state contamination

### DIFF
--- a/src/main/java/appeng/client/gui/widgets/GuiCraftingList.java
+++ b/src/main/java/appeng/client/gui/widgets/GuiCraftingList.java
@@ -103,6 +103,7 @@ public class GuiCraftingList {
                             GL11.glPushMatrix();
                             GL11.glClear(GL11.GL_COLOR_BUFFER_BIT | GL11.GL_DEPTH_BUFFER_BIT);
                             GL11.glScaled(4, 4, 1);
+                            GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
                             parent.bindTexture(FIELD_TEXTURE);
                             parent.drawTexturedModalRect(
                                     0,
@@ -118,6 +119,7 @@ public class GuiCraftingList {
                             GL11.glPushMatrix();
                             GL11.glClear(GL11.GL_COLOR_BUFFER_BIT | GL11.GL_DEPTH_BUFFER_BIT);
                             GL11.glScaled(4, 4, 1);
+                            GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
                             parent.bindTexture(FIELD_TEXTURE);
                             parent.drawTexturedModalRect(0, 0, 0, 0, FIELD_WIDTH, FIELD_HEIGHT);
                             GL11.glPopMatrix();
@@ -210,6 +212,7 @@ public class GuiCraftingList {
             GL11.glPushMatrix();
             GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS);
             GL11.glScaled(2.0d, 2.0d, 0.5d);
+            GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
 
             int lines = 0;
 


### PR DESCRIPTION
now version cause gl color state contamination, fix it
add color reset to prevent it

| now | fixed |
| :-: | :-: |
| <img width="4126" height="3991" alt="2026-06-22_02 35 00-ae2" src="https://github.com/user-attachments/assets/08f1b6a4-ec46-48ed-8ff2-611b90c6ce43" /> | <img width="4126" height="3706" alt="dda8285994986e9965b8521ca4f2c09d" src="https://github.com/user-attachments/assets/7f9ef23f-10e6-4064-bf59-4282fc4f27a4" />|
