### PR TITLE
Fix Shift+LMB drag extraction in ME terminals

### DIFF
--- a/src/main/java/appeng/client/gui/AEBaseGui.java
+++ b/src/main/java/appeng/client/gui/AEBaseGui.java
@@ -544,7 +544,7 @@ public abstract class AEBaseGui extends GuiContainer implements IGuiTooltipHandl
                 }
             }
 
-            if (holding != null && this.hoveredVirtualSlot != null
+            if ((holding != null || (c == 0 && isShiftKeyDown())) && this.hoveredVirtualSlot != null
                     && !this.draggedVirtualSlots.contains(this.hoveredVirtualSlot)) {
                 this.draggedVirtualSlots.add(this.hoveredVirtualSlot);
                 this.handleDragVirtualSlot(this.hoveredVirtualSlot, c);

--- a/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
@@ -154,6 +154,7 @@ public class GuiMEMonitorable extends AEBaseGui
     public final boolean hasPinHost;
     private boolean enableShiftPause = true;
     private boolean needsViewUpdate = false;
+    private boolean shiftDragActive = false;
 
     protected VirtualMEPinSlot[] pinSlots = null;
     protected VirtualMEMonitorableSlot[] monitorableSlots = null;
@@ -684,6 +685,36 @@ public class GuiMEMonitorable extends AEBaseGui
         else return super.handleVirtualSlotClick(virtualSlot, mouseButton);
     }
 
+    @Override
+    protected void handleDragVirtualSlot(VirtualMESlot virtualSlot, final int mouseButton) {
+        // Monitorable slots are virtual slots, not Container slots. When the
+        // cursor is empty, MouseTweaks' Shift+LMB extraction drag still needs
+        // to dispatch the same action as an individual Shift+LMB click.
+        if (mouseButton == 0 && isShiftKeyDown() && this.handleMonitorableSlotClick(virtualSlot, mouseButton)) {
+            this.shiftDragActive = true;
+            this.repo.setPaused(true);
+            return;
+        }
+
+        super.handleDragVirtualSlot(virtualSlot, mouseButton);
+    }
+
+    @Override
+    protected void mouseMovedOrUp(final int mouseX, final int mouseY, final int state) {
+        super.mouseMovedOrUp(mouseX, mouseY, state);
+
+        if (state == 0 && this.getScrollBar() != null) {
+            this.getScrollBar().release();
+        }
+
+        // Keep the terminal snapshot until the actual left-button release,
+        // even if the Shift key event arrives first.
+        if (state == 0 && this.shiftDragActive) {
+            this.shiftDragActive = false;
+            this.repo.setPaused(false);
+        }
+    }
+
     private boolean handleMonitorableSlotClick(VirtualMESlot virtualSlot, final int mouseButton) {
         if (!(virtualSlot instanceof VirtualMEMonitorableSlot slot)) return false;
         IAEItemStack slotStack = slot.getAEStack() instanceof IAEItemStack ais ? ais : null;
@@ -1072,7 +1103,20 @@ public class GuiMEMonitorable extends AEBaseGui
 
     @Override
     public void drawScreen(final int mouseX, final int mouseY, final float btn) {
-        if (this.needsViewUpdate) {
+        // Keyboard events can be missed while MouseTweaks is issuing a
+        // Shift-drag. Reconcile the pause state from the actual input state
+        // before processing network-driven view updates.
+        if (enableShiftPause && isShiftKeyDown() && Mouse.isButtonDown(0)) {
+            this.repo.setPaused(true);
+        } else if (this.repo.isPaused() && !isShiftKeyDown() && !this.shiftDragActive) {
+            this.repo.setPaused(false);
+        }
+
+        // Keep the visible terminal slots stable while Shift-dragging. The
+        // repository is deliberately paused in this state, but rebuilding
+        // the view here would still remove transferred stacks and shift the
+        // remaining slots under MouseTweaks' drag cursor.
+        if (this.needsViewUpdate && !this.repo.isPaused()) {
             this.needsViewUpdate = false;
             this.repo.updateView();
             this.setScrollBar();

--- a/src/main/java/appeng/client/gui/widgets/GuiScrollbar.java
+++ b/src/main/java/appeng/client/gui/widgets/GuiScrollbar.java
@@ -157,6 +157,10 @@ public class GuiScrollbar implements IScrollSource {
         }
     }
 
+    public void release() {
+        this.isLatestClickOnScrollbar = false;
+    }
+
     public void wheel(int delta) {
         delta = Math.max(Math.min(-delta, 1), -1);
         this.currentScroll += delta * this.pageSize;


### PR DESCRIPTION
Fixes #1520

## What changed

- Handle Shift+LMB drag extraction across virtual ME terminal slots while the cursor is empty.
- Keep the terminal repository snapshot stable from the first Shift+LMB press until the left mouse button is released.
- Defer removal, insertion, and reordering of visible terminal entries until the drag ends.

## Root cause

ME terminal entries are `VirtualMEMonitorableSlot` instances rather than normal container slots. The drag path only processed virtual slots when the cursor already held an item, so empty-cursor extraction drags were not dispatched consistently. Network updates could also remove fully extracted entries during the drag and shift later entries under the cursor.

## Validation

- Built successfully with Java 26 using `./gradlew.bat build --no-daemon`.
- The same rebuilt jar was installed on both client and server in a GTNH 2.9.0-beta-2 environment.
