### PR TITLE
Fixes cell workbench not clearing cell restrictions

### DIFF
--- a/src/main/java/appeng/container/implementations/ContainerCellWorkbench.java
+++ b/src/main/java/appeng/container/implementations/ContainerCellWorkbench.java
@@ -21,6 +21,8 @@ import net.minecraft.item.ItemStack;
 
 import org.jetbrains.annotations.Nullable;
 
+import com.gtnewhorizon.gtnhlib.item.ItemStackNBT;
+
 import appeng.api.AEApi;
 import appeng.api.config.CopyMode;
 import appeng.api.config.FuzzyMode;
@@ -76,7 +78,9 @@ public class ContainerCellWorkbench extends ContainerUpgradeable {
     public void setFuzzy(final FuzzyMode valueOf) {
         final ICellWorkbenchItem cwi = this.workBench.getCell();
         if (cwi != null) {
-            cwi.setFuzzyMode(this.workBench.getInventoryByName("cell").getStackInSlot(0), valueOf);
+            final ItemStack cell = this.workBench.getInventoryByName("cell").getStackInSlot(0);
+            cwi.setFuzzyMode(cell, valueOf);
+            if (valueOf == FuzzyMode.IGNORE_ALL) ItemStackNBT.removeTag(cell, "FuzzyMode");
         }
     }
 
@@ -180,6 +184,7 @@ public class ContainerCellWorkbench extends ContainerUpgradeable {
         for (int x = 0; x < inv.getSizeInventory(); x++) {
             inv.putAEStackInSlot(x, null);
         }
+        this.setFuzzy(FuzzyMode.IGNORE_ALL);
         this.workBench.setCellRestriction(null, new ICellRestriction.CellRestrictionData((byte) 0, 0));
         this.configSync.markDirty();
         this.detectAndSendChanges();
@@ -282,7 +287,11 @@ public class ContainerCellWorkbench extends ContainerUpgradeable {
         }
 
         @Override
-        public void markDirty() {}
+        public void markDirty() {
+            if (ContainerCellWorkbench.this.getUpgradeable().getInstalledUpgrades(Upgrades.FUZZY) == 0) {
+                ContainerCellWorkbench.this.setFuzzy(FuzzyMode.IGNORE_ALL);
+            }
+        }
 
         @Override
         public boolean isUseableByPlayer(final EntityPlayer entityplayer) {

--- a/src/main/java/appeng/container/implementations/ContainerCellWorkbench.java
+++ b/src/main/java/appeng/container/implementations/ContainerCellWorkbench.java
@@ -180,6 +180,7 @@ public class ContainerCellWorkbench extends ContainerUpgradeable {
         for (int x = 0; x < inv.getSizeInventory(); x++) {
             inv.putAEStackInSlot(x, null);
         }
+        this.workBench.setCellRestriction(null, new ICellRestriction.CellRestrictionData((byte) 0, 0));
         this.configSync.markDirty();
         this.getSyncManager().flushSync();
     }

--- a/src/main/java/appeng/container/implementations/ContainerCellWorkbench.java
+++ b/src/main/java/appeng/container/implementations/ContainerCellWorkbench.java
@@ -182,7 +182,7 @@ public class ContainerCellWorkbench extends ContainerUpgradeable {
         }
         this.workBench.setCellRestriction(null, new ICellRestriction.CellRestrictionData((byte) 0, 0));
         this.configSync.markDirty();
-        this.getSyncManager().flushSync();
+        this.detectAndSendChanges();
     }
 
     private FuzzyMode getWorkBenchFuzzyMode() {
@@ -219,7 +219,7 @@ public class ContainerCellWorkbench extends ContainerUpgradeable {
         }
 
         this.configSync.markDirty();
-        this.getSyncManager().flushSync();
+        this.detectAndSendChanges();
     }
 
     @Nullable

--- a/src/main/java/appeng/tile/misc/TileCellWorkbench.java
+++ b/src/main/java/appeng/tile/misc/TileCellWorkbench.java
@@ -283,7 +283,7 @@ public class TileCellWorkbench extends AEBaseTile implements ICellWorkbench, IPr
 
     @Override
     public void setCellRestriction(ItemStack n, CellRestrictionData newRestriction) {
-        if (this.manager.getSetting(Settings.COPY_MODE) == CopyMode.KEEP_ON_REMOVE) {
+        if (newRestriction.isReset() || this.manager.getSetting(Settings.COPY_MODE) == CopyMode.KEEP_ON_REMOVE) {
             this.cellRestrictTypes = newRestriction.restrictionTypes;
             this.cellRestrictAmount = newRestriction.restrictionAmount;
         }


### PR DESCRIPTION
## Summary

Fixes the Cell Workbench’s **Clear Config/Settings** action so it also clears cell restrictions. The cell stack is now synchronized immediately after clearing or partitioning, so the updated settings are visible without removing and reinserting the cell.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26136

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
