### PR TITLE
fix: annotate AE2FC compatibility test require ae2fc to be present

### DIFF
--- a/src/main/java/appeng/gametests/compatibility/appliedenergistics2_ae2fc/IOPortFluidCompatibilityTests.java
+++ b/src/main/java/appeng/gametests/compatibility/appliedenergistics2_ae2fc/IOPortFluidCompatibilityTests.java
@@ -17,7 +17,7 @@ import appeng.core.AppEng;
 import appeng.tile.storage.TileDrive;
 import appeng.tile.storage.TileIOPort;
 
-@GameTestHolder(AppEng.MOD_ID)
+@GameTestHolder(value = AppEng.MOD_ID, requiredMods = "ae2fc")
 public class IOPortFluidCompatibilityTests {
 
     private static final String IO_PORT_LABEL = "io_port";


### PR DESCRIPTION
## Summary
Skip AE2FC tests when the mod is not present. Other mods importing AE2 did not import AE2FC with it causing this test to fail


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
