### PR TITLE
Fix recipes created by late ore registrations

### DIFF
--- a/src/main/java/appeng/core/AppEng.java
+++ b/src/main/java/appeng/core/AppEng.java
@@ -35,7 +35,6 @@ import appeng.hooks.TickHandler;
 import appeng.integration.IntegrationRegistry;
 import appeng.recipes.CustomRecipeConfig;
 import appeng.recipes.CustomRecipeForgeConfiguration;
-import appeng.recipes.ores.OreDictionaryHandler;
 import appeng.server.AECommand;
 import appeng.services.export.ExportConfig;
 import appeng.services.export.ExportProcess;
@@ -53,7 +52,6 @@ import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.Mod.EventHandler;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLInterModComms;
-import cpw.mods.fml.common.event.FMLLoadCompleteEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.event.FMLServerAboutToStartEvent;
@@ -222,11 +220,6 @@ public final class AppEng {
         AELog.info("Post Initialization ( ended after " + start.elapsed(TimeUnit.MILLISECONDS) + "ms )");
 
         if (Platform.isPosteaLoaded) new ae2stuffConvertor().run();
-    }
-
-    @EventHandler
-    private void loadComplete(final FMLLoadCompleteEvent event) {
-        OreDictionaryHandler.INSTANCE.onLoadComplete();
     }
 
     @Mod.EventHandler

--- a/src/main/java/appeng/core/AppEng.java
+++ b/src/main/java/appeng/core/AppEng.java
@@ -35,6 +35,7 @@ import appeng.hooks.TickHandler;
 import appeng.integration.IntegrationRegistry;
 import appeng.recipes.CustomRecipeConfig;
 import appeng.recipes.CustomRecipeForgeConfiguration;
+import appeng.recipes.ores.OreDictionaryHandler;
 import appeng.server.AECommand;
 import appeng.services.export.ExportConfig;
 import appeng.services.export.ExportProcess;
@@ -52,6 +53,7 @@ import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.Mod.EventHandler;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLInterModComms;
+import cpw.mods.fml.common.event.FMLLoadCompleteEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.event.FMLServerAboutToStartEvent;
@@ -220,6 +222,11 @@ public final class AppEng {
         AELog.info("Post Initialization ( ended after " + start.elapsed(TimeUnit.MILLISECONDS) + "ms )");
 
         if (Platform.isPosteaLoaded) new ae2stuffConvertor().run();
+    }
+
+    @EventHandler
+    private void loadComplete(final FMLLoadCompleteEvent event) {
+        OreDictionaryHandler.INSTANCE.onLoadComplete();
     }
 
     @Mod.EventHandler

--- a/src/main/java/appeng/hooks/TickHandler.java
+++ b/src/main/java/appeng/hooks/TickHandler.java
@@ -41,9 +41,11 @@ import appeng.core.worlddata.WorldData;
 import appeng.entity.EntityFloatingItem;
 import appeng.me.Grid;
 import appeng.me.NetworkList;
+import appeng.recipes.ores.OreDictionaryHandler;
 import appeng.tile.AEBaseTile;
 import appeng.util.IWorldCallable;
 import appeng.util.Platform;
+import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.TickEvent;
 import cpw.mods.fml.common.gameevent.TickEvent.Phase;
