### PR TITLE
fix: reject crafted items when export target is missing

### DIFF
--- a/src/main/java/appeng/gametests/automation/importexport/ImportExportBusTests.java
+++ b/src/main/java/appeng/gametests/automation/importexport/ImportExportBusTests.java
@@ -24,9 +24,11 @@ import com.gtnewhorizons.horizonqa.api.annotation.GameTest;
 import com.gtnewhorizons.horizonqa.api.annotation.GameTestHolder;
 
 import appeng.api.AEApi;
+import appeng.api.config.Actionable;
 import appeng.api.config.RedstoneMode;
 import appeng.api.config.Settings;
 import appeng.api.storage.StorageName;
+import appeng.api.storage.data.IAEStack;
 import appeng.core.AppEng;
 import appeng.gametests.AEGameTestHelpers.ContinuousInvariant;
 import appeng.parts.automation.PartExportBus;
@@ -131,6 +133,27 @@ public class ImportExportBusTests {
                 .thenExecute("begin full-destination conservation invariant", fullDestinationPreservesNetwork::enable)
                 .thenIdle(120)
                 .thenExecute("finish full-destination observation window", fullDestinationPreservesNetwork::disable)
+                .thenSucceed();
+    }
+
+    // A crafting result can return after the export bus destination has been removed.
+    @GameTest(template = "bus_io", timeoutTicks = 120)
+    public static void missingDestinationRejectsCraftedItems(GameTestHelper helper) {
+        BusIO busIO = getBusIO(helper);
+
+        helper.startSequence()
+                .thenWaitUntil(
+                        "wait for export bus network activation",
+                        60,
+                        () -> { assertActive(helper, busIO.exportBus, "Export bus should receive a channel"); })
+                .thenExecute("remove export destination", () -> helper.destroyBlock(DESTINATION_CHEST_LABEL))
+                .thenIdle(1)
+                .thenExecute(
+                        "simulate crafted-item delivery",
+                        () -> { assertCraftedItemsRejected(helper, busIO.exportBus, Actionable.SIMULATE); })
+                .thenExecute(
+                        "attempt crafted-item delivery",
+                        () -> { assertCraftedItemsRejected(helper, busIO.exportBus, Actionable.MODULATE); })
                 .thenSucceed();
     }
 
@@ -310,6 +333,14 @@ public class ImportExportBusTests {
         helper.assertNull(
                 injectIntoGrid(busIO.controller, Blocks.cobblestone, amount),
                 "Injected cobblestone should fit into the drive cell");
+    }
+
+    private static void assertCraftedItemsRejected(GameTestHelper helper, PartExportBus exportBus, Actionable mode) {
+        IAEStack<?> items = itemStack(Blocks.cobblestone, 8);
+        IAEStack<?> remainder = exportBus.injectCraftedItems(null, items, mode);
+
+        helper.assertTrue(remainder == items, "Missing destination should reject the entire crafted stack");
+        helper.assertEquals(8L, remainder.getStackSize(), "Rejected crafted stack amount should be unchanged");
     }
 
     @Desugar

--- a/src/main/java/appeng/parts/automation/PartBaseExportBus.java
+++ b/src/main/java/appeng/parts/automation/PartBaseExportBus.java
@@ -224,7 +224,7 @@ public abstract class PartBaseExportBus<StackType extends IAEStack<StackType>> e
     @Override
     public IAEStack<?> injectCraftedItems(final ICraftingLink link, final IAEStack<?> items, final Actionable mode) {
         if (!(this.getTarget() instanceof InventoryAdaptor d)) {
-            throw new IllegalStateException("Target is not a InventoryAdaptor");
+            return items;
         }
 
         try {


### PR DESCRIPTION
## Summary

Prevents server crashes when an Export Bus’s crafting request completes after its destination inventory has been removed. The bus now rejects the crafted stack so it can return to network storage, with regression coverage for simulated and real delivery.

Fixes #1510

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
