### PR TITLE
Fix crafting cpu mouse over offset

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiCraftingCPU.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCraftingCPU.java
@@ -326,8 +326,8 @@ public class GuiCraftingCPU extends AEBaseGui implements IGuiTooltipHandler {
         int column = 0;
 
         for (int slotIndex = 0; slotIndex <= ITEMS_PER_ROW * this.rows; slotIndex++) {
-            final int minX = gridLeft + ITEMSTACK_LEFT_OFFSET + column * SECTION_LENGTH;
-            final int minY = gridTop + ITEMSTACK_TOP_OFFSET + row * SECTION_HEIGHT;
+            final int minX = gridLeft + ITEMSTACK_LEFT_OFFSET + column * (1 + SECTION_LENGTH);
+            final int minY = gridTop + ITEMSTACK_TOP_OFFSET - 4 + row * SECTION_HEIGHT;
 
             if (minX < mouseX && minX + SECTION_LENGTH > mouseX && minY < mouseY && minY + SECTION_HEIGHT > mouseY) {
                 return slotIndex;


### PR DESCRIPTION
## Summary
Fix crafting cpu mouse over offset

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25991
1px for the line
4px for the offset itself

## Checklist
- [X] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
