### PR TITLE
Crafting cpus improvements

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
@@ -529,12 +529,27 @@ public class GuiCraftConfirm extends GuiSub implements ICraftingCPUTableHolder, 
         for (int z = viewStart; z < Math.min(viewEnd, this.filteredVisual.size()); z++) {
             final IAEStack<?> refStack = this.filteredVisual.get(z); // repo.getReferenceItem( z );
             if (refStack != null) {
-                GL11.glPushMatrix();
-                GL11.glScaled(0.5, 0.5, 0.5);
-
                 final IAEStack<?> stored = this.storage.findPrecise(refStack);
                 final IAEStack<?> pendingStack = this.pending.findPrecise(refStack);
                 final IAEStack<?> missingStack = this.missing.findPrecise(refStack);
+
+                final boolean red = missingStack != null && missingStack.getStackSize() > 0;
+                final int posX = x * (1 + sectionLength) + xo + sectionLength - 19;
+                final int posY = y * offY + yo;
+
+                if (red) {
+                    final int startX = x * (1 + sectionLength) + xo;
+                    final int startY = posY - 3;
+                    drawRect(
+                            startX,
+                            startY,
+                            startX + sectionLength,
+                            startY + offY - 1,
+                            ColorUtils.craftConfirmMissingItem.getColor());
+                }
+
+                GL11.glPushMatrix();
+                GL11.glScaled(0.5, 0.5, 0.5);
 
                 int lines = 0;
 
@@ -573,7 +588,6 @@ public class GuiCraftConfirm extends GuiSub implements ICraftingCPUTableHolder, 
                     downY += 5;
                 }
 
-                boolean red = false;
                 if (missingStack != null && missingStack.getStackSize() > 0) {
                     String str = GuiText.Missing.getLocal() + ": "
                             + ReadableNumberConverter.INSTANCE.toWideReadableForm(missingStack.getStackSize());
@@ -590,7 +604,6 @@ public class GuiCraftConfirm extends GuiSub implements ICraftingCPUTableHolder, 
                                         + NumberFormat.getInstance().format(missingStack.getStackSize()));
                     }
 
-                    red = true;
                     downY += 5;
                 }
 
@@ -644,8 +657,6 @@ public class GuiCraftConfirm extends GuiSub implements ICraftingCPUTableHolder, 
                 }
 
                 GL11.glPopMatrix();
-                final int posX = x * (1 + sectionLength) + xo + sectionLength - 19;
-                final int posY = y * offY + yo;
 
                 if (this.tooltip == z - viewStart) {
                     dspToolTip = refStack.getDisplayName();
@@ -664,17 +675,7 @@ public class GuiCraftConfirm extends GuiSub implements ICraftingCPUTableHolder, 
                 }
 
                 refStack.drawInGui(this.mc, posX, posY);
-
-                if (red) {
-                    final int startX = x * (1 + sectionLength) + xo;
-                    final int startY = posY - 3;
-                    drawRect(
-                            startX,
-                            startY,
-                            startX + sectionLength,
-                            startY + offY - 1,
-                            ColorUtils.craftConfirmMissingItem.getColor());
-                }
+                
 
                 x++;
 

--- a/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCraftConfirm.java
@@ -674,8 +674,9 @@ public class GuiCraftConfirm extends GuiSub implements ICraftingCPUTableHolder, 
                     hoveredStack = itemStack;
                 }
 
+                GL11.glPushAttrib(GL11.GL_ENABLE_BIT | GL11.GL_COLOR_BUFFER_BIT | GL11.GL_LIGHTING_BIT);
                 refStack.drawInGui(this.mc, posX, posY);
-                
+                GL11.glPopAttrib();
 
                 x++;
 

--- a/src/main/java/appeng/client/gui/widgets/GuiCraftingCPUTable.java
+++ b/src/main/java/appeng/client/gui/widgets/GuiCraftingCPUTable.java
@@ -221,7 +221,7 @@ public class GuiCraftingCPUTable {
                     AEBaseGui.drawRect(
                             x + 1,
                             y + CPU_TABLE_SLOT_HEIGHT - 2,
-                            x + (int) ((CPU_TABLE_SLOT_WIDTH - 1) * craftingPercentage) - 1,
+                            x + 1 + (int) ((CPU_TABLE_SLOT_WIDTH - 3) * craftingPercentage),
                             y + CPU_TABLE_SLOT_HEIGHT - 1,
                             this.calculateGradientColor(craftingPercentage));
                 } else {


### PR DESCRIPTION
## Summary
- Changes the rendering of the overlay "tint" to be under the text - text is no longer colored for better visibility
- Fixed the starting point of the cpu crafting progress bar (was inverted)
- Fixed the text color going white on resource packs as of above changes

| Before | After |
| - | - |
| <img width="910" height="224" alt="Pre1" src="https://github.com/user-attachments/assets/60deddf3-0acb-4587-a282-d36054166c17" /> | <img width="862" height="176" alt="Post1" src="https://github.com/user-attachments/assets/d7dcf02e-0684-41cb-8309-667c9b6ca4ee" /> |

<img width="1647" height="638" alt="image" src="https://github.com/user-attachments/assets/940e893e-afa7-4f1c-a7bc-3903f05c3068" />


The change is better visible on other colors
<img width="362" height="155" alt="image" src="https://github.com/user-attachments/assets/fd3bd0fe-65fa-41ae-8b33-f6911851edad" />

## Checklist
- [X] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
