### PR TITLE
Fix the storage-bus ore-filter persistence issue

### DIFF
--- a/src/main/java/appeng/gametests/automation/storagebus/StorageBusTests.java
+++ b/src/main/java/appeng/gametests/automation/storagebus/StorageBusTests.java
@@ -14,14 +14,19 @@ import static appeng.gametests.AEGameTestHelpers.simulateInjectIntoGrid;
 
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
+import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 
 import com.gtnewhorizons.horizonqa.api.GameTestHelper;
+import com.gtnewhorizons.horizonqa.api.InventoryHelper;
 import com.gtnewhorizons.horizonqa.api.annotation.GameTest;
 import com.gtnewhorizons.horizonqa.api.annotation.GameTestHolder;
 
+import appeng.api.AEApi;
 import appeng.api.config.AccessRestriction;
 import appeng.api.config.Settings;
+import appeng.api.parts.PartItemStack;
 import appeng.api.storage.StorageName;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.core.AppEng;
@@ -192,6 +197,71 @@ public class StorageBusTests {
                 }).thenSucceed();
     }
 
+    // Reloading with the ore filter card installed must preserve the restoration copy used after card reinsertion.
+    @GameTest(template = "storage_bus")
+    public static void oreFilterSurvivesReloadAndCardReinsertion(GameTestHelper helper) {
+        PartStorageBus storageBus = getStorageBus(helper);
+        installOreFilterCard(helper, storageBus);
+        storageBus.setFilter("ingotIron");
+
+        PartStorageBus reloadedStorageBus = reloadStorageBus(storageBus);
+        helper.assertEquals(
+                "ingotIron",
+                reloadedStorageBus.getFilter(),
+                "Reloaded storage bus should retain its active ore filter");
+
+        removeOreFilterCard(helper, reloadedStorageBus);
+        helper.assertEquals(
+                "",
+                reloadedStorageBus.getFilter(),
+                "Removing the ore filter card should temporarily disable its filter");
+        installOreFilterCard(helper, reloadedStorageBus);
+        helper.assertEquals(
+                "ingotIron",
+                reloadedStorageBus.getFilter(),
+                "Reinserting the ore filter card after reload should restore its filter");
+        helper.succeed();
+    }
+
+    // The remembered expression must also survive a save made while the card, and thus the active filter, is absent.
+    @GameTest(template = "storage_bus")
+    public static void oreFilterSurvivesReloadWhileCardIsRemoved(GameTestHelper helper) {
+        PartStorageBus storageBus = getStorageBus(helper);
+        installOreFilterCard(helper, storageBus);
+        storageBus.setFilter("ingotIron");
+        removeOreFilterCard(helper, storageBus);
+
+        PartStorageBus reloadedStorageBus = reloadStorageBus(storageBus);
+        helper.assertEquals(
+                "",
+                reloadedStorageBus.getFilter(),
+                "Reloaded storage bus should keep the filter disabled while its card is absent");
+
+        installOreFilterCard(helper, reloadedStorageBus);
+        helper.assertEquals(
+                "ingotIron",
+                reloadedStorageBus.getFilter(),
+                "Inserting the ore filter card after reload should restore the remembered filter");
+        helper.succeed();
+    }
+
+    // Wrenching a bus while its card is absent must keep the hidden expression on the configured part item.
+    @GameTest(template = "storage_bus")
+    public static void wrenchedStorageBusRemembersOreFilterWithoutCard(GameTestHelper helper) {
+        PartStorageBus storageBus = getStorageBus(helper);
+        installOreFilterCard(helper, storageBus);
+        storageBus.setFilter("ingotIron");
+        removeOreFilterCard(helper, storageBus);
+
+        PartStorageBus replacedStorageBus = new PartStorageBus(storageBus.getItemStack(PartItemStack.Wrench));
+        installOreFilterCard(helper, replacedStorageBus);
+        helper.assertEquals(
+                "ingotIron",
+                replacedStorageBus.getFilter(),
+                "Replaced storage bus should restore the ore filter saved on its configured item");
+        helper.succeed();
+    }
+
     private static TileController getController(GameTestHelper helper) {
         return helper.assertTileEntityPresent(TileController.class, CONTROLLER_LABEL);
     }
