### PR TITLE
Fix throughput monitor accuracy

### DIFF
--- a/src/main/java/appeng/parts/reporting/PartThroughputMonitor.java
+++ b/src/main/java/appeng/parts/reporting/PartThroughputMonitor.java
@@ -19,6 +19,7 @@ import appeng.api.storage.data.IAEStack;
 import appeng.client.texture.CableBusTextures;
 import appeng.core.settings.TickRates;
 import appeng.helpers.Reflected;
+import appeng.me.GridAccessException;
 import appeng.util.IWideReadableNumberConverter;
 import appeng.util.Platform;
 import appeng.util.ReadableNumberConverter;
@@ -71,13 +72,14 @@ public class PartThroughputMonitor extends AbstractPartMonitor implements IGridT
 
     private TimeUnit timeMode;
     private double itemNumsChange;
-    private long lastStackSize;
+    private final ThroughputTracker throughputTracker = new ThroughputTracker();
+    private IAEStack<?> trackedStack;
+    private boolean discardNextInterval;
 
     @Reflected
     public PartThroughputMonitor(final ItemStack is) {
         super(is);
         this.itemNumsChange = 0;
-        this.lastStackSize = -1;
         this.timeMode = TimeUnit.Tick;
     }
 
@@ -124,6 +126,22 @@ public class PartThroughputMonitor extends AbstractPartMonitor implements IGridT
     }
 
     @Override
+    public boolean onPartActivate(final EntityPlayer player, final Vec3 pos) {
+        final IAEStack<?> previousDisplayed = this.getDisplayed();
+        final boolean activated = super.onPartActivate(player, pos);
+        if (!player.worldObj.isRemote && previousDisplayed != this.getDisplayed()) {
+            this.resetThroughput(this.getDisplayed());
+            if (this.getDisplayed() != null) {
+                this.discardNextInterval = true;
+                try {
+                    this.getProxy().getTick().alertDevice(this.getProxy().getNode());
+                } catch (final GridAccessException ignored) {}
+            }
+        }
+        return activated;
+    }
+
+    @Override
     public boolean onPartShiftActivate(final EntityPlayer player, final Vec3 pos) {
         if (Platform.isClient()) {
             return true;
@@ -138,6 +156,7 @@ public class PartThroughputMonitor extends AbstractPartMonitor implements IGridT
         }
 
         this.timeMode = this.timeMode.getNext();
+        this.itemNumsChange = this.throughputTracker.getAveragePerTick() * this.timeMode.totalTicks;
         this.host.markForUpdate();
 
         return true;
@@ -152,7 +171,7 @@ public class PartThroughputMonitor extends AbstractPartMonitor implements IGridT
         final String renderedStackSize = NUMBER_CONVERTER.toWideReadableForm(stackSize);
 
         final String renderedStackSizeChange = (this.itemNumsChange > 0 ? "+" : "")
-                + (Platform.formatNumberDoubleRestrictedByWidth(this.itemNumsChange, 3))
+                + (Platform.formatNumberDoubleRestrictedByWidth(this.itemNumsChange, 5))
                 + (this.timeMode.label);
 
         final FontRenderer fr = Minecraft.getMinecraft().fontRenderer;
@@ -178,7 +197,7 @@ public class PartThroughputMonitor extends AbstractPartMonitor implements IGridT
                 TickRates.ThroughputMonitor.getMin(),
                 TickRates.ThroughputMonitor.getMax(),
                 false,
-                false);
+                true);
     }
 
     @Override
@@ -187,20 +206,111 @@ public class PartThroughputMonitor extends AbstractPartMonitor implements IGridT
             return TickRateModulation.SAME;
         }
 
