### PR TITLE
Fix fake crafting

### DIFF
--- a/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
+++ b/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
@@ -935,6 +935,11 @@ public class CraftingCPUCluster implements IAECluster, ICraftingCPU {
                         }
 
                         if (this.finalOutput.isFakeCrafting() && this.finalOutput.isFinalPattern(details)) {
+                            craftingInventory = null; // hand off complete!
+                            didPatternCraft = true;
+                            this.markDirty();
+
+                            executedTasks += 1;
                             craftingEntry.getValue().value--;
 
                             if (craftingEntry.getValue().value <= 0) {
@@ -945,11 +950,30 @@ public class CraftingCPUCluster implements IAECluster, ICraftingCPU {
 
                                 this.finalOutput.performFakeCrafting(details);
 
-                                break;
+                                break doWhileCraftingLoop;
                             } else {
                                 this.finalOutput.performFakeCrafting(details);
 
-                                continue;
+                                if (this.remainingOperations == 0) {
+                                    if (mediumListCheck != null) parallelismProvider.put(details, mediumListCheck);
+                                    return;
+                                }
+
+                                // Smart blocking is fine sending the same recipe again.
+                                if (medium.getBlockingMode() == BlockingMode.BLOCKING) break;
+
+                                final List<IAEStack<?>> condensedInputsForRetry = getExpandedCondensedInputs(
+                                        details,
+                                        cc);
+                                if (condensedInputsForRetry == null) {
+                                    throw new IllegalStateException("Input-only pattern expansion failed");
+                                }
+                                if (!this.canCraft(details, condensedInputsForRetry)) {
+                                    sr = ScheduledReason.NOT_ENOUGH_INGREDIENTS;
+                                    break;
+                                }
+
+                                continue doWhileCraftingLoop;
                             }
                         }
 

--- a/src/main/java/appeng/util/inv/AdaptorItemIO.java
+++ b/src/main/java/appeng/util/inv/AdaptorItemIO.java
@@ -5,6 +5,7 @@ import java.util.Iterator;
 import net.minecraft.item.ItemStack;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import com.google.common.collect.Iterators;
 import com.gtnewhorizon.gtnhlib.capability.item.ItemIO;
@@ -15,6 +16,7 @@ import com.gtnewhorizon.gtnhlib.item.InventoryIterator;
 import com.gtnewhorizon.gtnhlib.util.ItemUtil;
 
 import appeng.api.config.FuzzyMode;
+import appeng.api.config.InsertionMode;
 import appeng.util.InventoryAdaptor;
 import appeng.util.Platform;
 
@@ -173,6 +175,17 @@ public class AdaptorItemIO extends InventoryAdaptor {
     }
 
     @Override
+    public ItemStack addItems(ItemStack toBeAdded, InsertionMode insertionMode) {
+        if (toBeAdded == null || toBeAdded.stackSize == 0) return null;
+        if (insertionMode == InsertionMode.DEFAULT) return addItems(toBeAdded);
+
+        ItemStack left = insertIntoEmptySlots(toBeAdded, itemIO.sinkIterator());
+        if (left == null || insertionMode == InsertionMode.ONLY_EMPTY) return left;
+
+        return addItems(left);
+    }
+
+    @Override
     public ItemStack simulateAdd(ItemStack toBeSimulated) {
         if (toBeSimulated == null || toBeSimulated.stackSize == 0) return null;
 
@@ -190,6 +203,34 @@ public class AdaptorItemIO extends InventoryAdaptor {
         }
 
         final ItemStack left = toBeSimulated.copy();
+        left.stackSize = insertion.getStackSize();
+        return left;
+    }
+
+    @Override
+    public ItemStack simulateAdd(ItemStack toBeSimulated, InsertionMode insertionMode) {
+        if (toBeSimulated == null || toBeSimulated.stackSize == 0) return null;
+        if (insertionMode != InsertionMode.ONLY_EMPTY) return simulateAdd(toBeSimulated);
+
+        return insertIntoEmptySlots(toBeSimulated, itemIO.simulatedSinkIterator());
+    }
+
+    private static @Nullable ItemStack insertIntoEmptySlots(ItemStack stack, @Nullable InventoryIterator iter) {
+        if (iter == null) return stack;
+
+        InsertionItemStack insertion = new InsertionItemStack(new FastImmutableItemStack(stack));
+
+        while (iter.hasNext()) {
+            ImmutableItemStack slot = iter.next();
+
+            if (slot != null && !slot.isEmpty()) continue;
+
+            insertion.set(iter.insert(insertion, false));
+
+            if (insertion.isEmpty()) return null;
+        }
+
+        final ItemStack left = stack.copy();
         left.stackSize = insertion.getStackSize();
         return left;
     }


### PR DESCRIPTION
## Summary
Fixes https://github.com/GTNewHorizons/Dupes-Exploits-GTNH/issues/325

If `craftingInventory` is not set to null after a successful `pushPattern()`, the subsequent `returnItems` will return the input to the network, causing item duplication.
And some handling was missing in the fake crafting branch, so this change brings it in line with the normal crafting branch.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