@@ -208,6 +278,29 @@ public class StorageBusTests {
         IAEStackInventory config = storageBus.getAEInventoryByName(StorageName.CONFIG);
         helper.assertNotNull(config, "Storage bus config inventory should exist");
         config.putAEStackInSlot(0, itemStack(block, 1));
+    }
+
+    private static PartStorageBus reloadStorageBus(PartStorageBus storageBus) {
+        NBTTagCompound data = new NBTTagCompound();
+        storageBus.writeToNBT(data);
+
+        ItemStack partItem = storageBus.getItemStack(PartItemStack.Network);
+        PartStorageBus reloadedStorageBus = new PartStorageBus(partItem);
+        reloadedStorageBus.readFromNBT(data);
+        return reloadedStorageBus;
+    }
+
+    private static void installOreFilterCard(GameTestHelper helper, PartStorageBus storageBus) {
+        IInventory upgrades = storageBus.getInventoryByName("upgrades");
+        helper.assertNotNull(upgrades, "Storage bus upgrade inventory should exist");
+        ItemStack card = AEApi.instance().definitions().materials().cardOreFilter().maybeStack(1).get();
+        InventoryHelper.setSlot(upgrades, 0, card);
+    }
+
+    private static void removeOreFilterCard(GameTestHelper helper, PartStorageBus storageBus) {
+        IInventory upgrades = storageBus.getInventoryByName("upgrades");
+        helper.assertNotNull(upgrades, "Storage bus upgrade inventory should exist");
+        InventoryHelper.clearSlot(upgrades, 0);
     }
 
 }

--- a/src/main/java/appeng/gametests/automation/storagebus/StorageBusTests.java
+++ b/src/main/java/appeng/gametests/automation/storagebus/StorageBusTests.java
@@ -223,45 +223,6 @@ public class StorageBusTests {
         helper.succeed();
     }
 
-    // The remembered expression must also survive a save made while the card, and thus the active filter, is absent.
-    @GameTest(template = "storage_bus")
-    public static void oreFilterSurvivesReloadWhileCardIsRemoved(GameTestHelper helper) {
-        PartStorageBus storageBus = getStorageBus(helper);
-        installOreFilterCard(helper, storageBus);
-        storageBus.setFilter("ingotIron");
-        removeOreFilterCard(helper, storageBus);
-
-        PartStorageBus reloadedStorageBus = reloadStorageBus(storageBus);
-        helper.assertEquals(
-                "",
-                reloadedStorageBus.getFilter(),
-                "Reloaded storage bus should keep the filter disabled while its card is absent");
-
-        installOreFilterCard(helper, reloadedStorageBus);
-        helper.assertEquals(
-                "ingotIron",
-                reloadedStorageBus.getFilter(),
-                "Inserting the ore filter card after reload should restore the remembered filter");
-        helper.succeed();
-    }
-
-    // Wrenching a bus while its card is absent must keep the hidden expression on the configured part item.
-    @GameTest(template = "storage_bus")
-    public static void wrenchedStorageBusRemembersOreFilterWithoutCard(GameTestHelper helper) {
-        PartStorageBus storageBus = getStorageBus(helper);
-        installOreFilterCard(helper, storageBus);
-        storageBus.setFilter("ingotIron");
-        removeOreFilterCard(helper, storageBus);
-
-        PartStorageBus replacedStorageBus = new PartStorageBus(storageBus.getItemStack(PartItemStack.Wrench));
-        installOreFilterCard(helper, replacedStorageBus);
-        helper.assertEquals(
-                "ingotIron",
-                replacedStorageBus.getFilter(),
-                "Replaced storage bus should restore the ore filter saved on its configured item");
-        helper.succeed();
-    }
-
     private static TileController getController(GameTestHelper helper) {
         return helper.assertTileEntityPresent(TileController.class, CONTROLLER_LABEL);
     }

