### PR TITLE
Fix terminal space-drag transfers

### DIFF
--- a/src/main/java/appeng/client/gui/AEBaseGui.java
+++ b/src/main/java/appeng/client/gui/AEBaseGui.java
@@ -410,8 +410,10 @@ public abstract class AEBaseGui extends GuiContainer implements IGuiTooltipHandl
         final VirtualMESlot virtualSlot = getVirtualMESlotUnderMouse();
         if (virtualSlot != null && this.handleVirtualSlotClick(
                 virtualSlot,
-                btn == this.mc.gameSettings.keyBindPickBlock.getKeyCode() + 100 ? keyBindPickBlockAction : btn))
+                btn == this.mc.gameSettings.keyBindPickBlock.getKeyCode() + 100 ? keyBindPickBlockAction : btn)) {
+            this.draggedVirtualSlots.add(virtualSlot);
             return;
+        }
 
         if (btn == 1) {
             for (final GuiButton guibutton : this.buttonList) {
@@ -525,6 +527,10 @@ public abstract class AEBaseGui extends GuiContainer implements IGuiTooltipHandl
         }
     }
 
+    protected boolean canDragVirtualSlot(VirtualMESlot slot, @Nullable ItemStack holding) {
+        return holding != null;
+    }
+
     private void handlePhantomSlotInteraction(VirtualMEPhantomSlot slot, int mouseButton) {
         slot.handleMouseClicked(this.getStackFromHand(), isCtrlKeyDown(), mouseButton);
     }
@@ -544,7 +550,7 @@ public abstract class AEBaseGui extends GuiContainer implements IGuiTooltipHandl
                 }
             }
 
-            if (holding != null && this.hoveredVirtualSlot != null
+            if (this.hoveredVirtualSlot != null && this.canDragVirtualSlot(this.hoveredVirtualSlot, holding)
                     && !this.draggedVirtualSlots.contains(this.hoveredVirtualSlot)) {
                 this.draggedVirtualSlots.add(this.hoveredVirtualSlot);
                 this.handleDragVirtualSlot(this.hoveredVirtualSlot, c);

--- a/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java
@@ -684,6 +684,19 @@ public class GuiMEMonitorable extends AEBaseGui
         else return super.handleVirtualSlotClick(virtualSlot, mouseButton);
     }
 
+    @Override
+    protected boolean canDragVirtualSlot(VirtualMESlot slot, @Nullable ItemStack holding) {
+        return (Keyboard.isKeyDown(Keyboard.KEY_SPACE) && slot instanceof VirtualMEMonitorableSlot)
+                || super.canDragVirtualSlot(slot, holding);
+    }
+
+    @Override
+    protected void handleDragVirtualSlot(VirtualMESlot slot, int mouseButton) {
+        if (!Keyboard.isKeyDown(Keyboard.KEY_SPACE) || !this.handleMonitorableSlotClick(slot, mouseButton)) {
+            super.handleDragVirtualSlot(slot, mouseButton);
+        }
+    }
+
     private boolean handleMonitorableSlotClick(VirtualMESlot virtualSlot, final int mouseButton) {
         if (!(virtualSlot instanceof VirtualMEMonitorableSlot slot)) return false;
         IAEItemStack slotStack = slot.getAEStack() instanceof IAEItemStack ais ? ais : null;


### PR DESCRIPTION
## Summary

Restores space+drag transfers in AE2 terminals after terminal entries were migrated to virtual slots.

Dragging across multiple item types while holding Space now performs the existing `MOVE_REGION` action once per crossed slot, matching the behavior from previous versions without affecting phantom-slot dragging.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25678

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
