### PR TITLE
Fix Interface Terminal creative pick-block

### DIFF
--- a/src/main/java/appeng/container/implementations/ContainerInterfaceTerminal.java
+++ b/src/main/java/appeng/container/implementations/ContainerInterfaceTerminal.java
@@ -243,8 +243,10 @@ public final class ContainerInterfaceTerminal extends AEBaseContainer implements
                 case MULTIPLY_PATTERN -> modifyPatternInSlot(inv, id, slot, slotStack, 1);
                 case DIVIDE_PATTERN -> modifyPatternInSlot(inv, id, slot, slotStack, -1);
                 case CREATIVE_DUPLICATE -> {
-                    if (player.capabilities.isCreativeMode) {
-                        playerHand.addItems(handStack);
+                    if (player.capabilities.isCreativeMode && handStack == null && slotStack != null) {
+                        final ItemStack duplicate = slotStack.copy();
+                        duplicate.stackSize = duplicate.getMaxStackSize();
+                        player.inventory.setItemStack(duplicate);
                     }
                 }
                 default -> {


### PR DESCRIPTION
## Summary

Fixes creative pick-block in the Interface Terminal by copying the selected encoded pattern instead of the empty cursor stack. The copied pattern now uses its maximum stack size, matching vanilla and other AE2 terminals, while the installed pattern remains unchanged.

Fixes #1505

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
