### PR TITLE
Fix energy cell tooltip ignoring the power usage multiplier

### DIFF
--- a/src/main/java/appeng/block/AEBaseItemBlockChargeable.java
+++ b/src/main/java/appeng/block/AEBaseItemBlockChargeable.java
@@ -24,9 +24,8 @@ import com.gtnewhorizon.gtnhlib.item.ItemStackNBT;
 
 import appeng.api.config.AccessRestriction;
 import appeng.api.config.PowerUnits;
-import appeng.api.definitions.IBlockDefinition;
 import appeng.api.implementations.items.IAEItemPowerStorage;
-import appeng.core.Api;
+import appeng.block.networking.BlockEnergyCell;
 import appeng.core.localization.GuiText;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -61,13 +60,9 @@ public class AEBaseItemBlockChargeable extends AEBaseItemBlock implements IAEIte
 
     private double getMaxEnergyCapacity() {
         final Block blockID = Block.getBlockFromItem(this);
-        final IBlockDefinition energyCell = Api.INSTANCE.definitions().blocks().energyCell();
-        for (final Block block : energyCell.maybeBlock().asSet()) {
-            if (blockID == block) {
-                return 200000;
-            } else {
-                return 8 * 200000;
-            }
+        // The block capacity is already scaled by the power multiplier.
+        if (blockID instanceof BlockEnergyCell energyCell) {
+            return energyCell.getMaxPower();
         }
 
         return 0;


### PR DESCRIPTION
## Summary
The chargeable energy cell item block computed the percentage against a hardcoded 200000 (or 8x that) capacity, while the actual cell capacity is scaled by the PowerRatios/UsageMultiplier config option. With the GTNH value of 10 a full dense cell showed 16,000,000AE and 1000%.

Capacity now comes from the block itself, so it stays in sync with the config for both the regular and the dense cell. This also fixes getAEMaxPower reporting the unscaled value.

## Checklist
- [X] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
