### PR TITLE
fix: validate Fluix output capacity

### DIFF
--- a/src/main/java/appeng/tile/misc/TileCrystalGrowthChamber.java
+++ b/src/main/java/appeng/tile/misc/TileCrystalGrowthChamber.java
@@ -233,7 +233,9 @@ public class TileCrystalGrowthChamber extends AENetworkPowerTile
                 new WrapperInventoryRange(this.inv, 0, this.inv.getSizeInventory(), true),
                 ForgeDirection.UNKNOWN);
 
-        if (adaptor.addItems(output) != null) return false;
+        if (adaptor.simulateAdd(output) != null) return false;
+
+        adaptor.addItems(output);
 
         decrStackSize(certusPos, 1);
         decrStackSize(netherPos, 1);


### PR DESCRIPTION
## Summary
Check capacity for the complete Fluix output before updating the chamber inventory


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
