### PR TITLE
Deduplicate objects in crafting tree serialization

### DIFF
--- a/src/main/java/appeng/crafting/v2/CraftingJobV2.java
+++ b/src/main/java/appeng/crafting/v2/CraftingJobV2.java
@@ -82,6 +82,11 @@ public class CraftingJobV2<StackType extends IAEStack<StackType>>
             return null;
         }
         final CraftingTreeSerializer serializer = new CraftingTreeSerializer(world, buffer);
+        try {
+            serializer.initializeSerializer();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
         final ITreeSerializable rawJob;
         try {
             rawJob = serializer.readSerializableAndQueueChildren(null);
@@ -126,7 +131,7 @@ public class CraftingJobV2<StackType extends IAEStack<StackType>>
                     break;
                 }
             }
-            return serializer.getBuffer().slice();
+            return serializer.finalizeSerializer().slice();
         } catch (Exception e) {
             AELog.error(e, "Could not serialize the crafting job");
             return Unpooled.buffer(0);

--- a/src/main/java/appeng/crafting/v2/CraftingRequest.java
+++ b/src/main/java/appeng/crafting/v2/CraftingRequest.java
@@ -58,13 +58,13 @@ public class CraftingRequest implements ITreeSerializable {
 
         public UsedResolverEntry(CraftingTreeSerializer serializer, ITreeSerializable parent) throws IOException {
             this.parent = (CraftingRequest) parent;
-            this.resolvedStack = serializer.readStack();
+            this.resolvedStack = serializer.readStackWithSize();
             this.task = null; // to be filled by loadChildren
         }
 
         @Override
         public List<? extends ITreeSerializable> serializeTree(CraftingTreeSerializer serializer) throws IOException {
-            serializer.writeStack(resolvedStack);
+            serializer.writeStackWithSize(resolvedStack);
             return Collections.singletonList(task);
         }
 
@@ -116,7 +116,7 @@ public class CraftingRequest implements ITreeSerializable {
     @Override
     public List<? extends ITreeSerializable> serializeTree(CraftingTreeSerializer serializer) throws IOException {
         final ByteBuf buffer = serializer.getBuffer();
-        serializer.writeStack(stack);
+        serializer.writeStackWithSize(stack);
         serializer.writeEnum(substitutionMode);
         buffer.writeBoolean(allowSimulation);
         buffer.writeLong(remainingToProcess);
@@ -139,7 +139,7 @@ public class CraftingRequest implements ITreeSerializable {
     @SuppressWarnings({ "unused" })
     public CraftingRequest(CraftingTreeSerializer serializer, ITreeSerializable parent) throws IOException {
         final ByteBuf buffer = serializer.getBuffer();
-        stack = serializer.readStack();
+        stack = serializer.readStackWithSize();
         parentRequest = null; // this state is not needed on client side
         parentRequests = Collections.emptySet();
         substitutionMode = serializer.readEnum(SubstitutionMode.class);

--- a/src/main/java/appeng/crafting/v2/CraftingTreeSerializer.java
+++ b/src/main/java/appeng/crafting/v2/CraftingTreeSerializer.java
@@ -50,8 +50,10 @@ public final class CraftingTreeSerializer {
     private final World world;
     private final boolean reading;
     private final ByteBuf buffer;
+    private final ByteBuf objCheckBuffer;
 
     private ArrayList<JobFn> workStack = new ArrayList<>(32);
+    private int estimatedObjBufferSize = 0;
 
     /**
      * Registers a serializable type for the crafting tree.
@@ -114,7 +116,9 @@ public final class CraftingTreeSerializer {
      * @param world The world of the AE system in which the tree is serialized
      */
     public CraftingTreeSerializer(final World world) {
-        this.buffer = Unpooled.buffer(4096, AEConfig.instance.maxCraftingTreeVisualizationSize / 2)
+        this.buffer = Unpooled.buffer(4096, AEConfig.instance.maxCraftingTreeVisualizationSize)
+                .order(ByteOrder.LITTLE_ENDIAN);
+        this.objCheckBuffer = Unpooled.buffer(4096, AEConfig.instance.maxCraftingTreeVisualizationSize)
                 .order(ByteOrder.LITTLE_ENDIAN);
         this.reading = false;
         this.world = world;
@@ -129,6 +133,7 @@ public final class CraftingTreeSerializer {
     public CraftingTreeSerializer(final World world, final ByteBuf toDeserialize) {
         toDeserialize.order(ByteOrder.LITTLE_ENDIAN);
         this.buffer = toDeserialize;
+        this.objCheckBuffer = null;
         this.reading = true;
         this.world = world;
     }
@@ -195,7 +200,7 @@ public final class CraftingTreeSerializer {
     }
 
     public ByteBuf finalizeSerializer() throws IOException {
-        final ByteBuf objBuffer = Unpooled.buffer(4096, AEConfig.instance.maxCraftingTreeVisualizationSize / 2)
+        final ByteBuf objBuffer = Unpooled.buffer(4096, AEConfig.instance.maxCraftingTreeVisualizationSize)
                 .order(ByteOrder.LITTLE_ENDIAN);
 
         // Write the objects at the beginning
@@ -303,7 +308,14 @@ public final class CraftingTreeSerializer {
                 .computeIfAbsent(klass, k -> new Object2IntOpenHashMap<>());
         int meta = objectMap.computeIfAbsent(obj, k -> objectMap.size());
         List<T> objectList = (List<T>) objectsList.computeIfAbsent(klass, k -> new ArrayList<>());
-        if (meta >= objectList.size()) objectList.add(obj);
+        if (meta >= objectList.size()) {
+            objectList.add(obj);
+            IObjectSerializer serializer = objectSerializers.get(klass);
+            objCheckBuffer.markWriterIndex();
+            serializer.write(objCheckBuffer, obj);
+            estimatedObjBufferSize += objCheckBuffer.readableBytes();
+            objCheckBuffer.resetWriterIndex();
+        } ;
         getBuffer().writeInt(meta);
     }
 
@@ -401,6 +413,11 @@ public final class CraftingTreeSerializer {
             job.run();
         } catch (IOException e) {
             throw new RuntimeException(e);
+        }
+        if (!reading && getBuffer().readableBytes() + estimatedObjBufferSize
+                > AEConfig.instance.maxCraftingTreeVisualizationSize) {
+            // Throw when exceeding max size, the caller will catch the error
+            throw new IndexOutOfBoundsException();
         }
     }
 

--- a/src/main/java/appeng/crafting/v2/CraftingTreeSerializer.java
+++ b/src/main/java/appeng/crafting/v2/CraftingTreeSerializer.java
@@ -10,7 +10,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import net.minecraft.world.World;
 
@@ -44,16 +43,16 @@ public final class CraftingTreeSerializer {
     private static final Map<Class<?>, IObjectSerializer<?>> objectSerializers = new HashMap<>();
     private static final Map<String, Class<?>> objectSerializerResolvers = new HashMap<>();
 
-    private final Map<Class<?>, Object2IntOpenHashMap<?>> objectsMap = new HashMap<>();
-    private final Map<Class<?>, List<?>> objectsList = new HashMap<>();
+    private final Map<Class<?>, Object2IntOpenHashMap<Object>> objectsMap = new HashMap<>();
+    private final Map<Class<?>, List<Object>> objectsList = new HashMap<>();
 
     private final World world;
     private final boolean reading;
     private final ByteBuf buffer;
-    private final ByteBuf objCheckBuffer;
+    private final ByteBuf objBuffer;
 
     private ArrayList<JobFn> workStack = new ArrayList<>(32);
-    private int estimatedObjBufferSize = 0;
+    private int objectsWritten = 0;
 
     /**
      * Registers a serializable type for the crafting tree.
@@ -118,7 +117,7 @@ public final class CraftingTreeSerializer {
     public CraftingTreeSerializer(final World world) {
         this.buffer = Unpooled.buffer(4096, AEConfig.instance.maxCraftingTreeVisualizationSize)
                 .order(ByteOrder.LITTLE_ENDIAN);
-        this.objCheckBuffer = Unpooled.buffer(4096, AEConfig.instance.maxCraftingTreeVisualizationSize)
+        this.objBuffer = Unpooled.buffer(4096, AEConfig.instance.maxCraftingTreeVisualizationSize)
                 .order(ByteOrder.LITTLE_ENDIAN);
         this.reading = false;
         this.world = world;
@@ -133,7 +132,7 @@ public final class CraftingTreeSerializer {
     public CraftingTreeSerializer(final World world, final ByteBuf toDeserialize) {
         toDeserialize.order(ByteOrder.LITTLE_ENDIAN);
         this.buffer = toDeserialize;
-        this.objCheckBuffer = null;
+        this.objBuffer = null;
         this.reading = true;
         this.world = world;
     }
@@ -200,27 +199,11 @@ public final class CraftingTreeSerializer {
     }
 
     public ByteBuf finalizeSerializer() throws IOException {
-        final ByteBuf objBuffer = Unpooled.buffer(4096, AEConfig.instance.maxCraftingTreeVisualizationSize)
+        final ByteBuf finalBuffer = Unpooled
+                .buffer(Integer.BYTES + objBuffer.readableBytes() + getBuffer().readableBytes())
                 .order(ByteOrder.LITTLE_ENDIAN);
 
-        // Write the objects at the beginning
-        objBuffer.writeInt(objectsList.size());
-        for (Entry<Class<?>, List<?>> entry : objectsList.entrySet()) {
-            Class<?> klass = entry.getKey();
-            List<?> list = entry.getValue();
-
-            IObjectSerializer serializer = objectSerializers.get(klass);
-
-            ByteBufUtils.writeUTF8String(objBuffer, serializer.id());
-            objBuffer.writeInt(list.size());
-
-            for (Object obj : list) {
-                serializer.write(objBuffer, obj);
-            }
-        }
-
-        final ByteBuf finalBuffer = Unpooled.buffer(objBuffer.readableBytes() + getBuffer().readableBytes())
-                .order(ByteOrder.LITTLE_ENDIAN);
+        finalBuffer.writeInt(objectsWritten);
         finalBuffer.writeBytes(objBuffer);
         finalBuffer.writeBytes(getBuffer());
 
@@ -229,8 +212,8 @@ public final class CraftingTreeSerializer {
 
     public void initializeSerializer() throws IOException {
         // Populate the serializer with objects
-        int types = getBuffer().readInt();
-        for (int i = 0; i < types; i++) {
+        int objects = getBuffer().readInt();
+        for (int i = 0; i < objects; i++) {
             final String id = ByteBufUtils.readUTF8String(getBuffer());
 
             if (id == null || id.isEmpty()) {
@@ -244,19 +227,8 @@ public final class CraftingTreeSerializer {
                 throw new IllegalArgumentException("No object serializer for id: " + id);
             }
 
-            int amount = getBuffer().readInt();
-            List<Object> list = new ArrayList<>(amount);
-            Object2IntOpenHashMap<Object> map = new Object2IntOpenHashMap<>();
-
-            objectsList.put(klass, list);
-            objectsMap.put(klass, map);
-
-            for (int j = 0; j < amount; j++) {
-                Object obj = serializer.read(getBuffer());
-
-                list.add(obj);
-                map.put(obj, j);
-            }
+            // Skip map because we only use list to read
+            objectsList.computeIfAbsent(klass, k -> new ArrayList<>()).add(serializer.read(getBuffer()));
         }
     }
 
@@ -294,7 +266,6 @@ public final class CraftingTreeSerializer {
         writeStack(AEItemStack.create(pattern.getPattern()));
     }
 
-    @SuppressWarnings("unchecked")
     public ICraftingPatternDetails readPattern() throws IOException {
         IAEItemStack stack = readItemStack();
         if (stack != null && stack.getItem() instanceof ICraftingPatternItem) {
@@ -304,26 +275,24 @@ public final class CraftingTreeSerializer {
     }
 
     public <T> void writeObject(Class<T> klass, T obj) {
-        Object2IntOpenHashMap<T> objectMap = (Object2IntOpenHashMap<T>) objectsMap
-                .computeIfAbsent(klass, k -> new Object2IntOpenHashMap<>());
+        Object2IntOpenHashMap<Object> objectMap = objectsMap.computeIfAbsent(klass, k -> new Object2IntOpenHashMap<>());
         int meta = objectMap.computeIfAbsent(obj, k -> objectMap.size());
-        List<T> objectList = (List<T>) objectsList.computeIfAbsent(klass, k -> new ArrayList<>());
+        List<Object> objectList = objectsList.computeIfAbsent(klass, k -> new ArrayList<>());
         if (meta >= objectList.size()) {
             objectList.add(obj);
             IObjectSerializer serializer = objectSerializers.get(klass);
-            objCheckBuffer.markWriterIndex();
-            serializer.write(objCheckBuffer, obj);
-            estimatedObjBufferSize += objCheckBuffer.readableBytes();
-            objCheckBuffer.resetWriterIndex();
-        } ;
+            ByteBufUtils.writeUTF8String(objBuffer, serializer.id());
+            serializer.write(objBuffer, obj);
+            objectsWritten++;
+        }
         getBuffer().writeInt(meta);
     }
 
     public <T> T readObject(Class<T> klass) {
         int meta = getBuffer().readInt();
-        List<T> objectList = (List<T>) objectsList.get(klass);
+        List<Object> objectList = objectsList.get(klass);
         if (objectList == null) return null;
-        return objectList.get(meta);
+        return (T) objectList.get(meta);
     }
 
     @FunctionalInterface
@@ -414,7 +383,7 @@ public final class CraftingTreeSerializer {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-        if (!reading && getBuffer().readableBytes() + estimatedObjBufferSize
+        if (!reading && getBuffer().readableBytes() + objBuffer.readableBytes()
                 > AEConfig.instance.maxCraftingTreeVisualizationSize) {
             // Throw when exceeding max size, the caller will catch the error
             throw new IndexOutOfBoundsException();

--- a/src/main/java/appeng/crafting/v2/CraftingTreeSerializer.java
+++ b/src/main/java/appeng/crafting/v2/CraftingTreeSerializer.java
@@ -304,7 +304,7 @@ public final class CraftingTreeSerializer {
     }
 
     public <T> void writeObject(Class<T> klass, T obj) {
-        Map<T, Integer> objectMap = (Map<T, Integer>) objectsMap
+        Object2IntOpenHashMap<T> objectMap = (Object2IntOpenHashMap<T>) objectsMap
                 .computeIfAbsent(klass, k -> new Object2IntOpenHashMap<>());
         int meta = objectMap.computeIfAbsent(obj, k -> objectMap.size());
         List<T> objectList = (List<T>) objectsList.computeIfAbsent(klass, k -> new ArrayList<>());

--- a/src/main/java/appeng/crafting/v2/CraftingTreeSerializer.java
+++ b/src/main/java/appeng/crafting/v2/CraftingTreeSerializer.java
@@ -30,6 +30,7 @@ import appeng.util.item.AEItemStack;
 import cpw.mods.fml.common.network.ByteBufUtils;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 
 /**
  * Walks down the tree of resolved crafting operations and (de)serializes them into a flat ByteBuf for network
@@ -43,7 +44,7 @@ public final class CraftingTreeSerializer {
     private static final Map<Class<?>, IObjectSerializer<?>> objectSerializers = new HashMap<>();
     private static final Map<String, Class<?>> objectSerializerResolvers = new HashMap<>();
 
-    private final Map<Class<?>, Map<?, Integer>> objectsMap = new HashMap<>();
+    private final Map<Class<?>, Object2IntOpenHashMap<?>> objectsMap = new HashMap<>();
     private final Map<Class<?>, List<?>> objectsList = new HashMap<>();
 
     private final World world;
@@ -240,7 +241,7 @@ public final class CraftingTreeSerializer {
 
             int amount = getBuffer().readInt();
             List<Object> list = new ArrayList<>(amount);
-            Map<Object, Integer> map = new HashMap<>();
+            Object2IntOpenHashMap<Object> map = new Object2IntOpenHashMap<>();
 
             objectsList.put(klass, list);
             objectsMap.put(klass, map);
@@ -298,7 +299,8 @@ public final class CraftingTreeSerializer {
     }
 
     public <T> void writeObject(Class<T> klass, T obj) {
-        Map<T, Integer> objectMap = (Map<T, Integer>) objectsMap.computeIfAbsent(klass, k -> new HashMap<>());
+        Map<T, Integer> objectMap = (Map<T, Integer>) objectsMap
+                .computeIfAbsent(klass, k -> new Object2IntOpenHashMap<>());
         int meta = objectMap.computeIfAbsent(obj, k -> objectMap.size());
         List<T> objectList = (List<T>) objectsList.computeIfAbsent(klass, k -> new ArrayList<>());
         if (meta >= objectList.size()) objectList.add(obj);

--- a/src/main/java/appeng/crafting/v2/CraftingTreeSerializer.java
+++ b/src/main/java/appeng/crafting/v2/CraftingTreeSerializer.java
@@ -1,8 +1,5 @@
 package appeng.crafting.v2;
 
-import static appeng.util.Platform.readStackByte;
-import static appeng.util.Platform.writeStackByte;
-
 import java.io.IOException;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -13,6 +10,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import net.minecraft.world.World;
 
@@ -41,6 +39,13 @@ public final class CraftingTreeSerializer {
 
     private static final Map<Class<? extends ITreeSerializable>, String> serializableKeys = new HashMap<>();
     private static final Map<String, MethodHandle> serializableConstructors = new HashMap<>();
+
+    private static final Map<Class<?>, IObjectSerializer<?>> objectSerializers = new HashMap<>();
+    private static final Map<String, Class<?>> objectSerializerResolvers = new HashMap<>();
+
+    private final Map<Class<?>, Map<?, Integer>> objectsMap = new HashMap<>();
+    private final Map<Class<?>, List<?>> objectsList = new HashMap<>();
+
     private final World world;
     private final boolean reading;
     private final ByteBuf buffer;
@@ -75,6 +80,19 @@ public final class CraftingTreeSerializer {
         }
     }
 
+    /**
+     * Registers an object serializer for the crafting tree
+     *
+     * @param klass      The object to serialize
+     * @param serializer The object serializer
+     */
+    public static void registerObjectSerializer(Class<?> klass, IObjectSerializer<?> serializer) {
+        final String id = serializer.id();
+        if ((objectSerializerResolvers.put(id, klass) != null) || (objectSerializers.put(klass, serializer) != null)) {
+            throw new IllegalArgumentException("Duplicate IObjectSerializer id: " + id);
+        }
+    }
+
     static {
         // modid:type, using empty modid for ae2 for compactness
         registerSerializable(":j", CraftingJobV2.class);
@@ -86,6 +104,7 @@ public final class CraftingTreeSerializer {
         registerSerializable(":tx", ExtractItemResolver.ExtractItemTask.class);
         registerSerializable(":ts", SimulateMissingItemResolver.ConjureItemTask.class);
         registerSerializable(":tp", IgnoreMissingItemTask.class);
+        registerObjectSerializer(IAEStack.class, new ObjectAEStackSerializer<>());
     }
 
     /**
@@ -94,7 +113,7 @@ public final class CraftingTreeSerializer {
      * @param world The world of the AE system in which the tree is serialized
      */
     public CraftingTreeSerializer(final World world) {
-        this.buffer = Unpooled.buffer(4096, AEConfig.instance.maxCraftingTreeVisualizationSize)
+        this.buffer = Unpooled.buffer(4096, AEConfig.instance.maxCraftingTreeVisualizationSize / 2)
                 .order(ByteOrder.LITTLE_ENDIAN);
         this.reading = false;
         this.world = world;
@@ -174,6 +193,67 @@ public final class CraftingTreeSerializer {
         return value;
     }
 
+    public ByteBuf finalizeSerializer() throws IOException {
+        final ByteBuf objBuffer = Unpooled.buffer(4096, AEConfig.instance.maxCraftingTreeVisualizationSize / 2)
+                .order(ByteOrder.LITTLE_ENDIAN);
+
+        // Write the objects at the beginning
+        objBuffer.writeInt(objectsList.size());
+        for (Entry<Class<?>, List<?>> entry : objectsList.entrySet()) {
+            Class<?> klass = entry.getKey();
+            List<?> list = entry.getValue();
+
+            IObjectSerializer serializer = objectSerializers.get(klass);
+
+            ByteBufUtils.writeUTF8String(objBuffer, serializer.id());
+            objBuffer.writeInt(list.size());
+
+            for (Object obj : list) {
+                serializer.write(objBuffer, obj);
+            }
+        }
+
+        final ByteBuf finalBuffer = Unpooled.buffer(objBuffer.readableBytes() + getBuffer().readableBytes())
+                .order(ByteOrder.LITTLE_ENDIAN);
+        finalBuffer.writeBytes(objBuffer);
+        finalBuffer.writeBytes(getBuffer());
+
+        return finalBuffer;
+    }
+
+    public void initializeSerializer() throws IOException {
+        // Populate the serializer with objects
+        int types = getBuffer().readInt();
+        for (int i = 0; i < types; i++) {
+            final String id = ByteBufUtils.readUTF8String(getBuffer());
+
+            if (id == null || id.isEmpty()) {
+                throw new IllegalArgumentException("No object id provided");
+            }
+
+            Class<?> klass = objectSerializerResolvers.get(id);
+            IObjectSerializer serializer = objectSerializers.get(klass);
+
+            if (serializer == null) {
+                throw new IllegalArgumentException("No object serializer for id: " + id);
+            }
+
+            int amount = getBuffer().readInt();
+            List<Object> list = new ArrayList<>(amount);
+            Map<Object, Integer> map = new HashMap<>();
+
+            objectsList.put(klass, list);
+            objectsMap.put(klass, map);
+
+            for (int j = 0; j < amount; j++) {
+                Object obj = serializer.read(getBuffer());
+
+                list.add(obj);
+                map.put(obj, j);
+            }
+        }
+    }
+
     public void writeEnum(Enum<?> value) throws IOException {
         buffer.writeByte(value.ordinal());
     }
@@ -184,15 +264,24 @@ public final class CraftingTreeSerializer {
     }
 
     public void writeStack(IAEStack<?> stack) {
-        writeStackByte(stack, buffer);
+        writeObject(IAEStack.class, stack);
     }
 
     public IAEStack<?> readStack() {
-        return readStackByte(buffer);
+        return readObject(IAEStack.class);
+    }
+
+    public void writeStackWithSize(IAEStack<?> stack) {
+        writeStack(stack);
+        getBuffer().writeLong(stack.getStackSize());
+    }
+
+    public IAEStack<?> readStackWithSize() {
+        return readStack().copy().setStackSize(getBuffer().readLong());
     }
 
     public IAEItemStack readItemStack() {
-        return (IAEItemStack) readStackByte(buffer);
+        return (IAEItemStack) readStack();
     }
 
     public void writePattern(ICraftingPatternDetails pattern) {
@@ -206,6 +295,21 @@ public final class CraftingTreeSerializer {
             return ((ICraftingPatternItem) stack.getItem()).getPatternForItem(stack.getItemStack(), world);
         }
         throw new UnsupportedOperationException("Illegal pattern type " + stack);
+    }
+
+    public <T> void writeObject(Class<T> klass, T obj) {
+        Map<T, Integer> objectMap = (Map<T, Integer>) objectsMap.computeIfAbsent(klass, k -> new HashMap<>());
+        int meta = objectMap.computeIfAbsent(obj, k -> objectMap.size());
+        List<T> objectList = (List<T>) objectsList.computeIfAbsent(klass, k -> new ArrayList<>());
+        if (meta >= objectList.size()) objectList.add(obj);
+        getBuffer().writeInt(meta);
+    }
+
+    public <T> T readObject(Class<T> klass) {
+        int meta = getBuffer().readInt();
+        List<T> objectList = (List<T>) objectsList.get(klass);
+        if (objectList == null) return null;
+        return objectList.get(meta);
     }
 
     @FunctionalInterface

--- a/src/main/java/appeng/crafting/v2/IObjectSerializer.java
+++ b/src/main/java/appeng/crafting/v2/IObjectSerializer.java
@@ -1,0 +1,15 @@
+package appeng.crafting.v2;
+
+import io.netty.buffer.ByteBuf;
+
+/**
+ * Interface for objects in the crafting tree that can be serialized and deduplicated
+ */
+public interface IObjectSerializer<T> {
+
+    String id();
+
+    void write(ByteBuf buffer, T obj);
+
+    T read(ByteBuf buffer);
+}

--- a/src/main/java/appeng/crafting/v2/ObjectAEStackSerializer.java
+++ b/src/main/java/appeng/crafting/v2/ObjectAEStackSerializer.java
@@ -1,0 +1,25 @@
+package appeng.crafting.v2;
+
+import static appeng.util.Platform.readStackByte;
+import static appeng.util.Platform.writeStackByte;
+
+import appeng.api.storage.data.IAEStack;
+import io.netty.buffer.ByteBuf;
+
+public class ObjectAEStackSerializer<T extends IAEStack<?>> implements IObjectSerializer<T> {
+
+    @Override
+    public String id() {
+        return ":s";
+    }
+
+    @Override
+    public void write(ByteBuf buffer, T stack) {
+        writeStackByte(stack, buffer);
+    }
+
+    @Override
+    public T read(ByteBuf buffer) {
+        return (T) readStackByte(buffer);
+    }
+}

--- a/src/main/java/appeng/crafting/v2/resolvers/CraftableItemResolver.java
+++ b/src/main/java/appeng/crafting/v2/resolvers/CraftableItemResolver.java
@@ -154,7 +154,7 @@ public class CraftableItemResolver implements CraftingRequestResolver {
             this.pattern = serializer.readPattern();
             this.allowSimulation = buffer.readBoolean();
             this.isComplex = buffer.readBoolean();
-            this.matchingOutput = serializer.readStack();
+            this.matchingOutput = serializer.readStackWithSize();
             this.craftingMachine = serializer.readItemStack();
             this.totalCraftsDone = buffer.readLong();
 
@@ -247,7 +247,7 @@ public class CraftableItemResolver implements CraftingRequestResolver {
             serializer.writePattern(pattern);
             buffer.writeBoolean(allowSimulation);
             buffer.writeBoolean(isComplex);
-            serializer.writeStack(matchingOutput);
+            serializer.writeStackWithSize(matchingOutput);
             serializer.writeStack(craftingMachine);
             buffer.writeLong(totalCraftsDone);
             return this.childRequests;

--- a/src/main/java/appeng/crafting/v2/resolvers/ExtractItemResolver.java
+++ b/src/main/java/appeng/crafting/v2/resolvers/ExtractItemResolver.java
@@ -37,15 +37,15 @@ public class ExtractItemResolver implements CraftingRequestResolver {
         @SuppressWarnings("unused")
         public ExtractItemTask(CraftingTreeSerializer serializer, ITreeSerializable parent) throws IOException {
             super(serializer, parent);
-            serializer.readList(removedFromSystem, serializer::readStack);
-            serializer.readList(removedFromByproducts, serializer::readStack);
+            serializer.readList(removedFromSystem, serializer::readStackWithSize);
+            serializer.readList(removedFromByproducts, serializer::readStackWithSize);
         }
 
         @Override
         public List<? extends ITreeSerializable> serializeTree(CraftingTreeSerializer serializer) throws IOException {
             super.serializeTree(serializer);
-            serializer.writeList(removedFromSystem, serializer::writeStack);
-            serializer.writeList(removedFromByproducts, serializer::writeStack);
+            serializer.writeList(removedFromSystem, serializer::writeStackWithSize);
+            serializer.writeList(removedFromByproducts, serializer::writeStackWithSize);
             return Collections.emptyList();
         }
 


### PR DESCRIPTION
## Summary
Add deduplication for objects (like AEStack) in the crafting tree serialization process, massively reducing the size of the serialized crafting tree

Example Crafting Tree:
<img width="6326" height="6176" alt="2026-07-13_19 11 32-ae2" src="https://github.com/user-attachments/assets/ca40b49c-363d-4d49-9471-3822ff1b8351" />

Previously, the crafting tree would take more than 33MB (the config limit) in size to serialize, making it fail and resulting in a partially serialized crafting tree
<img width="665" height="257" alt="Screenshot 2026-07-13 192017" src="https://github.com/user-attachments/assets/eb489609-135e-4a82-90b2-fcbfb4193642" />

After deduplication, the full serialized crafting tree only takes 13MB in size. Resulting in a **2.5x** size reduction
<img width="598" height="134" alt="Screenshot 2026-07-13 19102a4" src="https://github.com/user-attachments/assets/2fa72e38-35b1-42f0-9db7-6c413bbb62f2" />


## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
