### PR TITLE
Make advanced level emitter particles purple

### DIFF
--- a/src/main/java/appeng/parts/automation/PartAdvancedLevelEmitter.java
+++ b/src/main/java/appeng/parts/automation/PartAdvancedLevelEmitter.java
@@ -56,6 +56,10 @@ public class PartAdvancedLevelEmitter extends PartUpgradeable implements IAdvanc
     private static final int FLAG_ON = 8;
     private static final int SLOTS = SLOT_COUNT;
 
+    private static final double RED = 255 / 255d;
+    private static final double GREEN = 4 / 255d;
+    private static final double BLUE = 211 / 255d;
+
     private final IAEStackInventory config = new IAEStackInventory(this, SLOTS, StorageName.CONFIG);
 
     private final boolean[] slotActive = new boolean[SLOTS];
@@ -527,7 +531,7 @@ public class PartAdvancedLevelEmitter extends PartUpgradeable implements IAdvanc
             final double d1 = d.offsetY * 0.45F + (r.nextFloat() - 0.5F) * 0.2D;
             final double d2 = d.offsetZ * 0.45F + (r.nextFloat() - 0.5F) * 0.2D;
 
-            world.spawnParticle("reddust", 0.5 + x + d0, 0.5 + y + d1, 0.5 + z + d2, 0.0D, 0.0D, 0.0D);
+            world.spawnParticle("reddust", 0.5 + x + d0, 0.5 + y + d1, 0.5 + z + d2, RED, GREEN, BLUE);
         }
     }
 


### PR DESCRIPTION
Litterally unplayable.
<img width="411" height="274" alt="image" src="https://github.com/user-attachments/assets/1e2ae508-1894-40eb-a0ac-c99caf46661d" />

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge