### PR TITLE
Fix quartz fiber power cache after grid changes

### DIFF
--- a/src/main/java/appeng/parts/networking/PartQuartzFiber.java
+++ b/src/main/java/appeng/parts/networking/PartQuartzFiber.java
@@ -137,6 +137,11 @@ public class PartQuartzFiber extends AEBasePart implements IEnergyGridProvider {
     }
 
     @Override
+    public void gridChanged() {
+        this.lastEnergyGrid.clear();
+    }
+
+    @Override
     public double extractAEPower(final double amt, final Actionable mode, final Set<IEnergyGrid> seen) {
         double acquiredPower = 0;
 


### PR DESCRIPTION
## Summary
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25786


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
