### PR TITLE
Notify level emitter when its crafting item is oversupplied

### DIFF
--- a/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
+++ b/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
@@ -476,6 +476,7 @@ public class CraftingCPUCluster implements IAECluster, ICraftingCPU {
 
                 this.updateElapsedTime(insert);
                 this.recordReturnedOutputs(insert);
+                this.postCraftingStatusChange(is);
 
                 if (this.finalOutput.isFinalOutput(insert)) {
                     final IAEStack<?> outputToSend = this.finalOutput.splitOutputToIngredient(insert, type);


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
This PR is just one line, which fixes the issue where the crafting mode level emitter would not update when the requested item (from a crafting CPU) is oversupplied. See #1405 for more context.

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
