### PR TITLE
restore stuck tint remove stuck highlight

### DIFF
--- a/src/main/java/appeng/client/render/blocks/RenderBlockInterface.java
+++ b/src/main/java/appeng/client/render/blocks/RenderBlockInterface.java
@@ -19,6 +19,7 @@ import appeng.block.misc.BlockInterface;
 import appeng.client.render.BaseBlockRender;
 import appeng.client.render.BlockRenderInfo;
 import appeng.client.texture.ExtraBlockTextures;
+import appeng.core.AEConfig;
 import appeng.tile.misc.TileInterface;
 
 public class RenderBlockInterface extends BaseBlockRender<BlockInterface, TileInterface> {
@@ -44,7 +45,15 @@ public class RenderBlockInterface extends BaseBlockRender<BlockInterface, TileIn
                     side);
         }
 
-        final boolean fz = super.renderInWorld(block, world, x, y, z, renderer);
+        this.preRenderInWorld(block, world, x, y, z, renderer);
+        boolean fz;
+        if (AEConfig.instance.highlightWhenSomethingStuckInInterface && ti != null && ti.isStuck()) {
+            fz = renderer.renderStandardBlockWithColorMultiplier(block, x, y, z, 0.75f, 0.5f, 0.5f);
+        } else {
+            fz = renderer.renderStandardBlock(block, x, y, z);
+        }
+
+        this.postRenderInWorld(renderer);
 
         info.setTemporaryRenderIcon(null);
 

--- a/src/main/java/appeng/client/render/blocks/RenderBlockInterface.java
+++ b/src/main/java/appeng/client/render/blocks/RenderBlockInterface.java
@@ -20,6 +20,7 @@ import appeng.client.render.BaseBlockRender;
 import appeng.client.render.BlockRenderInfo;
 import appeng.client.texture.ExtraBlockTextures;
 import appeng.core.AEConfig;