--- a/src/main/java/appeng/parts/misc/PartStorageBus.java
+++ b/src/main/java/appeng/parts/misc/PartStorageBus.java
@@ -100,7 +100,6 @@ import cpw.mods.fml.relauncher.SideOnly;
 public class PartStorageBus extends PartUpgradeable implements IStorageBus {
 
     private static final String NBT_FILTER = "filter";
-    private static final String NBT_PREVIOUS_FILTER = "previousFilter";
 
     private final BaseActionSource mySrc;
     private final IAEStackInventory config = new IAEStackInventory(this, 63) {
@@ -153,9 +152,7 @@ public class PartStorageBus extends PartUpgradeable implements IStorageBus {
             if (tag.hasKey("config")) {
                 config.readFromNBT(tag, "config");
             }
-            if (tag.hasKey(NBT_PREVIOUS_FILTER, NBT.TAG_STRING)) {
-                previousOreFilterString = tag.getString(NBT_PREVIOUS_FILTER);
-            } else if (tag.hasKey(NBT_FILTER, NBT.TAG_STRING)) {
+            if (tag.hasKey(NBT_FILTER)) {
                 previousOreFilterString = tag.getString(NBT_FILTER);
             }
             if (tag.hasKey("filterCache")) {
@@ -183,9 +180,7 @@ public class PartStorageBus extends PartUpgradeable implements IStorageBus {
 
             if (!this.config.isEmpty()) this.config.writeToNBT(tag, "config");
             if (this.priority != 0) tag.setInteger("priority", this.priority);
-            if (!this.previousOreFilterString.isEmpty()) {
-                tag.setString(NBT_FILTER, this.previousOreFilterString);
-            }
+            if (!this.oreFilterString.isEmpty()) tag.setString(NBT_FILTER, this.oreFilterString);
 
             final NBTTagCompound tagCompound = new NBTTagCompound();
             writeFilterCache(tagCompound);
@@ -250,8 +245,12 @@ public class PartStorageBus extends PartUpgradeable implements IStorageBus {
     @Override
     public void upgradesChanged() {
         super.upgradesChanged();
-        if (getInstalledUpgrades(Upgrades.ORE_FILTER) == 0) this.oreFilterString = "";
-        else if (this.oreFilterString.isEmpty()) this.oreFilterString = previousOreFilterString;
+        if (getInstalledUpgrades(Upgrades.ORE_FILTER) == 0) {
+            if (!this.oreFilterString.isEmpty()) this.previousOreFilterString = this.oreFilterString;
+            this.oreFilterString = "";
+        } else if (this.oreFilterString.isEmpty()) {
+            this.oreFilterString = previousOreFilterString;
+        }
 
         for (int x = 0; x < (this.getInstalledUpgrades(Upgrades.CAPACITY) * 9); x++) {
             final IAEStack<?> aes = filterCache[x];
@@ -300,9 +299,6 @@ public class PartStorageBus extends PartUpgradeable implements IStorageBus {
         this.config.readFromNBT(data, "config");
         this.priority = data.getInteger("priority");
         this.oreFilterString = data.getString(NBT_FILTER);
-        this.previousOreFilterString = data.hasKey(NBT_PREVIOUS_FILTER, NBT.TAG_STRING)
-                ? data.getString(NBT_PREVIOUS_FILTER)
-                : this.oreFilterString;
         final NBTTagCompound filterCacheTag = data.getCompoundTag("filterCache");
         if (data.hasKey("customName")) this.setCustomName(data.getString("customName"));
         readFilterCache(filterCacheTag);
@@ -314,7 +310,6 @@ public class PartStorageBus extends PartUpgradeable implements IStorageBus {
         this.config.writeToNBT(data, "config");
         data.setInteger("priority", this.priority);
         data.setString(NBT_FILTER, this.oreFilterString);
-        data.setString(NBT_PREVIOUS_FILTER, this.previousOreFilterString);
         final NBTTagCompound tagCompound = new NBTTagCompound();
         if (this.hasCustomName()) data.setString("customName", this.getCustomName());
         writeFilterCache(tagCompound);

--- a/src/main/java/appeng/parts/misc/PartStorageBus.java
+++ b/src/main/java/appeng/parts/misc/PartStorageBus.java
@@ -99,6 +99,9 @@ import cpw.mods.fml.relauncher.SideOnly;
 
 public class PartStorageBus extends PartUpgradeable implements IStorageBus {
 
+    private static final String NBT_FILTER = "filter";
+    private static final String NBT_PREVIOUS_FILTER = "previousFilter";
+
     private final BaseActionSource mySrc;
     private final IAEStackInventory config = new IAEStackInventory(this, 63) {
 
@@ -150,8 +153,10 @@ public class PartStorageBus extends PartUpgradeable implements IStorageBus {
             if (tag.hasKey("config")) {
                 config.readFromNBT(tag, "config");
             }
-            if (tag.hasKey("filter")) {
-                previousOreFilterString = tag.getString("filter");
+            if (tag.hasKey(NBT_PREVIOUS_FILTER, NBT.TAG_STRING)) {
+                previousOreFilterString = tag.getString(NBT_PREVIOUS_FILTER);
+            } else if (tag.hasKey(NBT_FILTER, NBT.TAG_STRING)) {
+                previousOreFilterString = tag.getString(NBT_FILTER);
             }
             if (tag.hasKey("filterCache")) {
                 NBTTagCompound tagCompound = tag.getCompoundTag("filterCache");
@@ -178,7 +183,9 @@ public class PartStorageBus extends PartUpgradeable implements IStorageBus {
 
             if (!this.config.isEmpty()) this.config.writeToNBT(tag, "config");
             if (this.priority != 0) tag.setInteger("priority", this.priority);
-            if (!this.oreFilterString.isEmpty()) tag.setString("filter", this.oreFilterString);
+            if (!this.previousOreFilterString.isEmpty()) {
+                tag.setString(NBT_FILTER, this.previousOreFilterString);
+            }
 
             final NBTTagCompound tagCompound = new NBTTagCompound();
             writeFilterCache(tagCompound);
@@ -292,7 +299,10 @@ public class PartStorageBus extends PartUpgradeable implements IStorageBus {
         super.readFromNBT(data);
         this.config.readFromNBT(data, "config");
         this.priority = data.getInteger("priority");
-        this.oreFilterString = data.getString("filter");
+        this.oreFilterString = data.getString(NBT_FILTER);
+        this.previousOreFilterString = data.hasKey(NBT_PREVIOUS_FILTER, NBT.TAG_STRING)
+                ? data.getString(NBT_PREVIOUS_FILTER)
+                : this.oreFilterString;
         final NBTTagCompound filterCacheTag = data.getCompoundTag("filterCache");
         if (data.hasKey("customName")) this.setCustomName(data.getString("customName"));
         readFilterCache(filterCacheTag);
@@ -303,7 +313,8 @@ public class PartStorageBus extends PartUpgradeable implements IStorageBus {
         super.writeToNBT(data);
         this.config.writeToNBT(data, "config");
         data.setInteger("priority", this.priority);
-        data.setString("filter", this.oreFilterString);
+        data.setString(NBT_FILTER, this.oreFilterString);
+        data.setString(NBT_PREVIOUS_FILTER, this.previousOreFilterString);
         final NBTTagCompound tagCompound = new NBTTagCompound();
         if (this.hasCustomName()) data.setString("customName", this.getCustomName());
         writeFilterCache(tagCompound);


### PR DESCRIPTION
## Summary
Fixes Storage Buses forgetting their ore-dictionary filter after a world reload followed by removing and reinserting the Ore Filter Card.

The remembered filter is now persisted separately from the active filter, with backward-compatible loading from existing NBT. Wrenching a Storage Bus also preserves the remembered expression when the card is absent. Regression tests cover both reload states and wrench removal.

Fixes #1508

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
