### PR TITLE
Add IStorageBus#getPartName for storage bus GUI titles (#26041)

### DIFF
--- a/src/main/java/appeng/api/parts/IStorageBus.java
+++ b/src/main/java/appeng/api/parts/IStorageBus.java
@@ -16,6 +16,8 @@ import appeng.tile.inventory.IIAEStackInventory;
 import appeng.transformer.annotations.Integration.Interface;
 import appeng.util.IConfigManagerHost;
 import buildcraft.api.transport.IPipeConnection;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 
 @Interface(iname = IntegrationType.BuildCraftTransport, iface = "buildcraft.api.transport.IPipeConnection")
 public interface IStorageBus
@@ -33,4 +35,7 @@ public interface IStorageBus
     default IItemList getItemList() {
         return getStackType().createList();
     }
+
+    @SideOnly(Side.CLIENT)
+    String getPartName();
 }

--- a/src/main/java/appeng/client/gui/implementations/GuiStorageBus.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiStorageBus.java
@@ -51,10 +51,12 @@ public class GuiStorageBus extends GuiUpgradeable {
     private GuiImgButton extractionMode;
     private VirtualMEPhantomSlot[] configSlots;
     private final ContainerStorageBus containerStorageBus;
+    private final IStorageBus storageBus;
 
     public GuiStorageBus(final InventoryPlayer inventoryPlayer, final IStorageBus te) {
         super(new ContainerStorageBus(inventoryPlayer, te));
         this.containerStorageBus = (ContainerStorageBus) inventorySlots;
+        this.storageBus = te;
         this.ySize = 251;
     }
 
@@ -115,7 +117,7 @@ public class GuiStorageBus extends GuiUpgradeable {
     @Override
     public void drawFG(final int offsetX, final int offsetY, final int mouseX, final int mouseY) {
         this.fontRendererObj.drawString(
-                this.getGuiDisplayName(GuiText.StorageBus.getLocal()),
+                this.getGuiDisplayName(this.storageBus.getPartName()),
                 8,
                 6,
                 ColorUtils.guiTextColorGray.getColor());

--- a/src/main/java/appeng/parts/misc/PartStorageBus.java
+++ b/src/main/java/appeng/parts/misc/PartStorageBus.java
@@ -515,6 +515,12 @@ public class PartStorageBus extends PartUpgradeable implements IStorageBus {
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
+    public String getPartName() {
+        return this.getItemStack().getDisplayName();
+    }
+
+    @Override
     public TickingRequest getTickingRequest(final IGridNode node) {
         return new TickingRequest(
                 TickRates.StorageBus.getMin(),


### PR DESCRIPTION
## Summary
- Add `getPartName()` to `IStorageBus`, mirroring import/export bus `getBusName()`
- `GuiStorageBus` uses the part name instead of hardcoded `GuiText.StorageBus`
- Fixes GTNewHorizons/GT-New-Horizons-Modpack#26041 for ME Fluid Storage Bus when used with AE2FC

Replaces the approach in GTNewHorizons/AE2FluidCraft-Rework#454 per review feedback from @lc-1337.

## Test plan
- [ ] Open an ME Storage Bus GUI and confirm the title still looks correct
- [ ] Open an ME Fluid Storage Bus GUI and confirm the title says ME Fluid Storage Bus
- [ ] Open Priority from a Fluid Storage Bus and return; GUI still works

Made with [Cursor](https://cursor.com)