+import appeng.core.localization.ColorUtils;
 import appeng.tile.misc.TileInterface;
 
 public class RenderBlockInterface extends BaseBlockRender<BlockInterface, TileInterface> {
@@ -48,7 +49,11 @@ public class RenderBlockInterface extends BaseBlockRender<BlockInterface, TileIn
         this.preRenderInWorld(block, world, x, y, z, renderer);
         boolean fz;
         if (AEConfig.instance.highlightWhenSomethingStuckInInterface && ti != null && ti.isStuck()) {
-            fz = renderer.renderStandardBlockWithColorMultiplier(block, x, y, z, 0.75f, 0.5f, 0.5f);
+            final int color = ColorUtils.interfaceStuck.getColor();
+            final float r = ((color >> 16) & 0xFF) / 255.0f;
+            final float g = ((color >> 8) & 0xFF) / 255.0f;
+            final float b = (color & 0xFF) / 255.0f;
+            fz = renderer.renderStandardBlockWithColorMultiplier(block, x, y, z, r, g, b);
         } else {
             fz = renderer.renderStandardBlock(block, x, y, z);
         }

--- a/src/main/java/appeng/core/localization/ColorUtils.java
+++ b/src/main/java/appeng/core/localization/ColorUtils.java
@@ -39,7 +39,8 @@ public class ColorUtils {
         wirelessKitNeutral                  = color.rgb("wirelessKitNeutral",                   "0xFAAE44"),
         wirelessKitBad                      = color.rgb("wirelessKitBad",                       "0xFF003C"),
         contextMenuText                     = color.rgb("contextMenuText",                      "0x404040"),
-        
+        interfaceStuck                      = color.rgb("interfaceStuck",                       "0xff8080"),
+
         searchboxFocused                    = color.argb("searchboxFocused",                    "0x6E000000"),
         searchboxUnfocused                  = color.argb("searchboxUnfocused",                  "0x00000000"),
         itemSlotOverlayUnpowered            = color.argb("itemSlotOverlayUnpowered",            "0x66111111"),

--- a/src/main/java/appeng/tile/misc/TileInterface.java
+++ b/src/main/java/appeng/tile/misc/TileInterface.java
@@ -10,15 +10,12 @@
 
 package appeng.tile.misc;
 
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import net.minecraft.client.Minecraft;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.ItemStack;
@@ -61,8 +58,6 @@ import appeng.api.util.AECableType;
 import appeng.api.util.DimensionalCoord;
 import appeng.api.util.IConfigManager;
 import appeng.capabilities.MEItemIO;
-import appeng.client.render.highlighter.BlockPosHighlighter;
-import appeng.core.AEConfig;
 import appeng.helpers.DualityInterface;
 import appeng.helpers.IInterfaceHost;
 import appeng.helpers.IPrimaryGuiIconProvider;
@@ -74,15 +69,12 @@ import appeng.tile.grid.AENetworkInvTile;
 import appeng.tile.inventory.InvOperation;
 import appeng.util.Platform;
 import appeng.util.inv.IInventoryDestination;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 import io.netty.buffer.ByteBuf;
 
 public class TileInterface extends AENetworkInvTile
         implements IGridTickable, ITileStorageMonitorable, IStorageMonitorable, IInventoryDestination, IInterfaceHost,
         IPriorityHost, IPowerChannelState, IPrimaryGuiIconProvider {
 
-    private static final long STUCK_HIGHLIGHT_REFRESH_MS = 2000L;
     private final DualityInterface duality = new DualityInterface(this.getProxy(), this);
     private ForgeDirection pointAt = ForgeDirection.UNKNOWN;
 
@@ -91,7 +83,6 @@ public class TileInterface extends AENetworkInvTile
     private static final int BOOTING_FLAG = 4;
     private static final int STUCK_FLAG = 8;
     private int clientFlags = 0; // sent as byte.
-    private long nextStuckHighlightAt = 0L;
 
     @MENetworkEventSubscribe
     public void stateChange(final MENetworkChannelsChanged c) {
@@ -325,11 +316,8 @@ public class TileInterface extends AENetworkInvTile
         }
 
         if (oldStuck != isStuck()) {
-            if (isStuck()) {
-                this.highlightStuckInterface();
-            } else {
-                this.nextStuckHighlightAt = 0L;
-            }
+            this.markForUpdate();
+            changed = true;
         }
 
         return changed;
@@ -351,31 +339,6 @@ public class TileInterface extends AENetworkInvTile
         data.writeByte(clientFlags);
     }
 
-    @SideOnly(Side.CLIENT)
-    @TileEvent(TileEventType.TICK)
-    public void tickStuckHighlight_TileInterface() {
-        if (this.isStuck()) {
-            final long now = System.currentTimeMillis();
-            if (now >= this.nextStuckHighlightAt) {
-                this.highlightStuckInterface();
-            }
-        }
-    }
-
-    private void highlightStuckInterface() {
-        if (AEConfig.instance.highlightWhenSomethingStuckInInterface && Platform.isClient()) {
-            this.doStuckHighlightOnClient();
-        }
-    }
-
-    @SideOnly(Side.CLIENT)
-    private void doStuckHighlightOnClient() {
-        final EntityPlayer player = Minecraft.getMinecraft().thePlayer;
-        if (player == null) return;
-        BlockPosHighlighter.highlightBlocks(player, Collections.singletonList(new DimensionalCoord(this)), null, null);
-        this.nextStuckHighlightAt = System.currentTimeMillis() + STUCK_HIGHLIGHT_REFRESH_MS;
-    }
-
     @Override
     public boolean isPowered() {
         return (clientFlags & POWERED_FLAG) == POWERED_FLAG;
@@ -391,7 +354,7 @@ public class TileInterface extends AENetworkInvTile
         return (clientFlags & BOOTING_FLAG) == BOOTING_FLAG;
     }
 
-    private boolean isStuck() {
+    public boolean isStuck() {
         return (clientFlags & STUCK_FLAG) == STUCK_FLAG;
     }
 


### PR DESCRIPTION
## Summary
Remove stuck highlight, because it is annoying and break other highlights
Restore tint because want to indicate interface with stuck


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