@@ -163,6 +165,11 @@ public class TickHandler {
 
     @SubscribeEvent
     public void onTick(final TickEvent ev) {
+
+        if ((ev.type == Type.CLIENT || ev.type == Type.SERVER) && ev.phase == Phase.START
+                && ev.side == FMLCommonHandler.instance().getSide()) {
+            OreDictionaryHandler.INSTANCE.onTick();
+        }
 
         if (ev.type == Type.CLIENT && ev.phase == Phase.START) {
             this.tickColors(this.cliPlayerColors);

--- a/src/main/java/appeng/recipes/ores/OreDictionaryHandler.java
+++ b/src/main/java/appeng/recipes/ores/OreDictionaryHandler.java
@@ -28,6 +28,7 @@ public class OreDictionaryHandler {
     private final List<IOreListener> oreListeners = new ArrayList<>();
 
     private boolean enableRebaking = false;
+    private boolean rebakePending = false;
 
     @SubscribeEvent
     public void onOreDictionaryRegister(final OreDictionary.OreRegisterEvent event) {
@@ -42,7 +43,7 @@ public class OreDictionaryHandler {
         }
 
         if (this.enableRebaking) {
-            this.bakeRecipes();
+            this.rebakePending = true;
         }
     }
 
@@ -67,6 +68,17 @@ public class OreDictionaryHandler {
                     AELog.debug(e);
                 }
             }
+        }
+    }
+
+    public void onLoadComplete() {
+        this.rebakePending = true;
+    }
+
+    public void onTick() {
+        if (this.rebakePending) {
+            this.rebakePending = false;
+            this.bakeRecipes();
         }
     }
 

--- a/src/main/java/appeng/recipes/ores/OreDictionaryHandler.java
+++ b/src/main/java/appeng/recipes/ores/OreDictionaryHandler.java
@@ -71,10 +71,6 @@ public class OreDictionaryHandler {
         }
     }
 
-    public void onLoadComplete() {
-        this.rebakePending = true;
-    }
-
     public void onTick() {
         if (this.rebakePending) {
             this.rebakePending = false;

--- a/src/test/java/appeng/recipes/ores/OreDictionaryHandlerTest.java
+++ b/src/test/java/appeng/recipes/ores/OreDictionaryHandlerTest.java
@@ -2,16 +2,25 @@ package appeng.recipes.ores;
 
 import static org.junit.Assert.assertEquals;
 
+import java.lang.reflect.Field;
+
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.oredict.OreDictionary;
+
 import org.junit.Test;
 
 public class OreDictionaryHandlerTest {
 
     @Test
-    public void loadCompleteDefersAndCoalescesTheFinalBake() {
+    public void lateOreRegistrationsAreDeferredAndCoalesced() throws ReflectiveOperationException {
         final CountingHandler handler = new CountingHandler();
+        final Field enableRebaking = OreDictionaryHandler.class.getDeclaredField("enableRebaking");
 
-        handler.onLoadComplete();
-        handler.onLoadComplete();
+        enableRebaking.setAccessible(true);
+        enableRebaking.setBoolean(handler, true);
+        handler.onOreDictionaryRegister(new OreDictionary.OreRegisterEvent("oreTest", new ItemStack(new Item())));
+        handler.onOreDictionaryRegister(new OreDictionary.OreRegisterEvent("oreTest", new ItemStack(new Item())));
         assertEquals(0, handler.bakes);
 
         handler.onTick();

--- a/src/test/java/appeng/recipes/ores/OreDictionaryHandlerTest.java
+++ b/src/test/java/appeng/recipes/ores/OreDictionaryHandlerTest.java
@@ -1,0 +1,33 @@
+package appeng.recipes.ores;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class OreDictionaryHandlerTest {
+
+    @Test
+    public void loadCompleteDefersAndCoalescesTheFinalBake() {
+        final CountingHandler handler = new CountingHandler();
+
+        handler.onLoadComplete();
+        handler.onLoadComplete();
+        assertEquals(0, handler.bakes);
+
+        handler.onTick();
+        assertEquals(1, handler.bakes);
+
+        handler.onTick();
+        assertEquals(1, handler.bakes);
+    }
+
+    private static final class CountingHandler extends OreDictionaryHandler {
+
+        private int bakes;
+
+        @Override
+        public void bakeRecipes() {
+            this.bakes++;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Defers recipe rebaking caused by late ore dictionary registrations until the next physical client/server tick.

DreamCraft registers ore dictionary entries after Forge’s load-complete phase, so rebaking during load-complete would still be too early. Processing the pending rebake on the next tick ensures the late registration and all its listeners have finished. Multiple registrations are coalesced into a single rebake.

Includes regression coverage for deferred and coalesced rebaking.

Saves 350ms on modpack launch

Fixes #1529

## Checklist

- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge