### PR TITLE
Fix Spatial IO transfers into unloaded chunks

### DIFF
--- a/src/main/java/appeng/me/cluster/MBCalculator.java
+++ b/src/main/java/appeng/me/cluster/MBCalculator.java
@@ -70,7 +70,10 @@ public abstract class MBCalculator {
 
                     boolean updateGrid = false;
                     IAECluster cluster = this.target.getCluster();
-                    if (cluster == null) {
+                    if (cluster == null || !this.matchesExistingCluster(cluster, min, max)) {
+                        if (cluster != null) {
+                            cluster.destroy();
+                        }
                         cluster = this.createCluster(world, min, max);
                         this.updateTiles(cluster, world, min, max);
                         updateGrid = true;
@@ -119,6 +122,10 @@ public abstract class MBCalculator {
      * @return created cluster
      */
     public abstract IAECluster createCluster(World w, WorldCoord min, WorldCoord max);
+
+    protected boolean matchesExistingCluster(final IAECluster cluster, final WorldCoord min, final WorldCoord max) {
+        return true;
+    }
 
     public abstract boolean verifyInternalStructure(World worldObj, WorldCoord min, WorldCoord max);
 

--- a/src/main/java/appeng/me/cluster/implementations/SpatialPylonCalculator.java
+++ b/src/main/java/appeng/me/cluster/implementations/SpatialPylonCalculator.java
@@ -44,6 +44,12 @@ public class SpatialPylonCalculator extends MBCalculator {
     }
 
     @Override
+    protected boolean matchesExistingCluster(final IAECluster cluster, final WorldCoord min, final WorldCoord max) {
+        final SpatialPylonCluster pylonCluster = (SpatialPylonCluster) cluster;
+        return pylonCluster.getMin().isEqual(min) && pylonCluster.getMax().isEqual(max);
+    }
+
+    @Override
     public boolean verifyInternalStructure(final World w, final WorldCoord min, final WorldCoord max) {
 
         for (int x = min.x; x <= max.x; x++) {

--- a/src/main/java/appeng/spatial/StorageHelper.java
+++ b/src/main/java/appeng/spatial/StorageHelper.java
@@ -22,6 +22,9 @@ import net.minecraft.util.MathHelper;
 import net.minecraft.world.Teleporter;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.chunk.EmptyChunk;
+import net.minecraft.world.chunk.IChunkProvider;
 
 import appeng.api.AEApi;
 import appeng.api.util.WorldCoord;
@@ -29,6 +32,8 @@ import appeng.core.stats.Achievements;
 import appeng.util.Platform;
 
 public class StorageHelper {
+
+    private static final int CHUNK_COORDINATE_SHIFT = 4;
 
     private static StorageHelper instance;
 
@@ -173,6 +178,9 @@ public class StorageHelper {
             , final World dst/** storage cell **/
             ,final int x, final int y, final int z, final int i, final int j, final int k, final int scaleX,
             final int scaleY, final int scaleZ) {
+        ensureRegionLoaded(src.getChunkProvider(), x - 1, z - 1, x + scaleX + 1, z + scaleZ + 1);
+        ensureRegionLoaded(dst.getChunkProvider(), i - 1, k - 1, i + scaleX + 1, k + scaleZ + 1);
+
         for (final Block matrixFrameBlock : AEApi.instance().definitions().blocks().matrixFrame().maybeBlock()
                 .asSet()) {
             this.transverseEdges(
@@ -241,6 +249,24 @@ public class StorageHelper {
          * ChunkProviderServer srv = (ChunkProviderServer) cp; srv.unloadAllChunks(); } cp.unloadQueuedChunks();
          */
 
+    }
+
+    static void ensureRegionLoaded(final IChunkProvider chunkProvider, final int minBlockX, final int minBlockZ,
+            final int maxBlockX, final int maxBlockZ) {
+        final int minChunkX = minBlockX >> CHUNK_COORDINATE_SHIFT;
+        final int minChunkZ = minBlockZ >> CHUNK_COORDINATE_SHIFT;
+        final int maxChunkX = maxBlockX >> CHUNK_COORDINATE_SHIFT;
+        final int maxChunkZ = maxBlockZ >> CHUNK_COORDINATE_SHIFT;
+
+        for (int chunkX = minChunkX; chunkX <= maxChunkX; chunkX++) {
+            for (int chunkZ = minChunkZ; chunkZ <= maxChunkZ; chunkZ++) {
+                final Chunk chunk = chunkProvider.loadChunk(chunkX, chunkZ);
+                if (chunk == null || chunk instanceof EmptyChunk || !chunk.isAtLocation(chunkX, chunkZ)) {
+                    throw new IllegalStateException(
+                            "Unable to load chunk " + chunkX + ", " + chunkZ + " for spatial transfer");
+                }
+            }
+        }
     }
 
     private static class TriggerUpdates implements ISpatialVisitor {


### PR DESCRIPTION
## Summary

Preload and validate the required chunks before swapping Spatial IO regions
This prevents missing chunks in the storage dimension from resolving to a shared `EmptyChunk` and corrupting large transfers

resolves GTNewHorizons/GT-New-Horizons-Modpack#25282

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
