### PR TITLE
More placement fixes

### DIFF
--- a/src/main/java/appeng/core/sync/packets/PacketPartInteraction.java
+++ b/src/main/java/appeng/core/sync/packets/PacketPartInteraction.java
@@ -105,10 +105,14 @@ public class PacketPartInteraction extends AppEngPacket {
             if (player.isSneaking()) {
                 if (!spart.part.onShiftActivate(player, hitVec)) {
                     resync(player);
+                } else {
+                    player.swingItem();
                 }
             } else {
                 if (!spart.part.onActivate(player, hitVec)) {
                     resync(player);
+                } else {
+                    player.swingItem();
                 }
             }
         }

--- a/src/main/java/appeng/items/parts/ItemFacade.java
+++ b/src/main/java/appeng/items/parts/ItemFacade.java
@@ -66,7 +66,6 @@ public class ItemFacade extends AEBaseItem implements IFacadeItem, IAlphaPassIte
     @Override
     public boolean onItemUse(final ItemStack is, final EntityPlayer player, final World w, final int x, final int y,
             final int z, final int side, final float hitX, final float hitY, final float hitZ) {
-        // Ideally only client side but forge send some annoying packet
         return PartPlacement.placeItemPart(is, player, w, x, y, z, ForgeDirection.getOrientation(side));
     }
 

--- a/src/main/java/appeng/items/parts/ItemFacade.java
+++ b/src/main/java/appeng/items/parts/ItemFacade.java
@@ -38,6 +38,7 @@ import appeng.core.features.AEFeature;
 import appeng.facade.FacadePart;
 import appeng.facade.IFacadeItem;
 import appeng.items.AEBaseItem;
+import appeng.parts.PartPlacement;
 import appeng.util.Platform;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.common.registry.GameRegistry.UniqueIdentifier;
@@ -65,7 +66,8 @@ public class ItemFacade extends AEBaseItem implements IFacadeItem, IAlphaPassIte
     @Override
     public boolean onItemUse(final ItemStack is, final EntityPlayer player, final World w, final int x, final int y,
             final int z, final int side, final float hitX, final float hitY, final float hitZ) {
-        return AEApi.instance().partHelper().placeBus(is, x, y, z, side, player, w);
+        // Ideally only client side but forge send some annoying packet
+        return PartPlacement.placeItemPart(is, player, w, x, y, z, ForgeDirection.getOrientation(side));
     }
 
     @Override

--- a/src/main/java/appeng/items/parts/ItemMultiPart.java
+++ b/src/main/java/appeng/items/parts/ItemMultiPart.java
@@ -190,7 +190,6 @@ public final class ItemMultiPart extends AEBaseItem implements IPartItem, IItemG
             return false;
         }
 
-        // Ideally only client side but forge send some annoying packet
         return PartPlacement.placeItemPart(is, player, w, x, y, z, ForgeDirection.getOrientation(side));
     }
 

--- a/src/main/java/appeng/items/parts/ItemMultiPart.java
+++ b/src/main/java/appeng/items/parts/ItemMultiPart.java
@@ -33,10 +33,10 @@ import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
 
 import com.google.common.base.Preconditions;
 
-import appeng.api.AEApi;
 import appeng.api.implementations.items.IItemGroup;
 import appeng.api.parts.IPart;
 import appeng.api.parts.IPartHelper;
@@ -53,6 +53,7 @@ import appeng.core.localization.GuiText;
 import appeng.integration.IntegrationRegistry;
 import appeng.integration.IntegrationType;
 import appeng.items.AEBaseItem;
+import appeng.parts.PartPlacement;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
@@ -189,7 +190,8 @@ public final class ItemMultiPart extends AEBaseItem implements IPartItem, IItemG
             return false;
         }
 
-        return AEApi.instance().partHelper().placeBus(is, x, y, z, side, player, w);
+        // Ideally only client side but forge send some annoying packet
+        return PartPlacement.placeItemPart(is, player, w, x, y, z, ForgeDirection.getOrientation(side));
     }
 
     @Override

