### PR TITLE
Crafting row as crafting history

### DIFF
--- a/src/main/java/appeng/client/me/ItemRepo.java
+++ b/src/main/java/appeng/client/me/ItemRepo.java
@@ -180,7 +180,6 @@ public class ItemRepo implements IDisplayRepo {
             if (pin != null && pin.isSameType((Object) is)) {
                 pin.reset();
                 pin.add(is);
-                break;
             }
         }
 

--- a/src/main/java/appeng/client/me/ItemRepo.java
+++ b/src/main/java/appeng/client/me/ItemRepo.java
@@ -75,7 +75,7 @@ public class ItemRepo implements IDisplayRepo {
 
     @Override
     public void setAEPins(IAEStack<?>[] newPins) {
-        IItemList<IAEStack<?>> oldPins = getPinsCache();
+        IItemList<IAEStack<?>> oldPins = getPinsCache(true, true);
         pinsRepo = new IAEStack<?>[newPins.length];
 
         for (int i = 0; i < pinsRepo.length; i++) {
@@ -114,17 +114,22 @@ public class ItemRepo implements IDisplayRepo {
     }
 
     /** Returns only pins in currently visible rows, so items in reduced rows show in main inventory. */
-    private IItemList<IAEStack<?>> getPinsCache() {
+    private IItemList<IAEStack<?>> getPinsCache(boolean includeCrafting, boolean includePlayer) {
         IItemList<IAEStack<?>> oldPins = AEApi.instance().storage().createAEStackList();
 
-        int craftLimit = Math.min(visibleCraftingRows * 9, pinsRepo.length);
-        for (int i = 0; i < craftLimit; i++) {
-            if (pinsRepo[i] != null) oldPins.add(pinsRepo[i]);
+        if (includeCrafting) {
+            int craftLimit = Math.min(visibleCraftingRows * 9, pinsRepo.length);
+            for (int i = 0; i < craftLimit; i++) {
+                if (pinsRepo[i] != null) oldPins.add(pinsRepo[i]);
+            }
         }
-        int playerStart = PinList.PLAYER_OFFSET;
-        int playerLimit = Math.min(playerStart + visiblePlayerRows * 9, pinsRepo.length);
-        for (int i = playerStart; i < playerLimit; i++) {
-            if (pinsRepo[i] != null) oldPins.add(pinsRepo[i]);
+
+        if (includePlayer) {
+            int playerStart = PinList.PLAYER_OFFSET;
+            int playerLimit = Math.min(playerStart + visiblePlayerRows * 9, pinsRepo.length);
+            for (int i = playerStart; i < playerLimit; i++) {
+                if (pinsRepo[i] != null) oldPins.add(pinsRepo[i]);
+            }
         }
 
         return oldPins;
@@ -195,7 +200,7 @@ public class ItemRepo implements IDisplayRepo {
 
     @Override
     public void updateView() {
-        IItemList<IAEStack<?>> visiblePins = getPinsCache();
+        IItemList<IAEStack<?>> visiblePins = getPinsCache(!AEConfig.instance.showCraftingPinsItemsInMainView, true);
         if (this.paused) {
             for (int i = this.view.size() - 1; i >= 0; i--) {
                 IAEStack<?> entry = this.view.get(i);

--- a/src/main/java/appeng/container/implementations/ContainerCraftConfirm.java
+++ b/src/main/java/appeng/container/implementations/ContainerCraftConfirm.java
@@ -27,6 +27,7 @@ import net.minecraft.world.World;
 import appeng.api.AEApi;
 import appeng.api.config.Actionable;
 import appeng.api.config.CraftingAllow;
+import appeng.api.config.PinsRows;
 import appeng.api.config.SecurityPermissions;
 import appeng.api.networking.IGrid;
 import appeng.api.networking.crafting.ICraftingCPU;
@@ -37,6 +38,7 @@ import appeng.api.networking.security.BaseActionSource;
 import appeng.api.networking.security.IActionHost;
 import appeng.api.networking.security.PlayerSource;
 import appeng.api.storage.ITerminalHost;
+import appeng.api.storage.ITerminalPins;
 import appeng.api.storage.data.IAEStack;
 import appeng.api.storage.data.IItemList;
 import appeng.container.AEBaseContainer;
@@ -51,6 +53,7 @@ import appeng.core.sync.packets.PacketCraftingTreeData;
 import appeng.core.sync.packets.PacketMEInventoryUpdate;
 import appeng.crafting.MECraftingInventory;
 import appeng.crafting.v2.CraftingJobV2;
+import appeng.items.contents.PinsHandler;
 import appeng.tile.misc.TilePatternOptimizationMatrix;
 import appeng.util.Platform;
 import io.netty.buffer.ByteBuf;
@@ -60,6 +63,7 @@ public class ContainerCraftConfirm extends ContainerSubGui implements ICraftingC
 
     private Future<ICraftingJob> job;
     protected ICraftingJob result;
+    private final ITerminalHost host;
 
     @GuiSync(0)
     public long bytesUsed;
@@ -99,6 +103,7 @@ public class ContainerCraftConfirm extends ContainerSubGui implements ICraftingC
 
     public ContainerCraftConfirm(final InventoryPlayer ip, final ITerminalHost te) {
         super(ip, te);
+        this.host = te;
         this.cpuTable = new ContainerCPUTable(this, this::onCPUUpdate, false, this::cpuMatches);
     }
 
@@ -322,9 +327,23 @@ public class ContainerCraftConfirm extends ContainerSubGui implements ICraftingC
             this.setAutoStart(false);
             this.setAutoStartAndFollow(false);
             if (g != null) {
+                this.pushCraftedItemToPins();
                 this.switchToOriginalGUI();
             }
         }
+    }
+
+    private void pushCraftedItemToPins() {
+        if (!(this.host instanceof ITerminalPins itp)) return;
+
+        final PinsHandler pinsHandler = itp.getPinsHandler(this.getPlayerInv().player);
+        if (pinsHandler == null || pinsHandler.getCraftingPinsRows() == PinsRows.DISABLED) return;
+
+        final IAEStack<?> craftedItem = this.getItemToCraft();
+        if (craftedItem == null) return;
+
+        pinsHandler.addItemsToPins(java.util.Collections.singletonList(craftedItem));
+        pinsHandler.update(true);
     }
 
     public void optimizePatterns() {

--- a/src/main/java/appeng/container/implementations/ContainerMEMonitorable.java
+++ b/src/main/java/appeng/container/implementations/ContainerMEMonitorable.java
@@ -15,10 +15,8 @@ import static appeng.util.item.AEItemStackType.ITEM_STACK_TYPE;
 
 import java.io.IOException;
 import java.nio.BufferOverflowException;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -34,7 +32,6 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import org.jetbrains.annotations.Nullable;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.gtnewhorizon.gtnhlib.item.ItemStackNBT;
 
@@ -58,7 +55,6 @@ import appeng.api.networking.crafting.ICraftingCPU;
 import appeng.api.networking.crafting.ICraftingGrid;
 import appeng.api.networking.energy.IEnergyGrid;
 import appeng.api.networking.security.BaseActionSource;
-import appeng.api.networking.security.PlayerSource;
 import appeng.api.networking.storage.IBaseMonitor;
 import appeng.api.storage.IMEMonitor;
 import appeng.api.storage.IMEMonitorHandlerReceiver;
@@ -584,38 +580,8 @@ public class ContainerMEMonitorable extends AEBaseContainer
         return getMonitor(ITEM_STACK_TYPE);
     }
 
-    private int lastUpdate = 20;
-
     public void updatePins(boolean forceUpdate) {
-        if (pinsHandler == null || !(host instanceof ITerminalPins itp)) return;
-
-        boolean hasCraftingPins = pinsHandler.getCraftingPinsRows() != PinsRows.DISABLED;
-        ++lastUpdate;
-        if (!forceUpdate && lastUpdate <= 20) return;
-        lastUpdate = 0;
-        if (hasCraftingPins) {
-            final ICraftingGrid cc = itp.getGrid().getCache(ICraftingGrid.class);
-            final ImmutableList<ICraftingCPU> cpuList = cc.getCpus().asList();
-
-            List<IAEStack<?>> craftedItems = new ArrayList<>();
-
-            // fetch the first available crafting output
-            for (int i = 0; i < cpuList.size(); i++) {
-                ICraftingCPU cpu = cpuList.get(i);
-                IAEStack<?> output = cpu.getFinalMultiOutput();
-                if (cpu.getCraftingAllowMode() != CraftingAllow.ONLY_NONPLAYER && output != null
-                        && cpu.getCurrentJobSource() instanceof PlayerSource src
-                        && src.player == pinsHandler.getPlayer()) {
-                    if (craftedItems.contains(output)) {
-                        continue; // skip if already added
-                    }
-                    if (cpu.isBusy()) craftedItems.add(0, output.copy());
-                    else craftedItems.add(output.copy());
-                }
-            }
-
-            pinsHandler.addItemsToPins(craftedItems);
-        }
+        if (pinsHandler == null) return;
         pinsHandler.update(forceUpdate);
     }
 

--- a/src/main/java/appeng/container/implementations/ContainerMEMonitorable.java
+++ b/src/main/java/appeng/container/implementations/ContainerMEMonitorable.java
@@ -32,12 +32,10 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import org.jetbrains.annotations.Nullable;
 
-import com.google.common.collect.ImmutableSet;
 import com.gtnewhorizon.gtnhlib.item.ItemStackNBT;
 
 import appeng.api.AEApi;
 import appeng.api.config.Actionable;
-import appeng.api.config.CraftingAllow;
 import appeng.api.config.PinsRows;
 import appeng.api.config.PowerMultiplier;
 import appeng.api.config.SecurityPermissions;
@@ -51,8 +49,6 @@ import appeng.api.implementations.tiles.IViewCellStorage;
 import appeng.api.networking.IGrid;
 import appeng.api.networking.IGridHost;
 import appeng.api.networking.IGridNode;
-import appeng.api.networking.crafting.ICraftingCPU;
-import appeng.api.networking.crafting.ICraftingGrid;
 import appeng.api.networking.energy.IEnergyGrid;
 import appeng.api.networking.security.BaseActionSource;
 import appeng.api.networking.storage.IBaseMonitor;
@@ -589,21 +585,6 @@ public class ContainerMEMonitorable extends AEBaseContainer
     public void setPin(IAEStack<?> is, int idx) {
         if (pinsHandler == null || !(host instanceof ITerminalPins itp)) return;
 
-        if (is == null) {
-            final ICraftingGrid cc = itp.getGrid().getCache(ICraftingGrid.class);
-            final ImmutableSet<ICraftingCPU> cpuSet = cc.getCpus();
-            for (ICraftingCPU cpu : cpuSet) {
-                IAEStack<?> output = cpu.getFinalMultiOutput();
-                if (cpu.getCraftingAllowMode() != CraftingAllow.ONLY_NONPLAYER && output != null
-                        && output.isSameType(getPin(idx))) {
-                    if (!cpu.isBusy()) {
-                        cpu.resetFinalOutput();
-                    } else {
-                        return;
-                    }
-                }
-            }
-        }
         pinsHandler.setPin(idx, is);
         updatePins(true);
     }

--- a/src/main/java/appeng/core/AEConfig.java
+++ b/src/main/java/appeng/core/AEConfig.java
@@ -108,10 +108,8 @@ public final class AEConfig extends Configuration implements IConfigurableObject
     public boolean pinCraftingSectionFirst = false;
     /** Which pin section is shown first (derived from pinCraftingSectionFirst). */
     public PinSectionOrder pinSectionOrder = PinSectionOrder.PLAYER_FIRST;
-    /** Crafting row shows recent crafts, not static pins. */
-    public boolean craftingRowAsHistory = false;
     /** Also show crafting-pinned items in main list. */
-    public boolean showCraftingPinsItemsInMainView = false;
+    public boolean showCraftingPinsItemsInMainView = true;
 
     public boolean debugLogTiming = false;
     public boolean debugPathFinding = false;
@@ -429,9 +427,6 @@ public final class AEConfig extends Configuration implements IConfigurableObject
         this.pinCraftingSectionFirst = pOrder.getBoolean(this.pinCraftingSectionFirst);
         this.pinSectionOrder = this.pinCraftingSectionFirst ? PinSectionOrder.CRAFTING_FIRST
                 : PinSectionOrder.PLAYER_FIRST;
-        Property pCraftingRowAsHistory = this.get("Client", "craftingRowAsHistory", this.craftingRowAsHistory);
-        pCraftingRowAsHistory.comment = "Crafting rows show recently crafted items.";
-        this.craftingRowAsHistory = pCraftingRowAsHistory.getBoolean(this.craftingRowAsHistory);
         Property pShowCraftingPinsItemsInMainView = this
                 .get("Client", "showCraftingPinsItemsInMainView", this.showCraftingPinsItemsInMainView);
         pShowCraftingPinsItemsInMainView.comment = "Show crafting-pinned items in main list too.";

--- a/src/main/java/appeng/core/AEConfig.java
+++ b/src/main/java/appeng/core/AEConfig.java
@@ -108,6 +108,10 @@ public final class AEConfig extends Configuration implements IConfigurableObject
     public boolean pinCraftingSectionFirst = false;
     /** Which pin section is shown first (derived from pinCraftingSectionFirst). */
     public PinSectionOrder pinSectionOrder = PinSectionOrder.PLAYER_FIRST;
+    /** NEW: crafting row shows recent crafts, not static pins. */
+    public boolean craftingRowAsHistory = false;
+    /** NEW: also show crafting-pinned items in main list. */
+    public boolean showCraftingPinsItemsInMainView = false;
 
     public boolean debugLogTiming = false;
     public boolean debugPathFinding = false;
@@ -425,6 +429,14 @@ public final class AEConfig extends Configuration implements IConfigurableObject
         this.pinCraftingSectionFirst = pOrder.getBoolean(this.pinCraftingSectionFirst);
         this.pinSectionOrder = this.pinCraftingSectionFirst ? PinSectionOrder.CRAFTING_FIRST
                 : PinSectionOrder.PLAYER_FIRST;
+        Property pCraftingRowAsHistory = this.get("Client", "craftingRowAsHistory", this.craftingRowAsHistory);
+        pCraftingRowAsHistory.comment = "Crafting rows show recently crafted items.";
+        this.craftingRowAsHistory = pCraftingRowAsHistory.getBoolean(this.craftingRowAsHistory);
+        Property pShowCraftingPinsItemsInMainView = this
+                .get("Client", "showCraftingPinsItemsInMainView", this.showCraftingPinsItemsInMainView);
+        pShowCraftingPinsItemsInMainView.comment = "Show crafting-pinned items in main list too.";
+        this.showCraftingPinsItemsInMainView = pShowCraftingPinsItemsInMainView
+                .getBoolean(this.showCraftingPinsItemsInMainView);
 
         // load buttons..
         for (int btnNum = 0; btnNum < 4; btnNum++) {

--- a/src/main/java/appeng/core/AEConfig.java
+++ b/src/main/java/appeng/core/AEConfig.java
@@ -108,9 +108,9 @@ public final class AEConfig extends Configuration implements IConfigurableObject
     public boolean pinCraftingSectionFirst = false;
     /** Which pin section is shown first (derived from pinCraftingSectionFirst). */
     public PinSectionOrder pinSectionOrder = PinSectionOrder.PLAYER_FIRST;
-    /** NEW: crafting row shows recent crafts, not static pins. */
+    /** Crafting row shows recent crafts, not static pins. */
     public boolean craftingRowAsHistory = false;
-    /** NEW: also show crafting-pinned items in main list. */
+    /** Also show crafting-pinned items in main list. */
     public boolean showCraftingPinsItemsInMainView = false;
 
     public boolean debugLogTiming = false;

--- a/src/main/java/appeng/items/contents/PinsHandler.java
+++ b/src/main/java/appeng/items/contents/PinsHandler.java
@@ -71,7 +71,7 @@ public class PinsHandler {
     // Adds crafted items only to the crafting pin section (indices 0 to craftingRows*9-1).
     public void addItemsToPins(Iterable<IAEStack<?>> pinsList) {
         if (AEConfig.instance.craftingRowAsHistory) {
-            addItemsToPinsRolling(pinsList);
+            CraftingRowHistoryMode(pinsList);
             return;
         }
         int maxCraftingSlots = craftingPinsRows.getSlotCount();
@@ -106,7 +106,7 @@ public class PinsHandler {
         holder.markDirty();
     }
 
-    private void addItemsToPinsRolling(Iterable<IAEStack<?>> pinsList) {
+    private void CraftingRowHistoryMode(Iterable<IAEStack<?>> pinsList) {
         int maxCraftingSlots = craftingPinsRows.getSlotCount();
         if (maxCraftingSlots <= 0) return;
 

--- a/src/main/java/appeng/items/contents/PinsHandler.java
+++ b/src/main/java/appeng/items/contents/PinsHandler.java
@@ -13,6 +13,7 @@ import appeng.api.storage.data.IAEStack;
 import appeng.core.AELog;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketPinsUpdate;
+import appeng.core.AEConfig;
 
 public class PinsHandler {
 
@@ -58,6 +59,10 @@ public class PinsHandler {
 
     // Adds crafted items only to the crafting pin section (indices 0 to craftingRows*9-1).
     public void addItemsToPins(Iterable<IAEStack<?>> pinsList) {
+        if (AEConfig.instance.craftingRowAsHistory) {
+            addItemsToPinsRolling(pinsList);
+            return;
+        }
         int maxCraftingSlots = craftingPinsRows.getSlotCount();
         if (maxCraftingSlots <= 0) return;
 
@@ -86,6 +91,41 @@ public class PinsHandler {
             pinsInv.setPin(i, itemStack);
             itemStack = null;
         }
+        needUpdate = true;
+        holder.markDirty();
+    }
+
+    private void addItemsToPinsRolling(Iterable<IAEStack<?>> pinsList) {
+        int maxCraftingSlots = craftingPinsRows.getSlotCount();
+        if (maxCraftingSlots <= 0) return;
+
+        for (IAEStack<?> ais : pinsList) {
+            if (ais == null) continue;
+
+            final IAEStack<?> pinStack = ais.copy();
+            pinStack.setStackSize(0);
+
+            // Stop at first empty slot or duplicate, avoid needless shifting.
+            int shiftLimit = -1;
+            for (int i = 0; i < maxCraftingSlots; i++) {
+                final IAEStack<?> current = pinsInv.getPin(i);
+                if (current == null || current.isSameType(pinStack)) {
+                    shiftLimit = i;
+                    break;
+                }
+            }
+
+            // No duplicate and no empty slot found -> section is full, drop the oldest entry.
+            if (shiftLimit < 0) {
+                shiftLimit = maxCraftingSlots - 1;
+            }
+
+            for (int i = shiftLimit; i > 0; i--) {
+                pinsInv.setPin(i, pinsInv.getPin(i - 1));
+            }
+            pinsInv.setPin(0, pinStack);
+        }
+
         needUpdate = true;
         holder.markDirty();
     }

--- a/src/main/java/appeng/items/contents/PinsHandler.java
+++ b/src/main/java/appeng/items/contents/PinsHandler.java
@@ -1,16 +1,13 @@
 package appeng.items.contents;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Iterator;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 
 import appeng.api.config.PinsRows;
 import appeng.api.storage.data.IAEStack;
-import appeng.core.AEConfig;
 import appeng.core.AELog;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketPinsUpdate;
@@ -36,29 +33,29 @@ public class PinsHandler {
     }
 
     public void setPin(int idx, IAEStack<?> stack) {
-        final boolean lockCraftingRows = AEConfig.instance.craftingRowAsHistory;
         final int craftLimit = craftingPinsRows.getSlotCount();
 
         // Block pin items
-        if (lockCraftingRows && idx < craftLimit) {
-            return;
+        if (idx < craftLimit) {
+            if (stack != null) {
+                return;
+            }
         }
 
         if (stack != null) {
             stack = stack.copy();
             stack.setStackSize(0);
             for (int i = 0; i < pinsInv.size(); i++) {
+
                 // Block swap items
-                if (lockCraftingRows && i < craftLimit) continue;
+                if (i < craftLimit) continue;
 
                 if (pinsInv.getPin(i) != null && pinsInv.getPin(i).isSameType(stack)) {
-                    // pinsInv.setInventorySlotContents(i, pinsInv.getStackInSlot(idx)); // swap the pin
                     pinsInv.setPin(i, pinsInv.getPin(idx));
                     break;
                 }
             }
         }
-        // pinsInv.setInventorySlotContents(idx, stack); // set the pin
         pinsInv.setPin(idx, stack);
         needUpdate = true;
         holder.markDirty();
@@ -70,43 +67,6 @@ public class PinsHandler {
 
     // Adds crafted items only to the crafting pin section (indices 0 to craftingRows*9-1).
     public void addItemsToPins(Iterable<IAEStack<?>> pinsList) {
-        if (AEConfig.instance.craftingRowAsHistory) {
-            CraftingRowHistoryMode(pinsList);
-            return;
-        }
-        int maxCraftingSlots = craftingPinsRows.getSlotCount();
-        if (maxCraftingSlots <= 0) return;
-
-        Iterator<IAEStack<?>> it = pinsList.iterator();
-
-        final ArrayList<IAEStack<?>> checkCache = new ArrayList<>();
-        for (int i = 0; i < maxCraftingSlots; i++) {
-            IAEStack<?> ais = pinsInv.getPin(i);
-            if (ais != null) checkCache.add(ais);
-        }
-
-        IAEStack<?> itemStack = null;
-        for (int i = 0; i < maxCraftingSlots; i++) {
-            IAEStack<?> AEis;
-            while (itemStack == null && it.hasNext()) {
-                AEis = it.next();
-                if (AEis != null && !checkCache.contains(AEis)) {
-                    itemStack = AEis.copy();
-                    itemStack.setStackSize(0);
-                    break;
-                }
-            }
-
-            if (itemStack == null) break;
-            if (pinsInv.getPin(i) != null) continue;
-            pinsInv.setPin(i, itemStack);
-            itemStack = null;
-        }
-        needUpdate = true;
-        holder.markDirty();
-    }
-
-    private void CraftingRowHistoryMode(Iterable<IAEStack<?>> pinsList) {
         int maxCraftingSlots = craftingPinsRows.getSlotCount();
         if (maxCraftingSlots <= 0) return;
 
@@ -143,6 +103,14 @@ public class PinsHandler {
 
     public void setPinsRows(PinsRows craftingRows, PinsRows playerRows) {
         if (craftingPinsRows == craftingRows && playerPinsRows == playerRows) return;
+        final int oldCraftLimit = craftingPinsRows.getSlotCount();
+        final int newCraftLimit = craftingRows.getSlotCount();
+        if (newCraftLimit < oldCraftLimit) {
+            for (int i = newCraftLimit; i < oldCraftLimit; i++) {
+                // Clean new row before add
+                pinsInv.setPin(i, null);
+            }
+        }
         craftingPinsRows = craftingRows;
         playerPinsRows = playerRows;
         holder.setPinsRows(player, craftingRows, playerRows);

--- a/src/main/java/appeng/items/contents/PinsHandler.java
+++ b/src/main/java/appeng/items/contents/PinsHandler.java
@@ -36,10 +36,21 @@ public class PinsHandler {
     }
 
     public void setPin(int idx, IAEStack<?> stack) {
+        final boolean lockCraftingRows = AEConfig.instance.craftingRowAsHistory;
+        final int craftLimit = craftingPinsRows.getSlotCount();
+
+        // Block pin items
+        if (lockCraftingRows && idx < craftLimit) {
+            return;
+        }
+
         if (stack != null) {
             stack = stack.copy();
             stack.setStackSize(0);
             for (int i = 0; i < pinsInv.size(); i++) {
+                // Block swap items
+                if (lockCraftingRows && i < craftLimit) continue;
+
                 if (pinsInv.getPin(i) != null && pinsInv.getPin(i).isSameType(stack)) {
                     // pinsInv.setInventorySlotContents(i, pinsInv.getStackInSlot(idx)); // swap the pin
                     pinsInv.setPin(i, pinsInv.getPin(idx));

--- a/src/main/java/appeng/items/contents/PinsHandler.java
+++ b/src/main/java/appeng/items/contents/PinsHandler.java
@@ -10,10 +10,10 @@ import net.minecraft.entity.player.EntityPlayerMP;
 
 import appeng.api.config.PinsRows;
 import appeng.api.storage.data.IAEStack;
+import appeng.core.AEConfig;
 import appeng.core.AELog;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketPinsUpdate;
-import appeng.core.AEConfig;
 
 public class PinsHandler {
 


### PR DESCRIPTION
## Summary
# Crafting Row as History

This PR is a continuation of https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/1138.

When I first learned about the crafting row feature, I expected it to work as a crafting history, where new crafts would overwrite the oldest entries. That would be extremely convenient when queueing multiple items at once (or for long-running crafts), saving you the trouble of searching for them in the system afterwards. However, I found that it works quite differently — so this PR changes that.

~~Two new settings are added:~~
Only "showCraftingPinsItemsInMainView" be added

<img width="2510" height="1106" alt="Screenshot_237" src="https://github.com/user-attachments/assets/16ff7a55-697c-490a-b0cc-7e61ca9be972" />


## ~~`craftingRowAsHistory` (default: false)~~
## CraftingRow works like this by default:
The core feature of this PR. When enabled, the crafting row works as a crafting history: the most recent crafts always show up first, with older ones pushed further down and eventually dropped. Manual editing of the row's contents is disabled while this is active, since it's meant to reflect history rather than be manually curated.


https://github.com/user-attachments/assets/5a4d024c-a770-44f9-ac55-a5e16a86bb5c


## `showCraftingPinsItemsInMainView` (default: ~~false~~ true)

With craftingRowAsHistory enabled, since items are pinned dynamically as you craft — it's easy to miss that an item just got auto-pinned to the crafting row, and then panic when searching for it turns up nothing, making it look like it vanished from the system entirely. This setting keeps pinned crafting-row items visible in the main list as well.

<img width="849" height="989" alt="image" src="https://github.com/user-attachments/assets/305962d7-6250-4399-b706-b80663970a41" />

## Bug fixes

Along the way, this PR also fixes a few pre-existing bugs in the pin system:

- Pin quantity display could get stuck if the same item type was pinned in both a crafting row and a player row.
- Dragging an item out of a crafting-row slot into an occupied player-row slot could swap contents instead of respecting the locked crafting row.

---

This is my first PR and I'm very open to discussion and code improvements. Claude Sonnet 5 was used to help write this PR.

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
