### PR TITLE
Fix negative idle crafting processor count

### DIFF
--- a/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
+++ b/src/main/java/appeng/me/cluster/implementations/CraftingCPUCluster.java
@@ -801,6 +801,8 @@ public class CraftingCPUCluster implements IAECluster, ICraftingCPU {
 
         int executedTasks = 0;
         while (craftingTaskIterator.hasNext()) {
+            if (this.remainingOperations <= 0) return;
+
             final Entry<ICraftingPatternDetails, TaskProgress> craftingEntry = craftingTaskIterator.next();
 
             if (craftingEntry.getValue().value <= 0) {


### PR DESCRIPTION
## Summary

Fixes idle crafting processor counts becoming negative during large crafting requests.

The crafting CPU scheduler now stops processing additional tasks once its operation budget is exhausted, preventing it from dispatching more operations than its available processors allow.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25983

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