--- a/src/main/java/appeng/parts/PartPlacement.java
+++ b/src/main/java/appeng/parts/PartPlacement.java
@@ -286,9 +286,6 @@ public class PartPlacement {
 
             player.swingItem();
             decreaseHeldItem(held, player);
-            if (world.isRemote) {
-                NetworkHandler.instance.sendToServer(new PacketPartPlacement(host, mySide, false));
-            }
             return true;
         }
         return false;

--- a/src/main/java/appeng/parts/PartPlacement.java
+++ b/src/main/java/appeng/parts/PartPlacement.java
@@ -58,10 +58,10 @@ import appeng.util.LookDirection;
 import appeng.util.Platform;
 import cpw.mods.fml.common.eventhandler.EventPriority;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.gameevent.TickEvent.ClientTickEvent;
 
 public class PartPlacement {
 
-    private static float eyeHeight = 0.0f;
     // After we do a placement and cancel the event, we will also receive event for RIGHT_CLICK_AIR
     // Only used client side, do not use this server side
     private boolean placing = false;
@@ -112,37 +112,24 @@ public class PartPlacement {
                     if (sPart.part.onShiftActivate(player, hitVec)) {
                         NetworkHandler.instance
                                 .sendToServer(new PacketPartInteraction(x, y, z, sPart.side, true, false, hitVec));
+                        player.swingItem();
                         return true;
                     }
                 } else if (pass != PlaceType.INTERACT_FIRST_PASS) {
                     if (sPart.part.onActivate(player, hitVec)) {
                         NetworkHandler.instance
                                 .sendToServer(new PacketPartInteraction(x, y, z, sPart.side, true, false, hitVec));
+                        player.swingItem();
                         return true;
                     }
                 }
             }
         }
 
+        if (pass == PlaceType.INTERACT_FIRST_PASS) return false;
+
         // analogous to onItemUse
-
-        if (held == null || !(held.getItem() instanceof IPartItem)) {
-            return false;
-        }
-
-        // Try to add the part to the target block
-        if (host != null && tryPlace(held, player, world, x, y, z, side, host)) return true;
-
-        // If that didn't work, we try to place on the face of the target block
-        int tx = x + side.offsetX;
-        int ty = y + side.offsetY;
-        int tz = z + side.offsetZ;
-        ForgeDirection opposite = side.getOpposite();
-
-        TileEntity te = world.getTileEntity(tx, ty, tz);
-        IPartHost targetHost = getOrCreateHost(te, player, opposite.ordinal());
-
-        return tryPlace(held, player, world, tx, ty, tz, opposite, targetHost);
+        return placeItemPart(held, player, world, x, y, z, side);
     }
 
     public static boolean wrenchLogic(EntityPlayer player, World world, int x, int y, int z, IPartHost host,
@@ -193,6 +180,7 @@ public class PartPlacement {
             } else if (!is.isEmpty()) {
                 Platform.spawnDrops(world, x, y, z, is);
             }
+            player.swingItem();
             return true;
         }
         return false;
