### PR TITLE
Remove deprecated gametest methods usages

### DIFF
--- a/src/main/java/appeng/gametests/AEGameTestHelpers.java
+++ b/src/main/java/appeng/gametests/AEGameTestHelpers.java
@@ -57,14 +57,14 @@ public final class AEGameTestHelpers {
     }
 
     public static IPart part(GameTestHelper helper, String label, ForgeDirection side) {
-        TileCableBus cableBus = tile(helper, TileCableBus.class, label);
+        TileCableBus cableBus = helper.assertTileEntityPresent(TileCableBus.class, label);
         IPart part = cableBus.getPart(side);
         helper.assertNotNull(part, "Placed part should be readable from its host");
         return part;
     }
 
     public static <T extends IPart> T part(GameTestHelper helper, String label, Class<T> type) {
-        TileCableBus cableBus = tile(helper, TileCableBus.class, label);
+        TileCableBus cableBus = helper.assertTileEntityPresent(TileCableBus.class, label);
         for (ForgeDirection side : ForgeDirection.VALID_DIRECTIONS) {
             IPart candidate = cableBus.getPart(side);
             if (type.isInstance(candidate)) {
@@ -217,7 +217,7 @@ public final class AEGameTestHelpers {
 
     public static void fillChest(TileEntityChest chest, Block block) {
         for (int slot = 0; slot < chest.getSizeInventory(); slot++) {
-            setChestSlot(chest, slot, block, 64);
+            InventoryHelper.setSlot(chest, slot, new ItemStack(block, 64));
         }
     }
 
@@ -225,7 +225,7 @@ public final class AEGameTestHelpers {
             long expectedAmount) {
         helper.assertEquals(
                 expectedAmount,
-                chestStoredAmount(chest, block),
+                InventoryHelper.count(chest, new ItemStack(block)),
                 "Chest storage for " + describe(block) + " should match; chest=" + describe(chest));
     }
 

--- a/src/main/java/appeng/gametests/automation/importexport/ImportExportBusTests.java
+++ b/src/main/java/appeng/gametests/automation/importexport/ImportExportBusTests.java
@@ -4,7 +4,6 @@ import static appeng.gametests.AEGameTestHelpers.assertActive;
 import static appeng.gametests.AEGameTestHelpers.assertNetworkStoredAmount;
 import static appeng.gametests.AEGameTestHelpers.assertStoredAmount;
 import static appeng.gametests.AEGameTestHelpers.cell1k;
-import static appeng.gametests.AEGameTestHelpers.continuousInvariant;
 import static appeng.gametests.AEGameTestHelpers.injectIntoGrid;
 import static appeng.gametests.AEGameTestHelpers.insertItems;
 import static appeng.gametests.AEGameTestHelpers.itemStack;
@@ -30,7 +29,6 @@ import appeng.api.config.Settings;
 import appeng.api.storage.StorageName;
 import appeng.api.storage.data.IAEStack;
 import appeng.core.AppEng;
-import appeng.gametests.AEGameTestHelpers.ContinuousInvariant;
 import appeng.parts.automation.PartExportBus;
 import appeng.parts.automation.PartImportBus;
 import appeng.parts.automation.PartSharedItemBus;
@@ -61,14 +59,12 @@ public class ImportExportBusTests {
         helper.setSlot(SOURCE_CHEST_LABEL, 1, new ItemStack(Blocks.dirt, 32));
         configureFilter(helper, busIO.importBus, Blocks.cobblestone);
         configureFilter(helper, busIO.exportBus, Blocks.dirt);
-        ContinuousInvariant filterRejectsDirt = continuousInvariant(
-                helper,
-                "bus filters must retain source dirt and keep imported cobblestone out of the destination",
-                () -> {
-                    assertNetworkStoredAmount(helper, busIO.controller, Blocks.dirt, 0);
-                    helper.assertInventoryCount(SOURCE_CHEST_LABEL, new ItemStack(Blocks.dirt), 32);
-                    helper.assertInventoryCount(DESTINATION_CHEST_LABEL, new ItemStack(Blocks.cobblestone), 0);
-                });
+        TickCallbackHandle filterRejectsDirt = helper.onEachTick(() -> {
+            assertNetworkStoredAmount(helper, busIO.controller, Blocks.dirt, 0);
+            helper.assertInventoryCount(SOURCE_CHEST_LABEL, new ItemStack(Blocks.dirt), 32);
+            helper.assertInventoryCount(DESTINATION_CHEST_LABEL, new ItemStack(Blocks.cobblestone), 0);
+        });
+        filterRejectsDirt.disable();
 
         helper.startSequence()
                 .thenWaitUntil("wait for bus network activation", 60, () -> assertBusIOActive(helper, busIO))
@@ -89,13 +85,11 @@ public class ImportExportBusTests {
         helper.setSlot(DRIVE_LABEL, 0, driveCell);
         configureFilter(helper, busIO.importBus, Blocks.dirt);
         configureFilter(helper, busIO.exportBus, Blocks.cobblestone);
-        ContinuousInvariant filterRetainsDirt = continuousInvariant(
-                helper,
-                "export bus filter must retain dirt in ME storage",
-                () -> {
-                    helper.assertInventoryCount(DESTINATION_CHEST_LABEL, new ItemStack(Blocks.dirt), 0);
-                    assertStoredAmount(helper, busIO.drive.getStackInSlot(0), Blocks.dirt, 1);
-                });
+        TickCallbackHandle filterRetainsDirt = helper.onEachTick(() -> {
+            helper.assertInventoryCount(DESTINATION_CHEST_LABEL, new ItemStack(Blocks.dirt), 0);
+            assertStoredAmount(helper, busIO.drive.getStackInSlot(0), Blocks.dirt, 1);
+        });
+        filterRetainsDirt.disable();
 
         helper.startSequence()
                 .thenWaitUntil("wait for bus network activation", 60, () -> assertBusIOActive(helper, busIO))
@@ -116,17 +110,12 @@ public class ImportExportBusTests {
         long destinationCapacity = fillInventory(helper, DESTINATION_CHEST_LABEL, Blocks.dirt);
         configureFilter(helper, busIO.importBus, Blocks.dirt);
         configureFilter(helper, busIO.exportBus, Blocks.cobblestone);
-        ContinuousInvariant fullDestinationPreservesNetwork = continuousInvariant(
-                helper,
-                "full destination must not void or export network cobblestone",
-                () -> {
-                    assertNetworkStoredAmount(helper, busIO.controller, Blocks.cobblestone, 32);
-                    helper.assertInventoryCount(DESTINATION_CHEST_LABEL, new ItemStack(Blocks.cobblestone), 0);
-                    helper.assertInventoryCount(
-                            DESTINATION_CHEST_LABEL,
-                            new ItemStack(Blocks.dirt),
-                            destinationCapacity);
-                });
+        TickCallbackHandle fullDestinationPreservesNetwork = helper.onEachTick(() -> {
+            assertNetworkStoredAmount(helper, busIO.controller, Blocks.cobblestone, 32);
+            helper.assertInventoryCount(DESTINATION_CHEST_LABEL, new ItemStack(Blocks.cobblestone), 0);
+            helper.assertInventoryCount(DESTINATION_CHEST_LABEL, new ItemStack(Blocks.dirt), destinationCapacity);
+        });
+        fullDestinationPreservesNetwork.disable();
 
         helper.startSequence()
                 .thenWaitUntil("wait for bus network activation", 60, () -> assertBusIOActive(helper, busIO))
@@ -195,16 +184,11 @@ public class ImportExportBusTests {
         configureRedstone(busIO.exportBus, RedstoneMode.HIGH_SIGNAL);
         setRedstoneInput(helper, 0);
         long[] gatedAmounts = { 0, 0 };
-        ContinuousInvariant gatedBusDoesNotMoveItems = continuousInvariant(
-                helper,
-                "redstone-gated export bus must not move cobblestone",
-                () -> {
-                    assertStoredAmount(helper, busIO.drive.getStackInSlot(0), Blocks.cobblestone, gatedAmounts[0]);
-                    helper.assertInventoryCount(
-                            DESTINATION_CHEST_LABEL,
-                            new ItemStack(Blocks.cobblestone),
-                            gatedAmounts[1]);
-                });
+        TickCallbackHandle gatedBusDoesNotMoveItems = helper.onEachTick(() -> {
+            assertStoredAmount(helper, busIO.drive.getStackInSlot(0), Blocks.cobblestone, gatedAmounts[0]);
+            helper.assertInventoryCount(DESTINATION_CHEST_LABEL, new ItemStack(Blocks.cobblestone), gatedAmounts[1]);
+        });
+        gatedBusDoesNotMoveItems.disable();
 
         helper.startSequence()
                 .thenWaitUntil("wait for bus network activation", 60, () -> assertBusIOActive(helper, busIO))

--- a/src/main/java/appeng/gametests/crafting/CraftingExecutionTests.java
+++ b/src/main/java/appeng/gametests/crafting/CraftingExecutionTests.java
@@ -4,7 +4,6 @@ import static appeng.gametests.AEGameTestHelpers.assertActive;
 import static appeng.gametests.AEGameTestHelpers.assertNetworkStoredAmount;
 import static appeng.gametests.AEGameTestHelpers.assertStoredAmount;
 import static appeng.gametests.AEGameTestHelpers.cell1k;
-import static appeng.gametests.AEGameTestHelpers.continuousInvariant;
 import static appeng.gametests.AEGameTestHelpers.injectIntoGrid;
 import static appeng.gametests.AEGameTestHelpers.insertItems;
 import static appeng.gametests.AEGameTestHelpers.itemStack;
@@ -35,6 +34,7 @@ import com.github.bsideup.jabel.Desugar;
 import com.gtnewhorizons.horizonqa.api.GameTestHelper;
 import com.gtnewhorizons.horizonqa.api.InventoryHelper;
 import com.gtnewhorizons.horizonqa.api.TestPos;
+import com.gtnewhorizons.horizonqa.api.TickCallbackHandle;
 import com.gtnewhorizons.horizonqa.api.annotation.GameTest;
 import com.gtnewhorizons.horizonqa.api.annotation.GameTestHolder;
 
@@ -50,7 +50,6 @@ import appeng.api.storage.ICellWorkbenchItem;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IAEStack;
 import appeng.core.AppEng;
-import appeng.gametests.AEGameTestHelpers.ContinuousInvariant;
 import appeng.me.GridAccessException;
 import appeng.tile.crafting.TileCraftingStorageTile;
 import appeng.tile.crafting.TileCraftingTile;
@@ -286,21 +285,19 @@ public class CraftingExecutionTests {
         ItemStack driveCell = cell1k();
         insertItems(helper, driveCell, Blocks.cobblestone, 1);
         helper.setSlot(DRIVE_LABEL, 0, driveCell);
-        ContinuousInvariant cpuBreakDoesNotDuplicateOrProduceOutput = continuousInvariant(
-                helper,
-                "CPU break must not duplicate ingredients or produce processing output",
-                () -> {
-                    cpuBreakDrops.addAll(craftingCpuDrops(helper));
-                    long accountedCobblestone = networkStoredAmount(network.controller, Blocks.cobblestone)
-                            + droppedItemAmount(cpuBreakDrops, Blocks.cobblestone);
-                    long accountedStone = networkStoredAmount(network.controller, Blocks.stone)
-                            + droppedItemAmount(cpuBreakDrops, Blocks.stone);
-                    helper.assertTrue(
-                            accountedCobblestone <= 1,
-                            "At most one ingredient may exist while CPU break cancellation settles; observed="
-                                    + accountedCobblestone);
-                    helper.assertEquals(0L, accountedStone, "CPU break must never produce the requested output");
-                });
+        TickCallbackHandle cpuBreakDoesNotDuplicateOrProduceOutput = helper.onEachTick(() -> {
+            cpuBreakDrops.addAll(craftingCpuDrops(helper));
+            long accountedCobblestone = networkStoredAmount(network.controller, Blocks.cobblestone)
+                    + droppedItemAmount(cpuBreakDrops, Blocks.cobblestone);
+            long accountedStone = networkStoredAmount(network.controller, Blocks.stone)
+                    + droppedItemAmount(cpuBreakDrops, Blocks.stone);
+            helper.assertTrue(
+                    accountedCobblestone <= 1,
+                    "At most one ingredient may exist while CPU break cancellation settles; observed="
+                            + accountedCobblestone);
+            helper.assertEquals(0L, accountedStone, "CPU break must never produce the requested output");
+        });
+        cpuBreakDoesNotDuplicateOrProduceOutput.disable();
 
         helper.startSequence()
                 .thenWaitUntil(

--- a/src/main/java/appeng/gametests/interfaces/InterfaceTests.java
+++ b/src/main/java/appeng/gametests/interfaces/InterfaceTests.java
@@ -4,7 +4,6 @@ import static appeng.gametests.AEGameTestHelpers.assertActive;
 import static appeng.gametests.AEGameTestHelpers.assertNetworkStoredAmount;
 import static appeng.gametests.AEGameTestHelpers.assertStoredAmount;
 import static appeng.gametests.AEGameTestHelpers.cell1k;
-import static appeng.gametests.AEGameTestHelpers.continuousInvariant;
 import static appeng.gametests.AEGameTestHelpers.insertItems;
 import static appeng.gametests.AEGameTestHelpers.itemMonitor;
 import static appeng.gametests.AEGameTestHelpers.itemStack;
@@ -21,6 +20,7 @@ import com.github.bsideup.jabel.Desugar;
 import com.google.common.collect.ImmutableCollection;
 import com.gtnewhorizons.horizonqa.api.GameTestHelper;
 import com.gtnewhorizons.horizonqa.api.InventoryHelper;
+import com.gtnewhorizons.horizonqa.api.TickCallbackHandle;
 import com.gtnewhorizons.horizonqa.api.annotation.GameTest;
 import com.gtnewhorizons.horizonqa.api.annotation.GameTestHolder;
 
@@ -34,7 +34,6 @@ import appeng.api.networking.security.BaseActionSource;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.container.ContainerNull;
 import appeng.core.AppEng;
-import appeng.gametests.AEGameTestHelpers.ContinuousInvariant;
 import appeng.helpers.IInterfaceHost;
 import appeng.me.GridAccessException;
 import appeng.parts.misc.PartInterface;
@@ -233,13 +232,11 @@ public class InterfaceTests {
         ItemStack driveCell = cell1k();
         insertItems(helper, driveCell, Blocks.cobblestone, 64);
         helper.setSlot(DRIVE_LABEL, 0, driveCell);
-        ContinuousInvariant configuredStockDoesNotDrainNetwork = continuousInvariant(
-                helper,
-                "already satisfied interface stock must not drain ME storage",
-                () -> {
-                    assertInterfaceStoredAmount(helper, network.blockInterface, Blocks.cobblestone, STOCK_AMOUNT);
-                    assertStoredAmount(helper, network.drive.getStackInSlot(0), Blocks.cobblestone, 64);
-                });
+        TickCallbackHandle configuredStockDoesNotDrainNetwork = helper.onEachTick(() -> {
+            assertInterfaceStoredAmount(helper, network.blockInterface, Blocks.cobblestone, STOCK_AMOUNT);
+            assertStoredAmount(helper, network.drive.getStackInSlot(0), Blocks.cobblestone, 64);
+        });
+        configuredStockDoesNotDrainNetwork.disable();
 
         helper.startSequence()
                 .thenWaitUntil(

--- a/src/main/java/appeng/gametests/network/NetworkCoreTests.java
+++ b/src/main/java/appeng/gametests/network/NetworkCoreTests.java
@@ -5,7 +5,6 @@ import static appeng.gametests.AEGameTestHelpers.assertInactive;
 import static appeng.gametests.AEGameTestHelpers.assertNetworkStoredAmount;
 import static appeng.gametests.AEGameTestHelpers.assertStoredAmount;
 import static appeng.gametests.AEGameTestHelpers.cell1k;
-import static appeng.gametests.AEGameTestHelpers.continuousInvariant;
 import static appeng.gametests.AEGameTestHelpers.insertItems;
 
 import java.util.ArrayList;
@@ -19,6 +18,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import com.gtnewhorizons.horizonqa.api.GameTestHelper;
 import com.gtnewhorizons.horizonqa.api.TestPos;
+import com.gtnewhorizons.horizonqa.api.TickCallbackHandle;
 import com.gtnewhorizons.horizonqa.api.annotation.GameTest;
 import com.gtnewhorizons.horizonqa.api.annotation.GameTestHolder;
 
@@ -28,7 +28,6 @@ import appeng.api.parts.IPart;
 import appeng.api.parts.IPartHost;
 import appeng.api.util.AEColor;
 import appeng.core.AppEng;
-import appeng.gametests.AEGameTestHelpers.ContinuousInvariant;
 import appeng.tile.networking.TileCableBus;
 import appeng.tile.networking.TileController;
 import appeng.tile.storage.TileDrive;
@@ -135,15 +134,13 @@ public class NetworkCoreTests {
         installCableLine(helper, DOWNSTREAM_CABLE_LINE);
         IPart upstreamDevice = placePart(helper, DEVICE_A_LABEL, ForgeDirection.UP, terminal());
         IPart downstreamDevice = placePart(helper, DEVICE_B_LABEL, ForgeDirection.UP, terminal());
-        ContinuousInvariant unpoweredToggleBusGatesDownstream = continuousInvariant(
-                helper,
-                "unpowered toggle bus must keep only the upstream network active",
-                () -> {
-                    assertActive(helper, controller.getProxy(), "Controller side should remain active");
-                    assertActive(helper, upstreamDevice, "Upstream device should remain active");
-                    assertInactive(helper, drive.getProxy(), "Drive should remain gated");
-                    assertInactive(helper, downstreamDevice, "Downstream device should remain gated");
-                });
+        TickCallbackHandle unpoweredToggleBusGatesDownstream = helper.onEachTick(() -> {
+            assertActive(helper, controller.getProxy(), "Controller side should remain active");
+            assertActive(helper, upstreamDevice, "Upstream device should remain active");
+            assertInactive(helper, drive.getProxy(), "Drive should remain gated");
+            assertInactive(helper, downstreamDevice, "Downstream device should remain gated");
+        });
+        unpoweredToggleBusGatesDownstream.disable();
 
         helper.startSequence().thenWaitUntil("wait for initial unpowered toggle-bus state", 40, () -> {
             assertActive(helper, controller.getProxy(), "Controller side should boot without redstone");

--- a/src/main/java/appeng/gametests/network/p2p/P2PTests.java
+++ b/src/main/java/appeng/gametests/network/p2p/P2PTests.java
@@ -3,7 +3,6 @@ package appeng.gametests.network.p2p;
 import static appeng.gametests.AEGameTestHelpers.assertActive;
 import static appeng.gametests.AEGameTestHelpers.assertNetworkStoredAmount;
 import static appeng.gametests.AEGameTestHelpers.cell1k;
-import static appeng.gametests.AEGameTestHelpers.continuousInvariant;
 import static appeng.gametests.AEGameTestHelpers.insertItems;
 import static appeng.gametests.AEGameTestHelpers.part;
 
@@ -18,6 +17,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 import com.gtnewhorizons.horizonqa.api.GameTestHelper;
 import com.gtnewhorizons.horizonqa.api.InventoryHelper;
 import com.gtnewhorizons.horizonqa.api.TestPos;
+import com.gtnewhorizons.horizonqa.api.TickCallbackHandle;
 import com.gtnewhorizons.horizonqa.api.annotation.GameTest;
 import com.gtnewhorizons.horizonqa.api.annotation.GameTestHolder;
 
@@ -27,7 +27,6 @@ import appeng.api.networking.IGridNode;
 import appeng.api.parts.IPart;
 import appeng.api.parts.IPartHost;
 import appeng.core.AppEng;
-import appeng.gametests.AEGameTestHelpers.ContinuousInvariant;
 import appeng.me.GridAccessException;
 import appeng.parts.p2p.PartP2PInterface;
 import appeng.parts.p2p.PartP2PItems;
@@ -63,7 +62,7 @@ public class P2PTests {
         PartP2PItems input = inputTunnel(helper, PartP2PItems.class);
         PartP2PItems output = outputTunnel(helper, PartP2PItems.class);
         helper.setSlot(SOURCE_CHEST_LABEL, 0, new ItemStack(Blocks.cobblestone));
-        ContinuousInvariant itemConservation = itemConservationInvariant(helper, 1);
+        TickCallbackHandle itemConservation = itemConservationInvariant(helper, 1);
         itemConservation.enable();
 
         helper.startSequence().thenWaitUntil("wait for the item P2P pair to become active and linked", 60, () -> {
@@ -132,14 +131,12 @@ public class P2PTests {
         TileController controller = helper.assertTileEntityPresent(TileController.class, CONTROLLER_LABEL);
         PartP2PRedstone input = inputTunnel(helper, PartP2PRedstone.class);
         PartP2PRedstone output = outputTunnel(helper, PartP2PRedstone.class);
-        ContinuousInvariant unpoweredOutputStaysLow = continuousInvariant(
-                helper,
-                "an unpowered redstone P2P input must not produce output power",
-                () -> {
-                    assertCarrierActive(helper, controller);
-                    assertLinkedPair(helper, input, output, REDSTONE_FREQUENCY);
-                    assertRedstonePower(helper, 0);
-                });
+        TickCallbackHandle unpoweredOutputStaysLow = helper.onEachTick(() -> {
+            assertCarrierActive(helper, controller);
+            assertLinkedPair(helper, input, output, REDSTONE_FREQUENCY);
+            assertRedstonePower(helper, 0);
+        });
+        unpoweredOutputStaysLow.disable();
 
         helper.startSequence().thenWaitUntil("wait for the linked redstone P2P pair to settle low", 60, () -> {
             assertCarrierActive(helper, controller);
@@ -168,14 +165,12 @@ public class P2PTests {
         PartP2PItems input = (PartP2PItems) inputTunnel(helper, PartP2PItems.class).unbind(null);
         PartP2PItems output = (PartP2PItems) outputTunnel(helper, PartP2PItems.class).unbind(null);
         helper.setSlot(SOURCE_CHEST_LABEL, 0, new ItemStack(Blocks.cobblestone));
-        ContinuousInvariant noUnboundTransfer = continuousInvariant(
-                helper,
-                "unbound item tunnels must neither transfer nor duplicate the supplied item",
-                () -> {
-                    assertUnboundPairOnCarrier(helper, controller, input, output);
-                    helper.assertInventoryCount(DESTINATION_CHEST_LABEL, new ItemStack(Blocks.cobblestone), 0);
-                    assertInventoryTotal(helper, Blocks.cobblestone, 1);
-                });
+        TickCallbackHandle noUnboundTransfer = helper.onEachTick(() -> {
+            assertUnboundPairOnCarrier(helper, controller, input, output);
+            helper.assertInventoryCount(DESTINATION_CHEST_LABEL, new ItemStack(Blocks.cobblestone), 0);
+            assertInventoryTotal(helper, Blocks.cobblestone, 1);
+        });
+        noUnboundTransfer.disable();
 
         helper.startSequence()
                 .thenWaitUntil(
@@ -438,11 +433,11 @@ public class P2PTests {
         helper.assertNull(tunnel.getInput(), "Unbound tunnel should not resolve an input; role=" + role);
     }
 
-    private static ContinuousInvariant itemConservationInvariant(GameTestHelper helper, long expectedTotal) {
-        return continuousInvariant(
-                helper,
-                "item P2P transport must conserve the supplied stack on every tick",
-                () -> assertInventoryTotal(helper, Blocks.cobblestone, expectedTotal));
+    private static TickCallbackHandle itemConservationInvariant(GameTestHelper helper, long expectedTotal) {
+        TickCallbackHandle callback = helper
+                .onEachTick(() -> assertInventoryTotal(helper, Blocks.cobblestone, expectedTotal));
+        callback.disable();
+        return callback;
     }
 
     private static void assertInventoryTotal(GameTestHelper helper, Block block, long expectedTotal) {

--- a/src/main/java/appeng/gametests/network/p2p/P2PTests.java
+++ b/src/main/java/appeng/gametests/network/p2p/P2PTests.java
@@ -62,8 +62,8 @@ public class P2PTests {
         PartP2PItems input = inputTunnel(helper, PartP2PItems.class);
         PartP2PItems output = outputTunnel(helper, PartP2PItems.class);
         helper.setSlot(SOURCE_CHEST_LABEL, 0, new ItemStack(Blocks.cobblestone));
-        TickCallbackHandle itemConservation = itemConservationInvariant(helper, 1);
-        itemConservation.enable();
+        TickCallbackHandle itemConservationWatcher = watchItemConservation(helper, 1);
+        itemConservationWatcher.enable();
 
         helper.startSequence().thenWaitUntil("wait for the item P2P pair to become active and linked", 60, () -> {
             assertCarrierActive(helper, controller);
@@ -72,7 +72,7 @@ public class P2PTests {
             helper.assertInventoryCount(SOURCE_CHEST_LABEL, new ItemStack(Blocks.cobblestone), 0);
             helper.assertInventoryCount(SOURCE_INSERTER_LABEL, new ItemStack(Blocks.cobblestone), 0);
             helper.assertInventoryCount(DESTINATION_CHEST_LABEL, new ItemStack(Blocks.cobblestone), 1);
-        }).thenExecute("finish item-conservation observation", itemConservation::disable).thenSucceed();
+        }).thenExecute("finish item-conservation observation", itemConservationWatcher::disable).thenSucceed();
     }
 
     // P1: the outer ME connection must expose storage that is physically present only behind the output tunnel.
@@ -433,7 +433,7 @@ public class P2PTests {
         helper.assertNull(tunnel.getInput(), "Unbound tunnel should not resolve an input; role=" + role);
     }
 
-    private static TickCallbackHandle itemConservationInvariant(GameTestHelper helper, long expectedTotal) {
+    private static TickCallbackHandle watchItemConservation(GameTestHelper helper, long expectedTotal) {
         TickCallbackHandle callback = helper
                 .onEachTick(() -> assertInventoryTotal(helper, Blocks.cobblestone, expectedTotal));
         callback.disable();


### PR DESCRIPTION
## Summary
Replaces deprecated `AEGameTestHelpers` usages with the recommended `GameTestHelper`, `InventoryHelper`, and `TickCallbackHandle` APIs. Also updates continuous-invariant callback naming to match the new tick-watcher pattern.


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
