### PR TITLE
use decrStackSize to pull from unknown IInventory

### DIFF
--- a/src/main/java/appeng/me/storage/MEIInventoryWrapper.java
+++ b/src/main/java/appeng/me/storage/MEIInventoryWrapper.java
@@ -133,20 +133,7 @@ public class MEIInventoryWrapper implements IMEInventory<IAEItemStack> {
                         reqNum = Req.stackSize;
                     }
 
-                    ItemStack retrieved = null;
-
-                    if (sub.stackSize < Req.stackSize) {
-                        retrieved = Platform.cloneItemStack(sub);
-                        sub.stackSize = 0;
-                    } else {
-                        retrieved = sub.splitStack(Req.stackSize);
-                    }
-
-                    if (sub.stackSize <= 0) {
-                        this.target.setInventorySlotContents(x, null);
-                    } else {
-                        this.target.setInventorySlotContents(x, sub);
-                    }
+                    ItemStack retrieved = this.target.decrStackSize(x, reqNum);
 
                     if (retrieved != null) {
                         Gathered.stackSize += retrieved.stackSize;

--- a/src/main/java/appeng/util/inv/AdaptorIInventory.java
+++ b/src/main/java/appeng/util/inv/AdaptorIInventory.java
@@ -56,25 +56,13 @@ public class AdaptorIInventory extends InventoryAdaptor {
                 }
 
                 if (boundAmounts > 0) {
-                    if (rv == null) {
-                        rv = is.copy();
-                        filter = rv;
-                        rv.stackSize = boundAmounts;
-                        amount -= boundAmounts;
-                    } else {
-                        rv.stackSize += boundAmounts;
-                        amount -= boundAmounts;
+                    filter = this.i.decrStackSize(x, boundAmounts);
+                    if (filter != null) {
+                        amount -= filter.stackSize;
+                        if (rv == null) rv = filter;
+                        else rv.stackSize += filter.stackSize;
                     }
-
-                    if (is.stackSize == boundAmounts) {
-                        this.i.setInventorySlotContents(x, null);
-                        this.i.markDirty();
-                    } else {
-                        final ItemStack po = is.copy();
-                        po.stackSize -= boundAmounts;
-                        this.i.setInventorySlotContents(x, po);
-                        this.i.markDirty();
-                    }
+                    this.i.markDirty();
                 }
             }
         }

--- a/src/main/java/appeng/util/inv/AdaptorIInventory.java
+++ b/src/main/java/appeng/util/inv/AdaptorIInventory.java
@@ -114,34 +114,12 @@ public class AdaptorIInventory extends InventoryAdaptor {
             final ItemStack is = this.i.getStackInSlot(x);
             if (is != null && this.canRemoveStackFromSlot(x, is)
                     && (filter == null || Platform.isSameItemFuzzy(is, filter, fuzzyMode))) {
-                int newAmount = amount;
-                if (newAmount > is.stackSize) {
-                    newAmount = is.stackSize;
-                }
-                if (destination != null && !destination.canInsert(is)) {
-                    newAmount = 0;
-                }
 
-                ItemStack rv = null;
-                if (newAmount > 0) {
-                    rv = is.copy();
-                    rv.stackSize = newAmount;
+                if (destination != null && !destination.canInsert(is)) continue;
 
-                    if (is.stackSize == rv.stackSize) {
-                        this.i.setInventorySlotContents(x, null);
-                        this.i.markDirty();
-                    } else {
-                        final ItemStack po = is.copy();
-                        po.stackSize -= rv.stackSize;
-                        this.i.setInventorySlotContents(x, po);
-                        this.i.markDirty();
-                    }
-                }
+                ItemStack rv = this.i.decrStackSize(x, amount);
+                if (rv != null && rv.stackSize > 0) return rv;
 
-                if (rv != null) {
-                    // i.markDirty();
-                    return rv;
-                }
             }
         }
         return null;

--- a/src/main/java/appeng/util/inv/AdaptorIInventory.java
+++ b/src/main/java/appeng/util/inv/AdaptorIInventory.java
@@ -118,6 +118,7 @@ public class AdaptorIInventory extends InventoryAdaptor {
                 if (destination != null && !destination.canInsert(is)) continue;
 
                 ItemStack rv = this.i.decrStackSize(x, amount);
+                this.i.markDirty();
                 if (rv != null && rv.stackSize > 0) return rv;
 
             }


### PR DESCRIPTION
"Watch what happens when I `setInventorySlotContents` an `IInventory` I don't know!"

Bypassing decrStackSize when pulling from an inventory could lead to dupes when pulling from blocks that do processing on decrStackSize (it [already has](https://github.com/GTNewHorizons/Dupes-Exploits-GTNH/issues/321)). While individual tiles could be patched to intelligently handle setInventorySlotContents, it's just better to call decrStackSize.