### PR TITLE
Fix pattern scrolling in interfaces

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiInterface.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiInterface.java
@@ -38,6 +38,7 @@ import appeng.client.gui.widgets.GuiSimpleImgButton;
 import appeng.client.gui.widgets.GuiTabButton;
 import appeng.client.gui.widgets.GuiToggleButton;
 import appeng.container.implementations.ContainerInterface;
+import appeng.container.slot.OptionalSlotRestrictedInput;
 import appeng.core.AEConfig;
 import appeng.core.AELog;
 import appeng.core.localization.ButtonToolTips;
@@ -46,9 +47,11 @@ import appeng.core.localization.GuiText;
 import appeng.core.sync.GuiBridge;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketConfigButton;
+import appeng.core.sync.packets.PacketInventoryAction;
 import appeng.core.sync.packets.PacketSwitchGuis;
 import appeng.core.sync.packets.PacketValueConfig;
 import appeng.helpers.IInterfaceHost;
+import appeng.helpers.InventoryAction;
 
 public class GuiInterface extends GuiUpgradeable {
 
@@ -288,6 +291,19 @@ public class GuiInterface extends GuiUpgradeable {
     @Override
     protected String getBackground() {
         return "guis/interface.png";
+    }
+
+    @Override
+    protected boolean mouseWheelEvent(final int mouseX, final int mouseY, final int wheel) {
+        final Slot slot = this.getSlot(mouseX, mouseY);
+        if (isCtrlKeyDown() && slot instanceof OptionalSlotRestrictedInput && slot.getHasStack()) {
+            final InventoryAction action = wheel > 0 ? InventoryAction.MULTIPLY_PATTERN
+                    : InventoryAction.DIVIDE_PATTERN;
+            NetworkHandler.instance.sendToServer(new PacketInventoryAction(action, slot.slotNumber, 0));
+            return true;
+        }
+
+        return super.mouseWheelEvent(mouseX, mouseY, wheel);
     }
 
     @Override

--- a/src/main/java/appeng/container/implementations/ContainerInterface.java
+++ b/src/main/java/appeng/container/implementations/ContainerInterface.java
@@ -220,7 +220,15 @@ public class ContainerInterface extends ContainerUpgradeable implements IOptiona
             return;
 
         final ItemStack pattern = patternSlot.getStack();
-        if (pattern == null) return;
+        if (pattern == null || !(pattern.getItem() instanceof ICraftingPatternItem patternItem)) return;
+
+        final ICraftingPatternDetails details = patternItem
+                .getPatternForItem(pattern, this.myDuality.getHost().getTile().getWorldObj());
+        if (details == null || details.isCraftable()) return;
+
+        final int max = multiplier < 0 ? PatternMultiplierHelper.getMaxBitDivider(details)
+                : PatternMultiplierHelper.getMaxBitMultiplier(details);
+        if (max == 0) return;
 
         final ItemStack modifiedPattern = pattern.copy();
         PatternMultiplierHelper.applyModification(modifiedPattern, multiplier);

--- a/src/main/java/appeng/container/implementations/ContainerInterface.java
+++ b/src/main/java/appeng/container/implementations/ContainerInterface.java
@@ -204,23 +204,28 @@ public class ContainerInterface extends ContainerUpgradeable implements IOptiona
 
     @Override
     public void doAction(final EntityPlayerMP player, final InventoryAction action, final int slot, final long id) {
-        if (action == InventoryAction.MULTIPLY_PATTERN || action == InventoryAction.DIVIDE_PATTERN) {
-            if (this.isAllowedToMultiplyPatterns && slot >= 0 && slot < this.inventorySlots.size()) {
-                final Slot target = this.getSlot(slot);
-                if (target instanceof OptionalSlotRestrictedInput patternSlot && patternSlot.isEnabled()
-                        && target.inventory == this.myDuality.getPatterns()
-                        && target.getHasStack()) {
-                    final ItemStack copy = target.getStack().copy();
-                    PatternMultiplierHelper
-                            .applyModification(copy, action == InventoryAction.MULTIPLY_PATTERN ? 1 : -1);
-                    target.putStack(copy);
-                    this.standardDetectAndSendChanges();
-                }
-            }
-            return;
+        switch (action) {
+            case MULTIPLY_PATTERN -> modifyPatternInSlot(slot, 1);
+            case DIVIDE_PATTERN -> modifyPatternInSlot(slot, -1);
+            default -> super.doAction(player, action, slot, id);
         }
+    }
 
-        super.doAction(player, action, slot, id);
+    private void modifyPatternInSlot(final int slot, final int multiplier) {
+        if (!this.isAllowedToMultiplyPatterns || slot < 0 || slot >= this.inventorySlots.size()) return;
+
+        final Slot patternSlot = this.getSlot(slot);
+        if (!(patternSlot instanceof OptionalSlotRestrictedInput optionalSlot) || !optionalSlot.isEnabled()
+                || patternSlot.inventory != this.myDuality.getPatterns())
+            return;
+
+        final ItemStack pattern = patternSlot.getStack();
+        if (pattern == null) return;
+
+        final ItemStack modifiedPattern = pattern.copy();
+        PatternMultiplierHelper.applyModification(modifiedPattern, multiplier);
+        patternSlot.putStack(modifiedPattern);
+        this.standardDetectAndSendChanges();
     }
 
     public void doublePatterns(int val) {

--- a/src/main/java/appeng/container/implementations/ContainerInterface.java
+++ b/src/main/java/appeng/container/implementations/ContainerInterface.java
@@ -12,8 +12,10 @@ package appeng.container.implementations;
 
 import java.util.ArrayList;
 
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 
@@ -37,6 +39,7 @@ import appeng.container.slot.SlotNormal;
 import appeng.container.slot.SlotRestrictedInput;
 import appeng.helpers.DualityInterface;
 import appeng.helpers.IInterfaceHost;
+import appeng.helpers.InventoryAction;
 import appeng.me.cache.CraftingGridCache;
 import appeng.util.PatternMultiplierHelper;
 import appeng.util.Platform;
@@ -197,6 +200,27 @@ public class ContainerInterface extends ContainerUpgradeable implements IOptiona
         this.setAdvancedBlockingMode((AdvancedBlockingMode) cm.getSetting(Settings.ADVANCED_BLOCKING_MODE));
         this.setLockCraftingMode((LockCraftingMode) cm.getSetting(Settings.LOCK_CRAFTING_MODE));
         this.setFuzzyMode((FuzzyMode) cm.getSetting(Settings.FUZZY_MODE));
+    }
+
+    @Override
+    public void doAction(final EntityPlayerMP player, final InventoryAction action, final int slot, final long id) {
+        if (action == InventoryAction.MULTIPLY_PATTERN || action == InventoryAction.DIVIDE_PATTERN) {
+            if (this.isAllowedToMultiplyPatterns && slot >= 0 && slot < this.inventorySlots.size()) {
+                final Slot target = this.getSlot(slot);
+                if (target instanceof OptionalSlotRestrictedInput patternSlot && patternSlot.isEnabled()
+                        && target.inventory == this.myDuality.getPatterns()
+                        && target.getHasStack()) {
+                    final ItemStack copy = target.getStack().copy();
+                    PatternMultiplierHelper
+                            .applyModification(copy, action == InventoryAction.MULTIPLY_PATTERN ? 1 : -1);
+                    target.putStack(copy);
+                    this.standardDetectAndSendChanges();
+                }
+            }
+            return;
+        }
+
+        super.doAction(player, action, slot, id);
     }
 
     public void doublePatterns(int val) {

--- a/src/main/java/appeng/container/implementations/ContainerInterfaceTerminal.java
+++ b/src/main/java/appeng/container/implementations/ContainerInterfaceTerminal.java
@@ -27,6 +27,7 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
+import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import com.google.common.primitives.Ints;
@@ -34,8 +35,10 @@ import com.google.common.primitives.Ints;
 import appeng.api.AEApi;
 import appeng.api.config.Settings;
 import appeng.api.config.YesNo;
+import appeng.api.implementations.ICraftingPatternItem;
 import appeng.api.networking.IGrid;
 import appeng.api.networking.IGridNode;
+import appeng.api.networking.crafting.ICraftingPatternDetails;
 import appeng.api.parts.IInterfaceTerminal;
 import appeng.api.storage.data.IAEStackType;
 import appeng.api.util.DimensionalCoord;
@@ -146,6 +149,8 @@ public final class ContainerInterfaceTerminal extends AEBaseContainer implements
     public void doAction(final EntityPlayerMP player, final InventoryAction action, final int slot, final long id) {
         final InvTracker inv = this.trackedById.get(id);
         if (inv != null) {
+            if (slot < 0 || slot >= inv.numSlots || slot >= inv.patterns.getSizeInventory()) return;
+
             final ItemStack handStack = player.inventory.getItemStack();
 
             if (handStack != null && !(handStack.getItem() instanceof ItemEncodedPattern)) {
@@ -235,22 +240,8 @@ public final class ContainerInterfaceTerminal extends AEBaseContainer implements
                         isDirty = true;
                     }
                 }
-                case MULTIPLY_PATTERN -> {
-                    if (slotStack != null) {
-                        ItemStack copy = slotStack.copy();
-                        PatternMultiplierHelper.applyModification(copy, 1);
-                        inv.patterns.setInventorySlotContents(slot, copy);
-                        syncIfaceSlot(inv, id, slot, copy);
-                    }
-                }
-                case DIVIDE_PATTERN -> {
-                    if (slotStack != null) {
-                        ItemStack copy = slotStack.copy();
-                        PatternMultiplierHelper.applyModification(copy, -1);
-                        inv.patterns.setInventorySlotContents(slot, copy);
-                        syncIfaceSlot(inv, id, slot, copy);
-                    }
-                }
+                case MULTIPLY_PATTERN -> modifyPatternInSlot(inv, id, slot, slotStack, 1);
+                case DIVIDE_PATTERN -> modifyPatternInSlot(inv, id, slot, slotStack, -1);
                 case CREATIVE_DUPLICATE -> {
                     if (player.capabilities.isCreativeMode) {
                         playerHand.addItems(handStack);
@@ -263,6 +254,23 @@ public final class ContainerInterfaceTerminal extends AEBaseContainer implements
 
             this.updateHeld(player);
         }
+    }
+
+    private void modifyPatternInSlot(final InvTracker inv, final long id, final int slot, final ItemStack pattern,
+            final int multiplier) {
+        if (pattern == null || !(pattern.getItem() instanceof ICraftingPatternItem patternItem)) return;
+
+        final ICraftingPatternDetails details = patternItem.getPatternForItem(pattern, inv.world);
+        if (details == null || details.isCraftable()) return;
+
+        final int max = multiplier < 0 ? PatternMultiplierHelper.getMaxBitDivider(details)
+                : PatternMultiplierHelper.getMaxBitMultiplier(details);
+        if (max == 0) return;
+
+        final ItemStack modifiedPattern = pattern.copy();
+        PatternMultiplierHelper.applyModification(modifiedPattern, multiplier);
+        inv.patterns.setInventorySlotContents(slot, modifiedPattern);
+        syncIfaceSlot(inv, id, slot, modifiedPattern);
     }
 
     /**
@@ -463,6 +471,7 @@ public final class ContainerInterfaceTerminal extends AEBaseContainer implements
         private String name;
         private String suffix;
         private final IInventory patterns;
+        private final World world;
         private int rows;
         private int rowSize;
         private int numSlots;
@@ -484,6 +493,7 @@ public final class ContainerInterfaceTerminal extends AEBaseContainer implements
             this.name = machine.getRawName();
             this.suffix = machine.getNameSuffix();
             this.patterns = machine.getPatterns();
+            this.world = machine.getTileEntity().getWorldObj();
             this.rowSize = machine.rowSize();
             this.rows = machine.rows();
             this.numSlots = machine.numSlots();


### PR DESCRIPTION
## Summary

Adds Ctrl+scroll support for multiplying and dividing patterns directly within Interface pattern slots.


Fix pattern terminal CTRL+scroll dividing able to set a pattern to 0 and get stuck in value 0

Fixes #1460 

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
