### PR TITLE
Fix AE2 cable placement preview ignoring colour of GridHosts

### DIFF
--- a/src/main/java/appeng/client/render/previewBlocks/RendererCable.java
+++ b/src/main/java/appeng/client/render/previewBlocks/RendererCable.java
@@ -11,6 +11,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import appeng.api.implementations.parts.IPartCable;
+import appeng.api.implementations.tiles.IColorableTile;
 import appeng.api.networking.IGridHost;
 import appeng.api.parts.IPart;
 import appeng.api.parts.IPartHost;
@@ -224,24 +225,30 @@ public class RendererCable extends AbstractRendererPreview implements IRenderPre
 
     private boolean canConnectToGridHost(IGridHost gridHost, ForgeDirection side) {
         AECableType connectionType = gridHost.getCableConnectionType(side);
+        AEColor cableColor = ViewHelper.getCableColor(ViewHelper.getCachedItemStack());
+        AEColor gridHostColor = gridHost instanceof IColorableTile ? ((IColorableTile) gridHost).getColor()
+                : AEColor.Transparent;
 
         if (gridHost instanceof AENetworkInvTile) {
-            return hasConnectableSide(((AENetworkInvTile) gridHost)::getProxy, side);
+            return hasConnectableSide(((AENetworkInvTile) gridHost)::getProxy, side, cableColor, gridHostColor);
         }
 
         if (gridHost instanceof AENetworkPowerTile) {
-            return hasConnectableSide(((AENetworkPowerTile) gridHost)::getProxy, side);
+            return hasConnectableSide(((AENetworkPowerTile) gridHost)::getProxy, side, cableColor, gridHostColor);
         }
 
-        return connectionType != null && connectionType != AECableType.NONE;
+        return connectionType != null && connectionType != AECableType.NONE
+                && isColorCompatible(cableColor, gridHostColor);
     }
 
-    private boolean hasConnectableSide(Supplier<AENetworkProxy> proxySupplier, ForgeDirection side) {
+    private boolean hasConnectableSide(Supplier<AENetworkProxy> proxySupplier, ForgeDirection side, AEColor cableColor,
+            AEColor proxyColor) {
         EnumSet<ForgeDirection> connectableSides = proxySupplier.get().getConnectableSides();
         if (connectableSides.isEmpty()) {
             proxySupplier.get().onReady();
         }
-        return !connectableSides.isEmpty() && connectableSides.contains(side);
+        return !connectableSides.isEmpty() && connectableSides.contains(side)
+                && isColorCompatible(cableColor, proxyColor);
     }
 
     private AECableType getNeighborCableType(ForgeDirection direction) {


### PR DESCRIPTION
## Summary
Adds a colour compatibility check for the colour of the GridHost when checking if the connection is possible. Not entirely confident in the quality of the code, but it seems to be working?

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26177

<img width="1320" height="841" alt="Screenshot 2026-08-06 171006" src="https://github.com/user-attachments/assets/7a3baf9e-b667-4b43-bec9-42c44046f5b7" />
<img width="1373" height="940" alt="Screenshot 2026-08-06 171109" src="https://github.com/user-attachments/assets/fff95fcd-bd5d-4256-b02f-7d961be318d5" />
<img width="1325" height="928" alt="image" src="https://github.com/user-attachments/assets/06050de0-cf97-4ca0-8988-a41874f3844e" />




## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
