### PR TITLE
Support NEI bookmark group drops in storage buses

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiStorageBus.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiStorageBus.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.entity.player.InventoryPlayer;
+import net.minecraft.item.ItemStack;
 
 import org.lwjgl.input.Mouse;
 
@@ -231,6 +232,27 @@ public class GuiStorageBus extends GuiUpgradeable {
         for (VirtualMEPhantomSlot slot : this.configSlots) {
             slot.setHidden(slot.getSlotIndex() >= (18 + (9 * capacity)));
         }
+    }
+
+    public boolean handleBookmarkGroupDrop(int mouseX, int mouseY, Iterable<ItemStack> stacks) {
+        final int x = mouseX - this.guiLeft + 1;
+        final int y = mouseY - this.guiTop + 1;
+        this.updateSlotVisibility();
+
+        int slotIndex = -1;
+        for (VirtualMEPhantomSlot slot : this.configSlots) {
+            if (slot.isHovered(x, y)) {
+                slotIndex = slot.getSlotIndex();
+                break;
+            }
+        }
+        if (slotIndex < 0) return false;
+
+        for (ItemStack stack : stacks) {
+            if (slotIndex >= this.configSlots.length || this.configSlots[slotIndex].isHidden()) break;
+            this.configSlots[slotIndex++].handleMouseClicked(stack, false, 0);
+        }
+        return true;
     }
 
     private boolean acceptType(VirtualMEPhantomSlot slot, IAEStackType<?> type, int mouseButton) {

--- a/src/main/java/appeng/integration/modules/NEIHelpers/NEIInputHandler.java
+++ b/src/main/java/appeng/integration/modules/NEIHelpers/NEIInputHandler.java
@@ -1,5 +1,8 @@
 package appeng.integration.modules.NEIHelpers;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.Item;
@@ -7,13 +10,19 @@ import net.minecraft.item.ItemStack;
 
 import appeng.api.implementations.ICraftingPatternItem;
 import appeng.api.networking.crafting.ICraftingPatternDetails;
+import appeng.client.gui.implementations.GuiStorageBus;
+import codechicken.nei.ItemPanels;
 import codechicken.nei.NEIClientConfig;
+import codechicken.nei.bookmark.BookmarkItem;
+import codechicken.nei.bookmark.SortableGroup;
 import codechicken.nei.guihook.GuiContainerManager;
 import codechicken.nei.guihook.IContainerInputHandler;
 import codechicken.nei.recipe.GuiCraftingRecipe;
 import codechicken.nei.recipe.GuiUsageRecipe;
 
 public class NEIInputHandler implements IContainerInputHandler {
+
+    private List<ItemStack> draggedBookmarkGroup;
 
     @Override
     public boolean keyTyped(GuiContainer gui, char keyChar, int keyCode) {
@@ -60,7 +69,14 @@ public class NEIInputHandler implements IContainerInputHandler {
     public void onMouseClicked(GuiContainer gui, int mousex, int mousey, int button) {}
 
     @Override
-    public void onMouseUp(GuiContainer gui, int mousex, int mousey, int button) {}
+    public void onMouseUp(GuiContainer gui, int mousex, int mousey, int button) {
+        if (button != 0) return;
+
+        if (gui instanceof GuiStorageBus storageBus && this.draggedBookmarkGroup != null) {
+            storageBus.handleBookmarkGroupDrop(mousex, mousey, this.draggedBookmarkGroup);
+        }
+        this.draggedBookmarkGroup = null;
+    }
 
     @Override
     public boolean mouseScrolled(GuiContainer gui, int mousex, int mousey, int scrolled) {
@@ -71,5 +87,11 @@ public class NEIInputHandler implements IContainerInputHandler {
     public void onMouseScrolled(GuiContainer gui, int mousex, int mousey, int scrolled) {}
 
     @Override
-    public void onMouseDragged(GuiContainer gui, int mousex, int mousey, int button, long heldTime) {}
+    public void onMouseDragged(GuiContainer gui, int mousex, int mousey, int button, long heldTime) {
+        final SortableGroup group = ItemPanels.bookmarkPanel.sortableGroup;
+        if (gui instanceof GuiStorageBus && group != null && this.draggedBookmarkGroup == null) {
+            this.draggedBookmarkGroup = group.getBookmarkItems().stream().map(BookmarkItem::getItemStack)
+                    .collect(Collectors.toList());
+        }
+    }
 }


### PR DESCRIPTION
Allow Shift-dragging an NEI bookmark group into ME Storage Bus configuration slots.
Start filling from the configuration slot under the mouse and continue through the following visible slots in order.

ME Storage Bus filters previously had to be configured one item at a time. NEI exposes the active dragged bookmark group, but AE2 did not handle that group when it was dropped onto Storage Bus phantom slots.

This makes it possible to configure several consecutive filters with one bookmark-group drag while preserving the existing phantom-slot behavior.

Related to GTNewHorizons/GT-New-Horizons-Modpack#26226

https://github.com/user-attachments/assets/7626aa9f-8a7d-4cbb-becc-5a120ebb9567


## Checklist

- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
