### PR TITLE
Only update network visualiser from selected slot

### DIFF
--- a/src/main/java/appeng/items/tools/ToolNetworkVisualiser.java
+++ b/src/main/java/appeng/items/tools/ToolNetworkVisualiser.java
@@ -228,8 +228,6 @@ public class ToolNetworkVisualiser extends AEBaseItem {
         return false;
     }
 
-    ItemStack currItem;
-
     @Override
     public void onUpdate(ItemStack is, World w, Entity entity, int slot, boolean active) {
         if (!active || Platform.isClient()
@@ -237,14 +235,6 @@ public class ToolNetworkVisualiser extends AEBaseItem {
                 || is.getTagCompound() == null) {
             return;
         }
-        ItemStack currentItem = player.inventory.getCurrentItem();
-        if (currentItem != currItem) {
-            currItem = currentItem;
-        }
-        if (currentItem == null || !(currentItem.getItem() instanceof ToolNetworkVisualiser)) {
-            return;
-        }
-        currItem = currentItem;
 
         DimensionalCoord dc = DimensionalCoord.readFromNBT(is.getTagCompound());
         if (w.provider.dimensionId != dc.getDimension()) return;

--- a/src/main/java/appeng/items/tools/ToolNetworkVisualiser.java
+++ b/src/main/java/appeng/items/tools/ToolNetworkVisualiser.java
@@ -232,7 +232,9 @@ public class ToolNetworkVisualiser extends AEBaseItem {
 
     @Override
     public void onUpdate(ItemStack is, World w, Entity entity, int slot, boolean active) {
-        if (Platform.isClient() || !(entity instanceof EntityPlayerMP player) || is.getTagCompound() == null) {
+        if (!active || Platform.isClient()
+                || !(entity instanceof EntityPlayerMP player)
+                || is.getTagCompound() == null) {
             return;
         }
         ItemStack currentItem = player.inventory.getCurrentItem();


### PR DESCRIPTION
## Summary
hopefully fixes https://discord.com/channels/181078474394566657/522098956491030558/1519016880155787435

When there were multiple visualizers in the inventory, the ones not being held were also being updated.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
