### PR TITLE
Fix ME terminal drag extraction and scrollbar state

### DIFF
--- a/src/main/java/appeng/client/gui/AEBaseGui.java
+++ b/src/main/java/appeng/client/gui/AEBaseGui.java
@@ -544,7 +544,7 @@ public abstract class AEBaseGui extends GuiContainer implements IGuiTooltipHandl
                 }
             }
 
-            if (holding != null && this.hoveredVirtualSlot != null
+            if ((holding != null || (c == 0 && isShiftKeyDown())) && this.hoveredVirtualSlot != null
                     && !this.draggedVirtualSlots.contains(this.hoveredVirtualSlot)) {
                 this.draggedVirtualSlots.add(this.hoveredVirtualSlot);
                 this.handleDragVirtualSlot(this.hoveredVirtualSlot, c);

--- a/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
@@ -684,6 +684,26 @@ public class GuiMEMonitorable extends AEBaseGui
         else return super.handleVirtualSlotClick(virtualSlot, mouseButton);
     }
 
+    @Override
+    protected void mouseMovedOrUp(final int mouseX, final int mouseY, final int state) {
+        super.mouseMovedOrUp(mouseX, mouseY, state);
+        if (state == 0 && this.getScrollBar() != null) {
+            this.getScrollBar().release();
+        }
+    }
+
+    @Override
+    protected void handleDragVirtualSlot(VirtualMESlot virtualSlot, final int mouseButton) {
+        // Monitorable slots are virtual slots, not Container slots. When the
+        // cursor is empty, MouseTweaks' Shift+LMB extraction drag still needs
+        // to dispatch the same action as an individual Shift+LMB click.
+        if (mouseButton == 0 && isShiftKeyDown() && this.handleMonitorableSlotClick(virtualSlot, mouseButton)) {
+            return;
+        }
+
+        super.handleDragVirtualSlot(virtualSlot, mouseButton);
+    }
+
     private boolean handleMonitorableSlotClick(VirtualMESlot virtualSlot, final int mouseButton) {
         if (!(virtualSlot instanceof VirtualMEMonitorableSlot slot)) return false;
         IAEItemStack slotStack = slot.getAEStack() instanceof IAEItemStack ais ? ais : null;

--- a/src/main/java/appeng/client/gui/widgets/GuiScrollbar.java
+++ b/src/main/java/appeng/client/gui/widgets/GuiScrollbar.java
@@ -157,6 +157,11 @@ public class GuiScrollbar implements IScrollSource {
         }
     }
 
+    /** Clears the drag target after the mouse button is released. */
+    public void release() {
+        this.isLatestClickOnScrollbar = false;
+    }
+
     public void wheel(int delta) {
         delta = Math.max(Math.min(-delta, 1), -1);
         this.currentScroll += delta * this.pageSize;


### PR DESCRIPTION
## Summary

Fixes Shift+LMB extraction from ME terminals when the cursor is empty. ME terminal entries are virtual slots, so the drag path now dispatches the same extraction action for each virtual entry crossed by the cursor.

Also clears the ME terminal scrollbar drag state when the mouse button is released, preventing later mouse movement from continuing to scroll the terminal.

Fixes #1521

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [ ] I have reviewed this PR for compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge

Manual testing was performed on both client and server in GTNH 2.9.0-beta-2. The build passed with Java 26 using `./gradlew.bat build --no-daemon`, and `git diff --check` passed.