### PR TITLE
Add Blood Arsenal's Transparent Orb to blocking mode blacklist

### DIFF
--- a/src/main/java/appeng/core/features/registries/BlockingModeIgnoreItemRegistry.java
+++ b/src/main/java/appeng/core/features/registries/BlockingModeIgnoreItemRegistry.java
@@ -58,6 +58,10 @@ public class BlockingModeIgnoreItemRegistry implements IBlockingModeIgnoreItemRe
             if (Loader.isModLoaded("ForbiddenMagic")) {
                 register(GameRegistry.findItem("ForbiddenMagic", "EldritchOrb"));
             }
+
+            if (Loader.isModLoaded("BloodArsenal")) {
+                register(GameRegistry.findItem("BloodArsenal", "transparent_orb"));
+            }
         }
     }
 }


### PR DESCRIPTION
<img width="631" height="62" alt="image" src="https://github.com/user-attachments/assets/e57328e7-758d-488f-8c79-2d2e10c49f36" />

This item should work in chemistry sets with blocking mode, just like the other orbs.