### PR TITLE
Make AE2 dropoff use Bogo pins

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -39,6 +39,7 @@ dependencies {
     compileOnly('com.github.GTNewHorizons:Baubles-Expanded:2.2.21-GTNH:dev')
     compileOnly("org.jetbrains:annotations:26.0.2")
     compileOnly("com.github.GTNewHorizons:Postea:1.2.5:dev")
+    compileOnly("com.github.GTNewHorizons:InventoryBogoSorter:1.3.45-GTNH:dev")
 
     testImplementation('junit:junit:4.12')
     functionalTestImplementation(platform('org.junit:junit-bom:5.9.2'))

--- a/src/main/java/appeng/container/AEBaseContainer.java
+++ b/src/main/java/appeng/container/AEBaseContainer.java
@@ -38,6 +38,8 @@ import net.minecraft.tileentity.TileEntity;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import com.cleanroommc.bogosorter.api.IBogoSortAPI;
+
 import appeng.api.AEApi;
 import appeng.api.config.Actionable;
 import appeng.api.config.PowerMultiplier;
@@ -771,6 +773,7 @@ public abstract class AEBaseContainer extends Container {
                 }
 
                 for (final Slot fr : from) {
+                    if (Platform.isBogoLoaded && this.isPinnedByBogoSorter(player, fr)) continue;
                     this.transferStackInSlot(player, fr.slotNumber);
                 }
             }
@@ -1023,6 +1026,11 @@ public abstract class AEBaseContainer extends Container {
                 }
             }
         }
+    }
+
+    @cpw.mods.fml.common.Optional.Method(modid = "bogosorter")
+    private boolean isPinnedByBogoSorter(final EntityPlayer player, final Slot slot) {
+        return IBogoSortAPI.getInstance().isPinned(player, this, slot);
     }
 
     public void swapSlotContents(final int slotA, final int slotB) {

--- a/src/main/java/appeng/util/Platform.java
+++ b/src/main/java/appeng/util/Platform.java
@@ -187,6 +187,7 @@ public class Platform {
     public static final boolean isEIOLoaded = Loader.isModLoaded("EnderIO");
     public static final boolean isBaublesLoaded = Loader.isModLoaded("Baubles|Expanded");
     public static final boolean isBackhandLoaded = Loader.isModLoaded("backhand");
+    public static final boolean isBogoLoaded = Loader.isModLoaded("bogosorter");
     public static final boolean isPosteaLoaded = Loader.isModLoaded("postea");
     public static final boolean isGTLoaded = IntegrationRegistry.INSTANCE.isEnabled(IntegrationType.GT);
     public static final boolean isThaumicEnergisticsLoaded = Loader.isModLoaded("thaumicenergistics");


### PR DESCRIPTION
## Summary
Following merge of: https://github.com/GTNewHorizons/InventoryBogoSorter/pull/220

AE2 should now skip pinned slots during drop off.

Creating as a draft until I can confirm it works full pack. Only confirmed it doesn't crash in dev env.


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)

