### PR TITLE
Fix storage bus cache reset downgrade

### DIFF
--- a/src/main/java/appeng/gametests/automation/storagebus/StorageBusTests.java
+++ b/src/main/java/appeng/gametests/automation/storagebus/StorageBusTests.java
@@ -92,9 +92,10 @@ public class StorageBusTests {
                         "wait for cleared external chest to disappear from the network monitor",
                         60,
                         () -> assertNetworkMonitorStoredAmount(helper, controller, Blocks.cobblestone, 0))
-                .thenExecute(
-                        "configure storage bus for READ-only access",
-                        () -> storageBus.getConfigManager().putSetting(Settings.ACCESS, AccessRestriction.READ))
+                .thenExecute("configure storage bus for READ-only access while a neighbor refresh is queued", () -> {
+                    storageBus.getConfigManager().putSetting(Settings.ACCESS, AccessRestriction.READ);
+                    storageBus.onNeighborChanged();
+                })
                 .thenWaitUntil(
                         "wait for READ mode to reject simulated insertion",
                         STORAGE_BUS_REFRESH_TIMEOUT_TICKS,
@@ -165,9 +166,10 @@ public class StorageBusTests {
                         "wait for the empty external chest to disappear from the storage monitor",
                         60,
                         () -> assertNetworkMonitorStoredAmount(helper, controller, Blocks.cobblestone, 0))
-                .thenExecute(
-                        "configure cobblestone-only storage bus filter",
-                        () -> configureStorageBusFilter(helper, storageBus, Blocks.cobblestone))
+                .thenExecute("configure cobblestone-only storage bus filter while a neighbor refresh is queued", () -> {
+                    configureStorageBusFilter(helper, storageBus, Blocks.cobblestone);
+                    storageBus.onNeighborChanged();
+                })
                 .thenWaitUntil(
                         "wait for filter to accept cobblestone and reject dirt in simulation",
                         STORAGE_BUS_REFRESH_TIMEOUT_TICKS,

--- a/src/main/java/appeng/parts/misc/PartStorageBus.java
+++ b/src/main/java/appeng/parts/misc/PartStorageBus.java
@@ -319,7 +319,8 @@ public class PartStorageBus extends PartUpgradeable implements IStorageBus {
 
         if (fullReset) {
             this.resetCacheLogic = 2;
-        } else {
+        } else if (this.resetCacheLogic == 0) {
+            // A neighbor update must not downgrade a pending configuration-driven full reset.
             this.resetCacheLogic = 1;
         }
 


### PR DESCRIPTION
## Summary

Fixes an intermittent storage bus issue where live configuration changes, such as access mode or filtering, could remain unapplied after a neighbor notification.

`PartStorageBus.resetCacheLogic` represents the pending cache-reset strength:

- `0`: no reset
- `1`: partial neighbor-driven reset
- `2`: full configuration-driven reset

Previously, `resetCache(false)` unconditionally assigned `1`. If a neighbor notification arrived after a configuration change but before the storage bus ticked, it downgraded the pending full reset from `2` to `1`.

The resulting partial reset retained `handlerHash`, allowing `getInternalHandler()` to return the existing cached handler without applying the new access restriction or filter. Waiting longer did not resolve the problem because the pending reset had already been consumed with the wrong strength.

The fix makes reset strength monotonic: a partial reset is queued only when no reset is pending. A full reset can still upgrade a partial reset, but a partial reset cannot downgrade a full one.

The affected HorizonQA tests now reproduce this ordering deterministically by triggering a neighbor refresh immediately after changing the storage bus access mode or filter.

Before the production fix, the access-mode regression failed after all 80 attempts with the same assertion observed in CI. After the fix:

- Both targeted storage bus tests pass.
- The complete HorizonQA suite passes: 57/57.
- `./gradlew --max-workers=4 build` passes.
- `git diff --check` passes.

## Checklist

- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [ ] This PR is in compliance with the [[GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge