### PR TITLE
Refactor fluid IO port game tests to use HorizonQA helpers

### DIFF
--- a/src/main/java/appeng/gametests/compatibility/appliedenergistics2_ae2fc/IOPortFluidCompatibilityTests.java
+++ b/src/main/java/appeng/gametests/compatibility/appliedenergistics2_ae2fc/IOPortFluidCompatibilityTests.java
@@ -3,7 +3,6 @@ package appeng.gametests.compatibility.appliedenergistics2_ae2fc;
 import static appeng.gametests.AEGameTestHelpers.assertActive;
 import static appeng.gametests.AEGameTestHelpers.assertStoredFluidAmount;
 import static appeng.gametests.AEGameTestHelpers.insertFluids;
-import static appeng.gametests.AEGameTestHelpers.tile;
 
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.Fluid;
@@ -27,8 +26,8 @@ public class IOPortFluidCompatibilityTests {
     // AE2FC fluid cells use the real IO port transfer path and the same base transfer budget as item cells.
     @GameTest(template = "ioport", timeoutTicks = 30)
     public static void noUpgradeTransfersTwoHundredFiftySixBucketsOfFluidPerTick(GameTestHelper helper) {
-        TileIOPort ioport = tile(helper, TileIOPort.class, IO_PORT_LABEL);
-        TileDrive drive = tile(helper, TileDrive.class, DRIVE_LABEL);
+        TileIOPort ioport = helper.assertTileEntityPresent(TileIOPort.class, IO_PORT_LABEL);
+        TileDrive drive = helper.assertTileEntityPresent(TileDrive.class, DRIVE_LABEL);
         Fluid water = FluidRegistry.WATER;
         helper.assertNotNull(water, "Water fluid should be registered");
         ItemStack sourceCell = fluidCell1k(helper);
@@ -40,8 +39,8 @@ public class IOPortFluidCompatibilityTests {
                         "wait for AE2FC IO port network activation",
                         () -> assertActive(helper, ioport.getProxy(), "IO port network should become active"))
                 .thenIdle(1).thenExecuteAtStart("insert AE2FC source and destination fluid cells", () -> {
-                    drive.setInventorySlotContents(0, driveCell);
-                    ioport.setInventorySlotContents(0, sourceCell);
+                    helper.setSlot(DRIVE_LABEL, 0, driveCell);
+                    helper.setSlot(IO_PORT_LABEL, 0, sourceCell);
                 }).thenExecute("assert the first tick transfers exactly 256,000 mB", () -> {
                     helper.assertNotNull(
                             ioport.getStackInSlot(0),


### PR DESCRIPTION
## Summary
Updates `IOPortFluidCompatibilityTests` to use HorizonQA's inventory and tile-entity helpers instead of direct inventory manipulation and AE2-specific wrappers. This keeps the tests aligned with the shared HorizonQA API.


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