-        if (this.getDisplayed() == null) {
-            this.lastStackSize = -1;
-            this.host.markForUpdate();
+        final IAEStack<?> displayed = this.getDisplayed();
+        if (displayed == null) {
+            if (this.trackedStack != null) {
+                this.resetThroughput(null);
+            }
             return TickRateModulation.IDLE;
-        } else {
-            long nowStackSize = this.getDisplayed().getStackSize();
-            if (this.lastStackSize != -1) {
-                long changeStackSize = nowStackSize - this.lastStackSize;
-                this.itemNumsChange = (changeStackSize * this.timeMode.totalTicks) / TicksSinceLastCall;
+        }
+
+        if (this.trackedStack != displayed) {
+            this.resetThroughput(displayed);
+            return TickRateModulation.SLOWER;
+        }
+
+        if (this.discardNextInterval) {
+            this.discardNextInterval = false;
+            return TickRateModulation.SAME;
+        }
+
+        final boolean sampled = this.throughputTracker.update(displayed.getStackSize(), TicksSinceLastCall);
+        if (sampled || !this.throughputTracker.isFull()) {
+            final double itemNumsChange = this.throughputTracker.getAveragePerTick() * this.timeMode.totalTicks;
+            if (this.itemNumsChange != itemNumsChange) {
+                this.itemNumsChange = itemNumsChange;
                 this.host.markForUpdate();
             }
-            this.lastStackSize = nowStackSize;
         }
-        return TickRateModulation.FASTER;
+
+        return this.throughputTracker.isFull() ? TickRateModulation.IDLE : TickRateModulation.SLOWER;
+    }
+
+    private void resetThroughput(IAEStack<?> displayed) {
+        this.trackedStack = displayed;
+        this.discardNextInterval = false;
+        if (displayed == null) {
+            this.throughputTracker.clear();
+        } else {
+            this.throughputTracker.reset(displayed.getStackSize());
+        }
+        this.itemNumsChange = 0;
+        this.host.markForUpdate();
+    }
+
+    static final class ThroughputTracker {
+
+        private static final int SAMPLE_INTERVAL_TICKS = 200;
+        private static final int HISTORY_SIZE = 12;
+
+        private final long[] changes = new long[HISTORY_SIZE];
+        private final int[] durations = new int[HISTORY_SIZE];
+        private long previousAmount;
+        private long latestAmount;
+        private long totalChange;
+        private long totalTicks;
+        private int ticksSinceSample;
+        private int nextSample;
+        private int sampleCount;
+
+        void reset(long amount) {
+            this.clear();
+            this.previousAmount = amount;
+            this.latestAmount = amount;
+        }
+
+        void clear() {
+            this.totalChange = 0;
+            this.totalTicks = 0;
+            this.ticksSinceSample = 0;
+            this.nextSample = 0;
+            this.sampleCount = 0;
+        }
+
+        boolean update(long amount, int ticksSinceLastCall) {
+            this.latestAmount = amount;
+            this.ticksSinceSample += ticksSinceLastCall;
+            if (this.ticksSinceSample < SAMPLE_INTERVAL_TICKS) {
+                return false;
+            }
+
+            if (this.sampleCount == HISTORY_SIZE) {
+                this.totalChange -= this.changes[this.nextSample];
+                this.totalTicks -= this.durations[this.nextSample];
+            } else {
+                this.sampleCount++;
+            }
+
+            final long change = amount - this.previousAmount;
+            this.changes[this.nextSample] = change;
+            this.durations[this.nextSample] = this.ticksSinceSample;
+            this.totalChange += change;
+            this.totalTicks += this.ticksSinceSample;
+            this.previousAmount = amount;
+            this.ticksSinceSample = 0;
+            this.nextSample = (this.nextSample + 1) % HISTORY_SIZE;
+            return true;
+        }
+
+        double getAveragePerTick() {
+            final long elapsedTicks = this.totalTicks + this.ticksSinceSample;
+            return elapsedTicks == 0 ? 0
+                    : (this.totalChange + this.latestAmount - this.previousAmount) / (double) elapsedTicks;
+        }
+
+        boolean isFull() {
+            return this.sampleCount == HISTORY_SIZE;
+        }
     }
 
 }

--- a/src/test/java/appeng/parts/reporting/PartThroughputMonitorTest.java
+++ b/src/test/java/appeng/parts/reporting/PartThroughputMonitorTest.java
@@ -1,0 +1,52 @@
+package appeng.parts.reporting;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import appeng.parts.reporting.PartThroughputMonitor.ThroughputTracker;
+
+public final class PartThroughputMonitorTest {
+
+    @Test
+    public void averagesBurstsAcrossTwoMinutes() {
+        final ThroughputTracker tracker = new ThroughputTracker();
+        tracker.reset(0);
+
+        assertTrue(tracker.update(120, 200));
+        assertFalse(tracker.isFull());
+        for (int i = 1; i < 12; i++) {
+            assertTrue(tracker.update(120, 200));
+        }
+
+        assertTrue(tracker.isFull());
+        assertEquals(1.0, tracker.getAveragePerTick() * 20, 0.0001);
+
+        assertTrue(tracker.update(120, 200));
+        assertEquals(0.0, tracker.getAveragePerTick(), 0.0);
+    }
+
+    @Test
+    public void preservesFractionalRatesAndActualTickDurations() {
+        final ThroughputTracker tracker = new ThroughputTracker();
+        tracker.reset(1_000);
+
+        assertFalse(tracker.update(1_090, 199));
+        assertEquals(90 / 199.0, tracker.getAveragePerTick(), 0.0001);
+        assertTrue(tracker.update(1_090, 51));
+        assertEquals(7.2, tracker.getAveragePerTick() * 20, 0.0001);
+    }
+
+    @Test
+    public void resetClearsPreviousItemHistory() {
+        final ThroughputTracker tracker = new ThroughputTracker();
+        tracker.reset(0);
+        tracker.update(100, 200);
+
+        tracker.reset(1_000);
+
+        assertEquals(0.0, tracker.getAveragePerTick(), 0.0);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes GTNewHorizons/GT-New-Horizons-Modpack#20290

Improves the throughput monitor’s accuracy and responsiveness:

- Uses a time-weighted rolling average instead of comparing only adjacent snapshots.
- Preserves fractional rates such as `0.15/t` instead of displaying `0/t`.
- Samples more frequently during warm-up, then gradually stabilizes as history fills.
- Immediately clears stale throughput data when the tracked item changes.
- Avoids unnecessary allocations and network synchronization.
- Adds tests covering burst averaging, fractional rates, timing, history expiry, and resets.


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
