### PR TITLE
Fix memory card interaction on tile block

### DIFF
--- a/src/main/java/appeng/block/AEBaseTileBlock.java
+++ b/src/main/java/appeng/block/AEBaseTileBlock.java
@@ -211,7 +211,7 @@ public abstract class AEBaseTileBlock extends AEBaseBlock implements IAEFeature,
     @Override
     public boolean onBlockActivated(final World w, final int x, final int y, final int z, final EntityPlayer player,
             final int side, final float hitX, final float hitY, final float hitZ) {
-        if (player != null && !w.isRemote) {
+        if (player != null) {
             final ItemStack is = player.inventory.getCurrentItem();
             if (is != null) {
                 if (Platform.isWrench(player, is, x, y, z) && player.isSneaking()) {
@@ -246,7 +246,9 @@ public abstract class AEBaseTileBlock extends AEBaseBlock implements IAEFeature,
 
                         if (id.removedByPlayer(w, player, x, y, z, false)) {
                             final List<ItemStack> l = Lists.newArrayList(drops);
-                            Platform.spawnDrops(w, x, y, z, l);
+                            if (!w.isRemote) {
+                                Platform.spawnDrops(w, x, y, z, l);
+                            }
                             w.setBlockToAir(x, y, z);
                         }
                     }
@@ -260,6 +262,7 @@ public abstract class AEBaseTileBlock extends AEBaseBlock implements IAEFeature,
                             final String name = this.getUnlocalizedName();
                             final NBTTagCompound data = t.downloadSettings(SettingsFrom.MEMORY_CARD);
                             if (data != null) {
+                                if (w.isRemote) return true;
                                 memoryCard.setMemoryCardContents(is, name, data);
 
                                 if (t instanceof IUpgradeableHost iuh) {
@@ -273,6 +276,7 @@ public abstract class AEBaseTileBlock extends AEBaseBlock implements IAEFeature,
                             }
                         }
                     } else {
+                        if (w.isRemote) return false;
                         final String name = memoryCard.getSettingsName(is);
                         final NBTTagCompound data = memoryCard.getData(is);
                         if (this.getUnlocalizedName().equals(name)) {
@@ -298,12 +302,14 @@ public abstract class AEBaseTileBlock extends AEBaseBlock implements IAEFeature,
                     if (ForgeEventFactory.onItemUseStart(player, is, 1) <= 0) return false;
                     final AEBaseTile tile = this.getTileEntity(w, x, y, z);
                     if (tile == null) return false;
+                    if (w.isRemote) return true;
                     Platform.openGUI(player, tile, ForgeDirection.getOrientation(side), GuiBridge.GUI_RENAMER);
                     return true;
                 }
                 if (is.getItem() instanceof ToolPriorityCard && !(this instanceof BlockCableBus)) {
                     final AEBaseTile tile = this.getTileEntity(w, x, y, z);
                     if (tile == null) return false;
+                    if (w.isRemote) return true;
                     ToolPriorityCard.handleUse(player, tile, is, ForgeDirection.getOrientation(side));
                     return true;
                 }

--- a/src/main/java/appeng/block/AEBaseTileBlock.java
+++ b/src/main/java/appeng/block/AEBaseTileBlock.java
@@ -215,6 +215,7 @@ public abstract class AEBaseTileBlock extends AEBaseBlock implements IAEFeature,
             final ItemStack is = player.inventory.getCurrentItem();
             if (is != null) {
                 if (Platform.isWrench(player, is, x, y, z) && player.isSneaking()) {
+                    if (w.isRemote) return false;
                     final Block id = w.getBlock(x, y, z);
                     if (id != null) {
                         final AEBaseTile tile = this.getTileEntity(w, x, y, z);
@@ -246,9 +247,7 @@ public abstract class AEBaseTileBlock extends AEBaseBlock implements IAEFeature,
 
                         if (id.removedByPlayer(w, player, x, y, z, false)) {
                             final List<ItemStack> l = Lists.newArrayList(drops);
-                            if (!w.isRemote) {
-                                Platform.spawnDrops(w, x, y, z, l);
-                            }
+                            Platform.spawnDrops(w, x, y, z, l);
                             w.setBlockToAir(x, y, z);
                         }
                     }
@@ -259,10 +258,10 @@ public abstract class AEBaseTileBlock extends AEBaseBlock implements IAEFeature,
                     if (player.isSneaking()) {
                         final AEBaseTile t = this.getTileEntity(w, x, y, z);
                         if (t != null) {
+                            if (w.isRemote) return true;
                             final String name = this.getUnlocalizedName();
                             final NBTTagCompound data = t.downloadSettings(SettingsFrom.MEMORY_CARD);
                             if (data != null) {
-                                if (w.isRemote) return true;
                                 memoryCard.setMemoryCardContents(is, name, data);
 
                                 if (t instanceof IUpgradeableHost iuh) {
@@ -272,8 +271,8 @@ public abstract class AEBaseTileBlock extends AEBaseBlock implements IAEFeature,
                                 }
 
                                 memoryCard.notifyUser(player, MemoryCardMessages.SETTINGS_SAVED);
-                                return true;
                             }
+                            return true;
                         }
                     } else {
                         if (w.isRemote) return false;


### PR DESCRIPTION
## Summary
The return value of `onBlockActivated` mismatched client side and server side, causing unexpected outcome of using memory card on such blocks.


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