@@ -210,6 +198,7 @@ public class PartPlacement {
                 if (host.canAddPart(held, side)) {
                     if (host.getFacadeContainer().addFacade(fp)) {
                         host.markForUpdate();
+                        player.swingItem();
                         decreaseHeldItem(held, player);
                         if (isClient) {
                             NetworkHandler.instance.sendToServer(new PacketPartPlacement(host, side, true));
@@ -220,6 +209,29 @@ public class PartPlacement {
             }
         }
         return false;
+    }
+
+    public static boolean placeItemPart(ItemStack held, EntityPlayer player, World world, int x, int y, int z,
+            ForgeDirection side) {
+        if (held == null || !(held.getItem() instanceof IPartItem)) {
+            return false;
+        }
+
+        IPartHost host = getOrCreateHost(world.getTileEntity(x, y, z), player, side.ordinal());
+
+        // Try to add the part to the target block
+        if (host != null && tryPlace(held, player, world, x, y, z, side, host)) return true;
+
+        // If that didn't work, we try to place on the face of the target block
+        int tx = x + side.offsetX;
+        int ty = y + side.offsetY;
+        int tz = z + side.offsetZ;
+        ForgeDirection opposite = side.getOpposite();
+
+        TileEntity te = world.getTileEntity(tx, ty, tz);
+        IPartHost targetHost = getOrCreateHost(te, player, opposite.ordinal());
+
+        return tryPlace(held, player, world, tx, ty, tz, opposite, targetHost);
     }
 
     public static boolean tryPlace(ItemStack held, EntityPlayer player, World world, int x, int y, int z,
@@ -272,6 +284,7 @@ public class PartPlacement {
                         ss.getPitch() * 0.8F);
             }
 
+            player.swingItem();
             decreaseHeldItem(held, player);
             if (world.isRemote) {
                 NetworkHandler.instance.sendToServer(new PacketPartPlacement(host, mySide, false));
@@ -296,7 +309,14 @@ public class PartPlacement {
             return Platform.getEyeOffset(p);
         }
 
-        return getEyeHeight();
+        // Ideally this code is not used, it's here just in case some code that other mod use do end up here on server
+        // side
+        AELog.error(new Throwable(), "getEyeOffset called on server");
+        float eyeOffset = (float) (p.posY + p.getEyeHeight());
+        if (p.isSneaking()) {
+            eyeOffset -= 0.08f; // 0.2 * 0.4
+        }
+        return eyeOffset;
     }
 
     private static SelectedPart selectPart(final EntityPlayer player, final IPartHost host, final Vec3 pos) {
@@ -323,25 +343,17 @@ public class PartPlacement {
         return null;
     }
 
-    private static float getEyeHeight() {
-        return eyeHeight;
-    }
-
-    public static void setEyeHeight(final float eyeHeight) {
-        PartPlacement.eyeHeight = eyeHeight;
-    }
-
-    // We use receiveCanceled in order to perform cleanup of placing field and skip further processing
-    @SubscribeEvent(priority = EventPriority.HIGHEST, receiveCanceled = true)
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
     public void cancelSubsequentRightClickAirEvent(final PlayerInteractEvent event) {
         if (!event.entityPlayer.worldObj.isRemote) return;
         if (placing) {
-            if (event.action != Action.RIGHT_CLICK_AIR) {
-                AELog.error("Unexpected sequence for playerInteract event");
-            }
-            placing = false;
             event.setCanceled(true);
         }
+    }
+
+    @SubscribeEvent(priority = EventPriority.HIGHEST, receiveCanceled = true)
+    public void playerInteract(final ClientTickEvent event) {
+        placing = false;
     }
 
     @SubscribeEvent(priority = EventPriority.LOW)

--- a/src/main/java/appeng/parts/PartPlacement.java
+++ b/src/main/java/appeng/parts/PartPlacement.java
@@ -42,7 +42,6 @@ import appeng.api.parts.IPartHost;
 import appeng.api.parts.IPartItem;
 import appeng.api.parts.PartItemStack;
 import appeng.api.parts.SelectedPart;
-import appeng.core.AELog;
 import appeng.core.CommonHelper;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketClick;

--- a/src/main/java/appeng/parts/PartPlacement.java
+++ b/src/main/java/appeng/parts/PartPlacement.java
@@ -308,7 +308,6 @@ public class PartPlacement {
 
         // Ideally this code is not used, it's here just in case some code that other mod use do end up here on server
         // side
-        AELog.error(new Throwable(), "getEyeOffset called on server");
         float eyeOffset = (float) (p.posY + p.getEyeHeight());
         if (p.isSneaking()) {
             eyeOffset -= 0.08f; // 0.2 * 0.4


### PR DESCRIPTION
## Summary
More placement fixes, since the code still don't interact very well with item in backhand. Did not test offhand in the original PR so some changes are needed to interact better. Also added hand swinging back.

Tested in full pack (all action tested with both empty offhand and healing axe):
- Memory card save setting, apply setting, clear setting
- Priority card right click perform priority action
- Cutting knife rename (sneak rc open rename screen both before my changes and after my changes, I guess it is considered ok)
- Wirecutter rename (both sneaking and non-sneaking open renaming to be consistent with previous behaviour)
- Cable placing and storage bus placing, with and without sneaking
- Wrench part
- Opening gui if right click with cable held and not sneaking

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
