### PR TITLE
Fix cable render thread safety

### DIFF
--- a/src/main/java/appeng/client/render/CableRenderHelper.java
+++ b/src/main/java/appeng/client/render/CableRenderHelper.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -39,6 +40,10 @@ public class CableRenderHelper {
         final BusRenderHelper busRenderHelper = BusRenderHelper.instances.get();
         if (renderer.overrideBlockTexture != null) {
             busRenderHelper.setPass(0);
+        }
+
+        if (renderer.blockAccess == null) {
+            renderer.blockAccess = Minecraft.getMinecraft().theWorld;
         }
 
         for (final ForgeDirection s : FORGE_DIRECTIONS) {

--- a/src/main/java/appeng/client/render/CableRenderHelper.java
+++ b/src/main/java/appeng/client/render/CableRenderHelper.java
@@ -14,7 +14,6 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 
-import net.minecraft.client.Minecraft;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -41,8 +40,6 @@ public class CableRenderHelper {
         if (renderer.overrideBlockTexture != null) {
             busRenderHelper.setPass(0);
         }
-
-        renderer.blockAccess = Minecraft.getMinecraft().theWorld;
 
         for (final ForgeDirection s : FORGE_DIRECTIONS) {
             final IPart part = cableBusContainer.getPart(s);

--- a/src/main/java/appeng/client/render/blocks/RendererCableBus.java
+++ b/src/main/java/appeng/client/render/blocks/RendererCableBus.java
@@ -45,7 +45,9 @@ public class RendererCableBus extends BaseBlockRender<BlockCableBus, TileCableBu
             final RenderBlocksWorkaround rbw = BusRenderer.INSTANCE.getRenderer();
             rbw.renderAllFaces = true;
             rbw.overrideBlockTexture = renderer.overrideBlockTexture;
+            rbw.blockAccess = world;
             ((TileCableBus) tile).getCableBus().renderStatic(x, y, z);
+            rbw.blockAccess = null;
             rbw.renderAllFaces = false;
         }
 

--- a/src/main/java/appeng/parts/networking/PartCable.java
+++ b/src/main/java/appeng/parts/networking/PartCable.java
@@ -249,7 +249,7 @@ public class PartCable extends AEBasePart implements IPartCable {
                     break;
                 }
             } else if (this.getConnections().contains(dir)) {
-                final TileEntity te = this.getTile().getWorldObj()
+                final TileEntity te = renderer.blockAccess
                         .getTileEntity(x + dir.offsetX, y + dir.offsetY, z + dir.offsetZ);
                 final IPartHost partHost = te instanceof IPartHost ? (IPartHost) te : null;
                 final IGridHost gh = te instanceof IGridHost ? (IGridHost) te : null;
@@ -460,8 +460,7 @@ public class PartCable extends AEBasePart implements IPartCable {
     @SideOnly(Side.CLIENT)
     private void renderGlassConnection(final int x, final int y, final int z, final IPartRenderHelper rh,
             final RenderBlocks renderer, final ForgeDirection of) {
-        final TileEntity te = this.getTile().getWorldObj()
-                .getTileEntity(x + of.offsetX, y + of.offsetY, z + of.offsetZ);
+        final TileEntity te = renderer.blockAccess.getTileEntity(x + of.offsetX, y + of.offsetY, z + of.offsetZ);
         final IPartHost partHost = te instanceof IPartHost ? (IPartHost) te : null;
         final IGridHost gh = te instanceof IGridHost ? (IGridHost) te : null;
 
@@ -511,8 +510,7 @@ public class PartCable extends AEBasePart implements IPartCable {
     @SideOnly(Side.CLIENT)
     void renderCoveredConnection(final int x, final int y, final int z, final IPartRenderHelper rh,
             final RenderBlocks renderer, final int channels, final ForgeDirection of) {
-        final TileEntity te = this.getTile().getWorldObj()
-                .getTileEntity(x + of.offsetX, y + of.offsetY, z + of.offsetZ);
+        final TileEntity te = renderer.blockAccess.getTileEntity(x + of.offsetX, y + of.offsetY, z + of.offsetZ);
         final IPartHost partHost = te instanceof IPartHost ? (IPartHost) te : null;
         final IGridHost ghh = te instanceof IGridHost ? (IGridHost) te : null;
 
@@ -569,8 +567,7 @@ public class PartCable extends AEBasePart implements IPartCable {
     @SideOnly(Side.CLIENT)
     void renderSmartConnection(final int x, final int y, final int z, final IPartRenderHelper rh,
             final RenderBlocks renderer, final int channels, final ForgeDirection of) {
-        final TileEntity te = this.getTile().getWorldObj()
-                .getTileEntity(x + of.offsetX, y + of.offsetY, z + of.offsetZ);
+        final TileEntity te = renderer.blockAccess.getTileEntity(x + of.offsetX, y + of.offsetY, z + of.offsetZ);
         final IPartHost partHost = te instanceof IPartHost ? (IPartHost) te : null;
         final IGridHost ghh = te instanceof IGridHost ? (IGridHost) te : null;
         AEColor myColor = this.getCableColor();

--- a/src/main/java/appeng/parts/networking/PartDenseCable.java
+++ b/src/main/java/appeng/parts/networking/PartDenseCable.java
@@ -12,12 +12,14 @@ package appeng.parts.networking;
 
 import java.util.EnumSet;
 
+import appeng.client.render.BusRenderer;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import org.lwjgl.opengl.GL11;
@@ -65,8 +67,16 @@ public class PartDenseCable extends PartCable implements IUsedChannelProvider {
         return AECableType.DENSE;
     }
 
+    private IBlockAccess getBlockAccess() {
+        final World world = this.getTile().getWorldObj();
+        if (!world.isRemote) return world;
+        final IBlockAccess renderBlockAccess = BusRenderer.INSTANCE.getRenderer().blockAccess;
+        return renderBlockAccess == null ? world : renderBlockAccess;
+    }
+
     @Override
     public void getBoxes(final IPartCollisionHelper bch) {
+        final IBlockAccess blockAccess = this.getBlockAccess();
         final boolean noLadder = !bch.isBBCollision();
         final double min = noLadder ? 3.0 : 4.9;
         final double max = noLadder ? 13.0 : 11.1;
@@ -83,7 +93,7 @@ public class PartDenseCable extends PartCable implements IUsedChannelProvider {
         }
 
         for (final ForgeDirection of : this.getConnections()) {
-            if (this.isDense(this.getTile().getWorldObj(), of)) {
+            if (this.isDense(blockAccess, of)) {
                 switch (of) {
                     case DOWN -> bch.addBox(min, 0.0, min, max, min, max);
                     case EAST -> bch.addBox(max, min, min, 16.0, max, max);

--- a/src/main/java/appeng/parts/networking/PartDenseCable.java
+++ b/src/main/java/appeng/parts/networking/PartDenseCable.java
@@ -17,6 +17,7 @@ import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
+import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import org.lwjgl.opengl.GL11;
@@ -82,7 +83,7 @@ public class PartDenseCable extends PartCable implements IUsedChannelProvider {
         }
 
         for (final ForgeDirection of : this.getConnections()) {
-            if (this.isDense(of)) {
+            if (this.isDense(this.getTile().getWorldObj(), of)) {
                 switch (of) {
                     case DOWN -> bch.addBox(min, 0.0, min, max, min, max);
                     case EAST -> bch.addBox(max, min, min, 16.0, max, max);
@@ -172,14 +173,14 @@ public class PartDenseCable extends PartCable implements IUsedChannelProvider {
 
         boolean hasBuses = false;
         for (final ForgeDirection of : this.getConnections()) {
-            if (!this.isDense(of)) {
+            if (!this.isDense(renderer.blockAccess, of)) {
                 hasBuses = true;
             }
         }
 
         if (sides.size() != 2 || !this.nonLinear(sides) || hasBuses) {
             for (final ForgeDirection of : this.getConnections()) {
-                if (this.isDense(of)) {
+                if (this.isDense(renderer.blockAccess, of)) {
                     this.renderDenseConnection(x, y, z, rh, renderer, this.getChannelsOnSide()[of.ordinal()], of);
                 } else if (this.isSmart(of)) {
                     this.renderSmartConnection(x, y, z, rh, renderer, this.getChannelsOnSide()[of.ordinal()], of);
@@ -366,8 +367,8 @@ public class PartDenseCable extends PartCable implements IUsedChannelProvider {
         });
     }
 
-    private boolean isDense(final ForgeDirection of) {
-        final TileEntity te = this.getTile().getWorldObj().getTileEntity(
+    private boolean isDense(final IBlockAccess world, final ForgeDirection of) {
+        final TileEntity te = world.getTileEntity(
                 this.getTile().xCoord + of.offsetX,
                 this.getTile().yCoord + of.offsetY,
                 this.getTile().zCoord + of.offsetZ);

--- a/src/main/java/appeng/parts/networking/PartDenseCable.java
+++ b/src/main/java/appeng/parts/networking/PartDenseCable.java
@@ -192,7 +192,7 @@ public class PartDenseCable extends PartCable implements IUsedChannelProvider {
             for (final ForgeDirection of : this.getConnections()) {
                 if (this.isDense(renderer.blockAccess, of)) {
                     this.renderDenseConnection(x, y, z, rh, renderer, this.getChannelsOnSide()[of.ordinal()], of);
-                } else if (this.isSmart(of)) {
+                } else if (this.isSmart(renderer.blockAccess, of)) {
                     this.renderSmartConnection(x, y, z, rh, renderer, this.getChannelsOnSide()[of.ordinal()], of);
                 } else {
                     this.renderCoveredConnection(x, y, z, rh, renderer, this.getChannelsOnSide()[of.ordinal()], of);
@@ -292,7 +292,7 @@ public class PartDenseCable extends PartCable implements IUsedChannelProvider {
             final RenderBlocks renderer, final int channels, final ForgeDirection of) {
         final Tessellator tessellator = Tessellator.instance;
 
-        final TileEntity te = this.getTile().getWorldObj()
+        final TileEntity te = renderer.blockAccess
                 .getTileEntity(x + of.offsetX, y + of.offsetY, z + of.offsetZ);
         final IPartHost partHost = te instanceof IPartHost ? (IPartHost) te : null;
         final IGridHost ghh = te instanceof IGridHost ? (IGridHost) te : null;
@@ -343,8 +343,8 @@ public class PartDenseCable extends PartCable implements IUsedChannelProvider {
         }
     }
 
-    private boolean isSmart(final ForgeDirection of) {
-        final TileEntity te = this.getTile().getWorldObj().getTileEntity(
+    private boolean isSmart(final IBlockAccess world, final ForgeDirection of) {
+        final TileEntity te = world.getTileEntity(
                 this.getTile().xCoord + of.offsetX,
                 this.getTile().yCoord + of.offsetY,
                 this.getTile().zCoord + of.offsetZ);

--- a/src/main/java/appeng/parts/networking/PartDenseCable.java
+++ b/src/main/java/appeng/parts/networking/PartDenseCable.java
@@ -292,8 +292,7 @@ public class PartDenseCable extends PartCable implements IUsedChannelProvider {
             final RenderBlocks renderer, final int channels, final ForgeDirection of) {
         final Tessellator tessellator = Tessellator.instance;
 
-        final TileEntity te = renderer.blockAccess
-                .getTileEntity(x + of.offsetX, y + of.offsetY, z + of.offsetZ);
+        final TileEntity te = renderer.blockAccess.getTileEntity(x + of.offsetX, y + of.offsetY, z + of.offsetZ);
         final IPartHost partHost = te instanceof IPartHost ? (IPartHost) te : null;
         final IGridHost ghh = te instanceof IGridHost ? (IGridHost) te : null;
         AEColor myColor = this.getCableColor();

--- a/src/main/java/appeng/parts/networking/PartDenseCable.java
+++ b/src/main/java/appeng/parts/networking/PartDenseCable.java
@@ -12,7 +12,6 @@ package appeng.parts.networking;
 
 import java.util.EnumSet;
 
-import appeng.client.render.BusRenderer;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.item.ItemStack;
@@ -38,6 +37,7 @@ import appeng.api.parts.IPartRenderHelper;
 import appeng.api.util.AECableType;
 import appeng.api.util.AEColor;
 import appeng.block.AEBaseBlock;
+import appeng.client.render.BusRenderer;
 import appeng.client.texture.CableBusTextures;
 import appeng.client.texture.FlippableIcon;
 import appeng.client.texture.OffsetIcon;

--- a/src/main/java/appeng/parts/networking/PartDenseCableCovered.java
+++ b/src/main/java/appeng/parts/networking/PartDenseCableCovered.java
@@ -12,11 +12,13 @@ package appeng.parts.networking;
 
 import java.util.EnumSet;
 
+import appeng.client.render.BusRenderer;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import org.lwjgl.opengl.GL11;
@@ -63,8 +65,16 @@ public class PartDenseCableCovered extends PartCable {
         return AECableType.DENSE_COVERED;
     }
 
+    private IBlockAccess getBlockAccess() {
+        final World world = this.getTile().getWorldObj();
+        if (!world.isRemote) return world;
+        final IBlockAccess renderBlockAccess = BusRenderer.INSTANCE.getRenderer().blockAccess;
+        return renderBlockAccess == null ? world : renderBlockAccess;
+    }
+
     @Override
     public void getBoxes(final IPartCollisionHelper bch) {
+        final IBlockAccess blockAccess = this.getBlockAccess();
         final boolean noLadder = !bch.isBBCollision();
         final double min = noLadder ? 3.0 : 4.9;
         final double max = noLadder ? 13.0 : 11.1;
@@ -81,7 +91,7 @@ public class PartDenseCableCovered extends PartCable {
         }
 
         for (final ForgeDirection of : this.getConnections()) {
-            if (this.isDense(this.getTile().getWorldObj(), of)) {
+            if (this.isDense(blockAccess, of)) {
                 switch (of) {
                     case DOWN -> bch.addBox(min, 0.0, min, max, min, max);
                     case EAST -> bch.addBox(max, min, min, 16.0, max, max);

--- a/src/main/java/appeng/parts/networking/PartDenseCableCovered.java
+++ b/src/main/java/appeng/parts/networking/PartDenseCableCovered.java
@@ -237,7 +237,7 @@ public class PartDenseCableCovered extends PartCable {
     @SideOnly(Side.CLIENT)
     private void renderDenseCoveredConnection(final int x, final int y, final int z, final IPartRenderHelper rh,
             final RenderBlocks renderer, final ForgeDirection of) {
-        final TileEntity te = this.getTile().getWorldObj()
+        final TileEntity te = renderer.blockAccess
                 .getTileEntity(x + of.offsetX, y + of.offsetY, z + of.offsetZ);
         final IPartHost partHost = te instanceof IPartHost ? (IPartHost) te : null;
         final IGridHost ghh = te instanceof IGridHost ? (IGridHost) te : null;

--- a/src/main/java/appeng/parts/networking/PartDenseCableCovered.java
+++ b/src/main/java/appeng/parts/networking/PartDenseCableCovered.java
@@ -12,7 +12,6 @@ package appeng.parts.networking;
 
 import java.util.EnumSet;
 
-import appeng.client.render.BusRenderer;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
@@ -37,6 +36,7 @@ import appeng.api.parts.IPartRenderHelper;
 import appeng.api.util.AECableType;
 import appeng.api.util.AEColor;
 import appeng.block.AEBaseBlock;
+import appeng.client.render.BusRenderer;
 import appeng.client.texture.CableBusTextures;
 import appeng.client.texture.FlippableIcon;
 import appeng.client.texture.OffsetIcon;

--- a/src/main/java/appeng/parts/networking/PartDenseCableCovered.java
+++ b/src/main/java/appeng/parts/networking/PartDenseCableCovered.java
@@ -16,6 +16,7 @@ import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
+import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import org.lwjgl.opengl.GL11;
@@ -80,7 +81,7 @@ public class PartDenseCableCovered extends PartCable {
         }
 
         for (final ForgeDirection of : this.getConnections()) {
-            if (this.isDense(of)) {
+            if (this.isDense(this.getTile().getWorldObj(), of)) {
                 switch (of) {
                     case DOWN -> bch.addBox(min, 0.0, min, max, min, max);
                     case EAST -> bch.addBox(max, min, min, 16.0, max, max);
@@ -157,14 +158,14 @@ public class PartDenseCableCovered extends PartCable {
 
         boolean hasBuses = false;
         for (final ForgeDirection of : this.getConnections()) {
-            if (!this.isDense(of)) {
+            if (!this.isDense(renderer.blockAccess, of)) {
                 hasBuses = true;
             }
         }
 
         if (sides.size() != 2 || !this.nonLinear(sides) || hasBuses) {
             for (final ForgeDirection of : this.getConnections()) {
-                if (this.isDense(of)) {
+                if (this.isDense(renderer.blockAccess, of)) {
                     this.renderDenseCoveredConnection(x, y, z, rh, renderer, of);
                 } else {
                     this.renderCoveredConnection(x, y, z, rh, renderer, this.getChannelsOnSide()[of.ordinal()], of);
@@ -279,8 +280,8 @@ public class PartDenseCableCovered extends PartCable {
         });
     }
 
-    private boolean isDense(final ForgeDirection of) {
-        final TileEntity te = this.getTile().getWorldObj().getTileEntity(
+    private boolean isDense(final IBlockAccess world, final ForgeDirection of) {
+        final TileEntity te = world.getTileEntity(
                 this.getTile().xCoord + of.offsetX,
                 this.getTile().yCoord + of.offsetY,
                 this.getTile().zCoord + of.offsetZ);

--- a/src/main/java/appeng/parts/networking/PartDenseCableCovered.java
+++ b/src/main/java/appeng/parts/networking/PartDenseCableCovered.java
@@ -237,8 +237,7 @@ public class PartDenseCableCovered extends PartCable {
     @SideOnly(Side.CLIENT)
     private void renderDenseCoveredConnection(final int x, final int y, final int z, final IPartRenderHelper rh,
             final RenderBlocks renderer, final ForgeDirection of) {
-        final TileEntity te = renderer.blockAccess
-                .getTileEntity(x + of.offsetX, y + of.offsetY, z + of.offsetZ);
+        final TileEntity te = renderer.blockAccess.getTileEntity(x + of.offsetX, y + of.offsetY, z + of.offsetZ);
         final IPartHost partHost = te instanceof IPartHost ? (IPartHost) te : null;
         final IGridHost ghh = te instanceof IGridHost ? (IGridHost) te : null;
 

--- a/src/main/java/appeng/tile/networking/TileCableBus.java
+++ b/src/main/java/appeng/tile/networking/TileCableBus.java
@@ -35,6 +35,7 @@ import appeng.api.util.AECableType;
 import appeng.api.util.AEColor;
 import appeng.api.util.DimensionalCoord;
 import appeng.block.networking.BlockCableBus;
+import appeng.core.AELog;
 import appeng.helpers.AEMultiTile;
 import appeng.helpers.ICustomCollision;
 import appeng.hooks.TickHandler;
@@ -49,6 +50,8 @@ import appeng.util.Platform;
 import io.netty.buffer.ByteBuf;
 
 public class TileCableBus extends AEBaseTile implements AEMultiTile, ICustomCollision {
+
+    private final Thread owner = Thread.currentThread();
 
     private CableBusContainer cb = new CableBusContainer(this);
 
@@ -115,6 +118,9 @@ public class TileCableBus extends AEBaseTile implements AEMultiTile, ICustomColl
 
     @Override
     public void invalidate() {
+        if (Thread.currentThread() != this.owner) {
+            AELog.warn(new Throwable(), "Invalidating from wrong thread");
+        }
         super.invalidate();
         this.getCableBus().removeFromWorld();
     }

--- a/src/main/java/appeng/tile/networking/TileCableBus.java
+++ b/src/main/java/appeng/tile/networking/TileCableBus.java
@@ -35,6 +35,7 @@ import appeng.api.util.AECableType;
 import appeng.api.util.AEColor;
 import appeng.api.util.DimensionalCoord;
 import appeng.block.networking.BlockCableBus;
+import appeng.core.AELog;
 import appeng.helpers.AEMultiTile;
 import appeng.helpers.ICustomCollision;
 import appeng.hooks.TickHandler;
@@ -115,6 +116,11 @@ public class TileCableBus extends AEBaseTile implements AEMultiTile, ICustomColl
 
     @Override
     public void invalidate() {
+        if (worldObj.isRemote) {
+            if (!Thread.currentThread().getName().equals("Client thread")) {
+                AELog.error(new Throwable(), "invalidate on the wrong thread!");
+            }
+        }
         super.invalidate();
         this.getCableBus().removeFromWorld();
     }

--- a/src/main/java/appeng/tile/networking/TileCableBus.java
+++ b/src/main/java/appeng/tile/networking/TileCableBus.java
@@ -116,11 +116,6 @@ public class TileCableBus extends AEBaseTile implements AEMultiTile, ICustomColl
 
     @Override
     public void invalidate() {
-        if (worldObj.isRemote) {
-            if (!Thread.currentThread().getName().equals("Client thread")) {
-                AELog.error(new Throwable(), "invalidate on the wrong thread!");
-            }
-        }
         super.invalidate();
         this.getCableBus().removeFromWorld();
     }

--- a/src/main/java/appeng/tile/networking/TileCableBus.java
+++ b/src/main/java/appeng/tile/networking/TileCableBus.java
@@ -35,7 +35,6 @@ import appeng.api.util.AECableType;
 import appeng.api.util.AEColor;
 import appeng.api.util.DimensionalCoord;
 import appeng.block.networking.BlockCableBus;
-import appeng.core.AELog;
 import appeng.helpers.AEMultiTile;
 import appeng.helpers.ICustomCollision;
 import appeng.hooks.TickHandler;


### PR DESCRIPTION
## Summary
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26215

Note: only occur with Angelica when rendering cable multi-threaded.

world.getTileEntity can trigger world.invalidate, and cause corruption of the tile entity.

Reproduction step of the original issue is to put a bunch of cables, and then quickly unload and load the same chunk client side. This will trigger invalidation of the newly loaded tile entity (or similar) on a separate thread repeatedly.

I added logging in TileCableBus.invalidate to detect non client thread access during debug, issue is fixed after my changes.


## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
