### PR TITLE
Fix repeated ore filter operands

### DIFF
--- a/src/functionalTest/java/appeng/test/util/prioitylist/OreFilteredListFunctionalTest.java
+++ b/src/functionalTest/java/appeng/test/util/prioitylist/OreFilteredListFunctionalTest.java
@@ -1,0 +1,41 @@
+package appeng.test.util.prioitylist;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.function.Predicate;
+
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.oredict.OreDictionary;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import appeng.api.storage.data.IAEItemStack;
+import appeng.util.item.AEItemStack;
+import appeng.util.prioitylist.OreFilteredList;
+
+public class OreFilteredListFunctionalTest {
+
+    private static IAEItemStack ironIngot;
+    private static IAEItemStack goldIngot;
+
+    @BeforeAll
+    public static void registerTestOres() {
+        OreDictionary.registerOre("ingotIron", new ItemStack(Items.iron_ingot));
+        OreDictionary.registerOre("ingotGold", new ItemStack(Items.gold_ingot));
+
+        ironIngot = AEItemStack.create(new ItemStack(Items.iron_ingot));
+        goldIngot = AEItemStack.create(new ItemStack(Items.gold_ingot));
+    }
+
+    @Test
+    public void repeatedConjunctiveOperandRejectsAllItems() {
+        Predicate<IAEItemStack> filter = OreFilteredList.makeFilter("!ingotIron&ingotIron");
+
+        assertNotNull(filter);
+        assertFalse(filter.test(ironIngot));
+        assertFalse(filter.test(goldIngot));
+    }
+}

--- a/src/main/java/appeng/util/prioitylist/OreFilteredList.java
+++ b/src/main/java/appeng/util/prioitylist/OreFilteredList.java
@@ -3,6 +3,7 @@ package appeng.util.prioitylist;
 import java.util.Map;
 import java.util.StringJoiner;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -21,6 +22,8 @@ import codechicken.nei.FormattedTextField.TextFormatter;
 import cpw.mods.fml.common.Optional;
 
 public class OreFilteredList implements IPartitionList<IAEItemStack> {
+
+    private static final Pattern BOOLEAN_OPERAND_PATTERN = Pattern.compile("[^&|]+");
 
     @Optional.Interface(modid = "NotEnoughItems", iface = "codechicken.nei.FormattedTextField.TextFormatter")
     public static class OreFilterTextFormatter implements TextFormatter {
@@ -123,31 +126,34 @@ public class OreFilteredList implements IPartitionList<IAEItemStack> {
             matcher = (is) -> is != null
                     && IntStream.of(OreDictionary.getOreIDs(is)).mapToObj(OreDictionary::getOreName).anyMatch(test);
         } else if (!f.isEmpty()) {
-            String[] filters = f.split("[&|]");
-            String lastFilter = null;
+            matcher = makeBooleanMatcher(f, OreFilteredList::filterToItemStackPredicate);
+        }
+        return matcher;
+    }
 
-            for (String filter : filters) {
-                filter = filter.trim();
-                if (filter.isEmpty()) continue;
-                boolean negated = filter.startsWith("!");
-                if (negated) filter = filter.substring(1);
+    static <T> Predicate<T> makeBooleanMatcher(String f, Function<String, Predicate<T>> predicateFactory) {
+        Predicate<T> matcher = null;
+        final Matcher operands = BOOLEAN_OPERAND_PATTERN.matcher(f);
+        int endLast = 0;
 
-                Predicate<ItemStack> test = filterToItemStackPredicate(filter);
+        while (operands.find()) {
+            String filter = operands.group().trim();
+            if (filter.isEmpty()) continue;
+            boolean negated = filter.startsWith("!");
+            if (negated) filter = filter.substring(1);
 
-                if (negated) test = test.negate();
+            Predicate<T> test = predicateFactory.apply(filter);
 
-                if (matcher == null) {
-                    matcher = test;
-                    lastFilter = filter;
-                } else {
-                    int endLast = f.indexOf(lastFilter) + lastFilter.length();
-                    int startThis = f.indexOf(filter);
-                    lastFilter = filter;
-                    if (startThis <= endLast) continue;
-                    boolean or = f.substring(endLast, startThis).contains("|");
-                    matcher = or ? matcher.or(test) : matcher.and(test);
-                }
+            if (negated) test = test.negate();
+
+            if (matcher == null) {
+                matcher = test;
+            } else {
+                boolean or = f.substring(endLast, operands.start()).contains("|");
+                matcher = or ? matcher.or(test) : matcher.and(test);
             }
+
+            endLast = operands.end();
         }
         return matcher;
     }

--- a/src/test/java/appeng/util/prioitylist/OreFilteredListTest.java
+++ b/src/test/java/appeng/util/prioitylist/OreFilteredListTest.java
@@ -1,0 +1,50 @@
+package appeng.util.prioitylist;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.function.Predicate;
+
+import org.junit.Test;
+
+public class OreFilteredListTest {
+
+    @Test
+    public void repeatedConjunctiveOperandIsNotDropped() {
+        assertRejectsIronAndGold("!ingotIron&ingotIron");
+    }
+
+    @Test
+    public void repeatedConjunctiveOperandPreservesWhitespaceAndNegation() {
+        assertRejectsIronAndGold(" ingotIron & !ingotIron ");
+    }
+
+    @Test
+    public void repeatedDisjunctiveOperandIsNotDropped() {
+        assertAcceptsIronAndGold("!ingotIron|ingotIron");
+    }
+
+    @Test
+    public void repeatedDisjunctiveOperandPreservesWhitespaceAndNegation() {
+        assertAcceptsIronAndGold(" ingotIron | !ingotIron ");
+    }
+
+    private static void assertRejectsIronAndGold(String expression) {
+        Predicate<String> filter = makeStringFilter(expression);
+        assertNotNull(filter);
+        assertFalse(filter.test("ingotIron"));
+        assertFalse(filter.test("ingotGold"));
+    }
+
+    private static void assertAcceptsIronAndGold(String expression) {
+        Predicate<String> filter = makeStringFilter(expression);
+        assertNotNull(filter);
+        assertTrue(filter.test("ingotIron"));
+        assertTrue(filter.test("ingotGold"));
+    }
+
+    private static Predicate<String> makeStringFilter(String expression) {
+        return OreFilteredList.makeBooleanMatcher(expression, filter -> filter::equals);
+    }
+}


### PR DESCRIPTION
## Summary

Fix ore-dictionary filter parsing so repeated operands retain their original positions instead of being silently dropped. This prevents filters from becoming broader or narrower than configured and adds regression coverage for repetition, whitespace, negation, conjunction, and disjunction.

Fixes #1506


**DISCLAIMER:** Even if this PR fixes an issues, there may be some people having (bad) configurations that works only thanks to this issue, and fixing it will make those bad configuration show up


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
