### PR TITLE
fix: render interface terminal tooltips above patterns

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiInterfaceTerminal.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiInterfaceTerminal.java
@@ -148,9 +148,9 @@ public class GuiInterfaceTerminal extends AEBaseGui
     private List<String> pendingSectionTooltip;
     private int pendingSectionTooltipX;
     private int pendingSectionTooltipY;
-    private List<String> pendingHideButtonTooltip;
-    private int pendingHideButtonTooltipX;
-    private int pendingHideButtonTooltipY;
+    private List<String> pendingEntryButtonTooltip;
+    private int pendingEntryButtonTooltipX;
+    private int pendingEntryButtonTooltipY;
     private final boolean neiPresent;
     protected static String searchFieldInputsText = "";
     protected static String searchFieldOutputsText = "";
@@ -167,7 +167,6 @@ public class GuiInterfaceTerminal extends AEBaseGui
     private static final float SLOT_Z = 0.5f;
     private static final float ITEM_STACK_OVERLAY_Z = 200.0f;
     private static final float SLOT_HOVER_Z = 310.0f;
-    private static final float TOOLTIP_Z = 410.0f;
     private static final float STEP_Z = 10.0f;
     private static final float MAGIC_RENDER_ITEM_Z = 50.0f;
 
@@ -423,20 +422,20 @@ public class GuiInterfaceTerminal extends AEBaseGui
             pendingSectionTooltip = null;
         }
 
-        if (pendingHideButtonTooltip != null) {
+        if (pendingEntryButtonTooltip != null) {
             GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS);
             GL11.glDisable(GL11.GL_LIGHTING);
             GL11.glDisable(GL11.GL_DEPTH_TEST);
             GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 
             drawHoveringText(
-                    pendingHideButtonTooltip,
-                    pendingHideButtonTooltipX,
-                    pendingHideButtonTooltipY,
+                    pendingEntryButtonTooltip,
+                    pendingEntryButtonTooltipX,
+                    pendingEntryButtonTooltipY,
                     fontRendererObj);
 
             GL11.glPopAttrib();
-            pendingHideButtonTooltip = null;
+            pendingEntryButtonTooltip = null;
         }
 
     }
@@ -577,7 +576,7 @@ public class GuiInterfaceTerminal extends AEBaseGui
         GL11.glEnable(GL11.GL_SCISSOR_TEST);
 
         pendingSectionTooltip = null;
-        pendingHideButtonTooltip = null;
+        pendingEntryButtonTooltip = null;
 
         /*
          * Render each section
@@ -877,20 +876,14 @@ public class GuiInterfaceTerminal extends AEBaseGui
             if (activeButton.getMouseIn()
                     && relMouseY >= Math.max(titleBottom - viewY + activeButton.yPosition, activeButton.yPosition)) {
                 if (altHeld) {
-                    pendingHideButtonTooltip = buildInterfaceTerminalVisibilityTooltip(entry.hideButton);
-                    pendingHideButtonTooltipX = relMouseX + guiLeft + VIEW_LEFT;
-                    pendingHideButtonTooltipY = relMouseY + guiTop + HEADER_HEIGHT + 1;
+                    pendingEntryButtonTooltip = buildInterfaceTerminalVisibilityTooltip(entry.hideButton);
                 } else if (shiftHeld) {
-                    pendingHideButtonTooltip = Collections.singletonList(ButtonToolTips.RenameInterface.getLocal());
-                    pendingHideButtonTooltipX = relMouseX + guiLeft + VIEW_LEFT;
-                    pendingHideButtonTooltipY = relMouseY + guiTop + HEADER_HEIGHT + 1;
+                    pendingEntryButtonTooltip = Collections.singletonList(ButtonToolTips.RenameInterface.getLocal());
                 } else {
-                    GL11.glTranslatef(0f, 0f, TOOLTIP_Z);
-                    GL11.glDisable(GL11.GL_SCISSOR_TEST);
-                    drawHoveringText(extraOptionsText, relMouseX, relMouseY);
-                    GL11.glTranslatef(0f, 0f, -TOOLTIP_Z);
-                    GL11.glEnable(GL11.GL_SCISSOR_TEST);
+                    pendingEntryButtonTooltip = extraOptionsText;
                 }
+                pendingEntryButtonTooltipX = relMouseX + guiLeft + VIEW_LEFT;
+                pendingEntryButtonTooltipY = relMouseY + guiTop + HEADER_HEIGHT + 1;
             }
         } else {
             entry.optionsButton.yPosition = -1;


### PR DESCRIPTION
## Summary

Fixes the Interface Terminal render order so the **Highlight interface** tooltip is drawn after pattern icons and amount labels.

The tooltip is now queued during viewport rendering and drawn in the final GUI pass with depth testing disabled and graphics state safely restored. This prevents pattern amounts from appearing above the tooltip and uses the same deferred rendering path as the hide and rename interface tooltips.

Fixes #1507

### Before
<img width="411" height="118" alt="imagen" src="https://github.com/user-attachments/assets/8bdc67a4-1a47-4f85-bf96-b3df27a84d5d" />

### After

<img width="373" height="90" alt="imagen" src="https://github.com/user-attachments/assets/7f982f17-2a22-4c1c-b268-685237a25b93" />


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
