### PR TITLE
Add option to disable Interface Terminal search autofocus

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiInterfaceTerminal.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiInterfaceTerminal.java
@@ -283,7 +283,7 @@ public class GuiInterfaceTerminal extends AEBaseGui
 
         searchFieldNames.x = guiLeft + Math.max(32, VIEW_LEFT) + 99;
         searchFieldNames.y = guiTop + 38;
-        searchFieldNames.setFocused(true);
+        searchFieldNames.setFocused(AEConfig.instance.autoFocusInterfaceTerminalSearch);
 
         int offset = guiTop + 8;
         terminalStyleBox.xPosition = guiLeft - 18;

--- a/src/main/java/appeng/core/AEConfig.java
+++ b/src/main/java/appeng/core/AEConfig.java
@@ -91,6 +91,7 @@ public final class AEConfig extends Configuration implements IConfigurableObject
     public int previewLineWidth;
     public boolean preserveSearchBar = true;
     public boolean showOnlyInterfacesWithFreeSlotsInInterfaceTerminal = false;
+    public boolean autoFocusInterfaceTerminalSearch = true;
     public boolean showContainerInteractionTooltips = true;
     public int MEMonitorableSmallSize = 6;
     public int InterfaceTerminalSmallSize = 6;
@@ -390,6 +391,8 @@ public final class AEConfig extends Configuration implements IConfigurableObject
         this.preserveSearchBar = this.get("Client", "preserveSearchBar", true).getBoolean(true);
         this.showOnlyInterfacesWithFreeSlotsInInterfaceTerminal = this
                 .get("Client", "showOnlyInterfacesWithFreeSlotsInInterfaceTerminal", false).getBoolean(false);
+        this.autoFocusInterfaceTerminalSearch = this.get("Client", "autoFocusInterfaceTerminalSearch", true)
+                .getBoolean(true);
         this.showContainerInteractionTooltips = this.get("Client", "showContainerInteractionTooltips", true)
                 .getBoolean(true);
         this.highlightWhenSomethingStuckInInterface = this.get("Client", "highlightWhenSomethingStuckInInterface", true)


### PR DESCRIPTION
The Names search field was always focused when opening the Interface Terminal, unlike other ME terminals. Adds a client config option, enabled by default, so it can be turned off.