### PR TITLE
Expose some constants to the world

### DIFF
--- a/src/main/java/appeng/tile/crafting/TileMolecularAssembler.java
+++ b/src/main/java/appeng/tile/crafting/TileMolecularAssembler.java
@@ -70,6 +70,10 @@ public class TileMolecularAssembler extends AENetworkInvTile
 
     private static final int[] SIDES = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 
+    // SPEED.length == ACCELERATION_TAX.length
+    public static final int[] SPEED = { 10, 13, 17, 20, 25, 50 };
+    public static final double[] ACCELERATION_TAX = { 1.0, 1.3, 1.7, 2.0, 2.5, 5.0 };
+
     private final InventoryCrafting craftingInv;
     private final AppEngInternalInventory inv = new AppEngInternalInventory(this, 9 + 2);
     private final IConfigManager settings;
@@ -379,15 +383,11 @@ public class TileMolecularAssembler extends AENetworkInvTile
         }
 
         this.reboot = false;
-        int speed = 10;
-        switch (this.upgrades.getInstalledUpgrades(Upgrades.SPEED)) {
-            case 0 -> this.progress += this.userPower(ticksSinceLastCall, speed = 10, 1.0);
-            case 1 -> this.progress += this.userPower(ticksSinceLastCall, speed = 13, 1.3);
-            case 2 -> this.progress += this.userPower(ticksSinceLastCall, speed = 17, 1.7);
-            case 3 -> this.progress += this.userPower(ticksSinceLastCall, speed = 20, 2.0);
-            case 4 -> this.progress += this.userPower(ticksSinceLastCall, speed = 25, 2.5);
-            case 5 -> this.progress += this.userPower(ticksSinceLastCall, speed = 50, 5.0);
-        }
+
+        final int installedUpgrades = this.upgrades.getInstalledUpgrades(Upgrades.SPEED);
+        if (installedUpgrades > this.upgrades.getSizeInventory()) return TickRateModulation.FASTER;
+        final int speed = SPEED[installedUpgrades];
+        this.progress += this.userPower(ticksSinceLastCall, speed, ACCELERATION_TAX[installedUpgrades]);
 
         if (this.progress >= 100) {
             for (int x = 0; x < this.craftingInv.getSizeInventory(); x++) {

--- a/src/main/java/appeng/tile/misc/TileAdvancedInscriber.java
+++ b/src/main/java/appeng/tile/misc/TileAdvancedInscriber.java
@@ -56,8 +56,9 @@ public class TileAdvancedInscriber extends AENetworkPowerTile
     public static final String NBT_BOTTOM_LOCKED = "bottomLocked";
     public static final String NBT_PENDING_OUTPUT = "output";
 
-    private static final int MAX_PROCESSING_TIME = 100;
-    private static final int BASE_POWER_PER_TICK = 10;
+    public static final int MAX_PROCESSING_TIME = 100;
+    public static final int BASE_POWER_PER_TICK = 10;
+    public static final int BASE_SPEED = 1;
     private static final int[] ACCESSIBLE_SLOTS = { SLOT_TOP, SLOT_MIDDLE, SLOT_BOTTOM, SLOT_OUTPUT };
 
     private final AppEngInternalInventory inv = new AppEngInternalInventory(this, 4);
@@ -247,7 +248,7 @@ public class TileAdvancedInscriber extends AENetworkPowerTile
         try {
             final IEnergyGrid energyGrid = this.getProxy().getEnergy();
             IEnergySource source = this;
-            final int speedFactor = this.getSpeedFactor();
+            final int speedFactor = BASE_SPEED + this.upgrades.getInstalledUpgrades(Upgrades.SPEED);
             final int powerConsumption = BASE_POWER_PER_TICK * speedFactor;
             final double powerThreshold = powerConsumption - 0.01;
             double extracted = this.extractAEPower(powerConsumption, Actionable.SIMULATE, PowerMultiplier.CONFIG);
@@ -271,10 +272,6 @@ public class TileAdvancedInscriber extends AENetworkPowerTile
         }
 
         this.active = false;
-    }
-
-    private int getSpeedFactor() {
-        return 1 + this.upgrades.getInstalledUpgrades(Upgrades.SPEED);
     }
 
     private boolean tryOutput() {

--- a/src/main/java/appeng/tile/misc/TileInscriber.java
+++ b/src/main/java/appeng/tile/misc/TileInscriber.java
@@ -69,7 +69,12 @@ import io.netty.buffer.ByteBuf;
  */
 public class TileInscriber extends AENetworkPowerTile implements IGridTickable, IUpgradeableHost, IConfigManagerHost {
 
-    private final int maxProcessingTime = 100;
+    private final int maxProcessingTime = MAX_PROCESSING_TIME;
+
+    public static final int MAX_PROCESSING_TIME = 100;
+    public static final int BASE_POWER_PER_TICK = 10;
+    public static final int BASE_SPEED = 1;
+
     private final int[] top = { 0 };
     private final int[] bottom = { 1 };
     private final int[] sides = { 2, 3 };
@@ -373,8 +378,8 @@ public class TileInscriber extends AENetworkPowerTile implements IGridTickable, 
                 IEnergySource src = this;
 
                 // Base 1, increase by 1 for each card
-                final int speedFactor = 1 + this.upgrades.getInstalledUpgrades(Upgrades.SPEED);
-                final int powerConsumption = 10 * speedFactor;
+                final int speedFactor = BASE_SPEED + this.upgrades.getInstalledUpgrades(Upgrades.SPEED);
+                final int powerConsumption = BASE_POWER_PER_TICK * speedFactor;
                 final double powerThreshold = powerConsumption - 0.01;
                 double powerReq = this.extractAEPower(powerConsumption, Actionable.SIMULATE, PowerMultiplier.CONFIG);
 


### PR DESCRIPTION
The TileInscriber `maxProcessingTime` is kept as a local variable in the extremely unlikely case that something is using a mixin and somehow relies on it being a member variable

## Summary
Expose some constants to outside mods, I would be convenient to have them for plannh in order to model correctly autocrafting times. I can hardcode these values in my mod, but this way if they ever change, I don't need to update anything

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
