### PR TITLE
Fix unconfigured ore filter cards using hidden filters

### DIFF
--- a/src/main/java/appeng/items/storage/ItemViewCell.java
+++ b/src/main/java/appeng/items/storage/ItemViewCell.java
@@ -92,8 +92,10 @@ public class ItemViewCell extends AEBaseItem implements ICellWorkbenchItem {
                     }
                 }
 
-                if (hasOreFilter && !filter.isEmpty()) {
-                    myMergedList.addNewList(new OreFilteredList(filter), !hasInverter);
+                if (hasOreFilter) {
+                    if (!filter.isEmpty()) {
+                        myMergedList.addNewList(new OreFilteredList(filter), !hasInverter);
+                    }
                 } else {
                     final IItemList priorityList = AEApi.instance().storage().createAEStackList();
 

--- a/src/main/java/appeng/me/storage/CellInventoryHandler.java
+++ b/src/main/java/appeng/me/storage/CellInventoryHandler.java
@@ -68,7 +68,7 @@ public abstract class CellInventoryHandler<StackType extends IAEStack<StackType>
                 setSticky(true);
             }
 
-            if (hasOreFilter && !filter.isEmpty()) {
+            if (hasOreFilter) {
                 setOreFilteredList(filter);
             } else {
                 setPriorityList(hasFuzzy, config, fzMode);

--- a/src/main/java/appeng/parts/misc/PartStorageBus.java
+++ b/src/main/java/appeng/parts/misc/PartStorageBus.java
@@ -674,10 +674,9 @@ public class PartStorageBus extends PartUpgradeable implements IStorageBus {
                         this.handler.setSticky(true);
                     }
 
-                    final boolean useOreFilter = this.getInstalledUpgrades(Upgrades.ORE_FILTER) > 0
-                            && !this.oreFilterString.isEmpty();
+                    final boolean hasOreFilter = this.getInstalledUpgrades(Upgrades.ORE_FILTER) > 0;
 
-                    if (!useOreFilter) {
+                    if (!hasOreFilter) {
                         final IItemList priorityList = getItemList();
 
                         final int slotsToUse = 18 + this.getInstalledUpgrades(Upgrades.CAPACITY) * 9;


### PR DESCRIPTION
## Summary
When the filter string is empty, it allows everything instead of using the regular config.


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
