### PR TITLE
Use named Horizon-QA tick callbacks

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -53,7 +53,7 @@ dependencies {
         exclude module: "waila"
     }
 
-    devOnlyNonPublishable("com.github.GTNewHorizons:Horizon-QA:0.13.0:dev")
+    devOnlyNonPublishable("com.github.GTNewHorizons:Horizon-QA:0.99.26.8.25.16.16:dev")
 
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:Postea:1.2.5:dev")
     runtimeOnlyNonPublishable('com.github.GTNewHorizons:waila:1.19.31:dev') {transitive = false}

--- a/src/main/java/appeng/gametests/AEGameTestHelpers.java
+++ b/src/main/java/appeng/gametests/AEGameTestHelpers.java
@@ -321,18 +321,6 @@ public final class AEGameTestHelpers {
         return AEApi.instance().definitions().items().cell64k().maybeStack(1).get();
     }
 
-    /**
-     * @deprecated Use directly GameTestHelper#onEachTick(Runnable) and disable the returned handle initially
-     * @see GameTestHelper#onEachTick(Runnable)
-     */
-    @Deprecated
-    public static ContinuousInvariant continuousInvariant(GameTestHelper helper, String description,
-            Runnable assertion) {
-        TickCallbackHandle callback = helper.onEachTick(() -> checkContinuousInvariant(description, assertion));
-        callback.disable();
-        return new ContinuousInvariant(callback);
-    }
-
     private static void checkContinuousInvariant(String description, Runnable assertion) {
         try {
             assertion.run();

--- a/src/main/java/appeng/gametests/automation/importexport/ImportExportBusTests.java
+++ b/src/main/java/appeng/gametests/automation/importexport/ImportExportBusTests.java
@@ -59,12 +59,11 @@ public class ImportExportBusTests {
         helper.setSlot(SOURCE_CHEST_LABEL, 1, new ItemStack(Blocks.dirt, 32));
         configureFilter(helper, busIO.importBus, Blocks.cobblestone);
         configureFilter(helper, busIO.exportBus, Blocks.dirt);
-        TickCallbackHandle filterRejectsDirt = helper.onEachTick(() -> {
+        TickCallbackHandle filterRejectsDirt = helper.onEachTickDisabled("import filter rejects dirt", () -> {
             assertNetworkStoredAmount(helper, busIO.controller, Blocks.dirt, 0);
             helper.assertInventoryCount(SOURCE_CHEST_LABEL, new ItemStack(Blocks.dirt), 32);
             helper.assertInventoryCount(DESTINATION_CHEST_LABEL, new ItemStack(Blocks.cobblestone), 0);
         });
-        filterRejectsDirt.disable();
 
         helper.startSequence()
                 .thenWaitUntil("wait for bus network activation", 60, () -> assertBusIOActive(helper, busIO))
@@ -85,11 +84,10 @@ public class ImportExportBusTests {
         helper.setSlot(DRIVE_LABEL, 0, driveCell);
         configureFilter(helper, busIO.importBus, Blocks.dirt);
         configureFilter(helper, busIO.exportBus, Blocks.cobblestone);
-        TickCallbackHandle filterRetainsDirt = helper.onEachTick(() -> {
+        TickCallbackHandle filterRetainsDirt = helper.onEachTickDisabled("export filter retains dirt", () -> {
             helper.assertInventoryCount(DESTINATION_CHEST_LABEL, new ItemStack(Blocks.dirt), 0);
             assertStoredAmount(helper, busIO.drive.getStackInSlot(0), Blocks.dirt, 1);
         });
-        filterRetainsDirt.disable();
 
         helper.startSequence()
                 .thenWaitUntil("wait for bus network activation", 60, () -> assertBusIOActive(helper, busIO))
@@ -110,12 +108,15 @@ public class ImportExportBusTests {
         long destinationCapacity = fillInventory(helper, DESTINATION_CHEST_LABEL, Blocks.dirt);
         configureFilter(helper, busIO.importBus, Blocks.dirt);
         configureFilter(helper, busIO.exportBus, Blocks.cobblestone);
-        TickCallbackHandle fullDestinationPreservesNetwork = helper.onEachTick(() -> {
-            assertNetworkStoredAmount(helper, busIO.controller, Blocks.cobblestone, 32);
-            helper.assertInventoryCount(DESTINATION_CHEST_LABEL, new ItemStack(Blocks.cobblestone), 0);
-            helper.assertInventoryCount(DESTINATION_CHEST_LABEL, new ItemStack(Blocks.dirt), destinationCapacity);
-        });
-        fullDestinationPreservesNetwork.disable();
+        TickCallbackHandle fullDestinationPreservesNetwork = helper
+                .onEachTickDisabled("full destination preserves network contents", () -> {
+                    assertNetworkStoredAmount(helper, busIO.controller, Blocks.cobblestone, 32);
+                    helper.assertInventoryCount(DESTINATION_CHEST_LABEL, new ItemStack(Blocks.cobblestone), 0);
+                    helper.assertInventoryCount(
+                            DESTINATION_CHEST_LABEL,
+                            new ItemStack(Blocks.dirt),
+                            destinationCapacity);
+                });
 
         helper.startSequence()
                 .thenWaitUntil("wait for bus network activation", 60, () -> assertBusIOActive(helper, busIO))
@@ -156,13 +157,17 @@ public class ImportExportBusTests {
         helper.setSlot(SOURCE_CHEST_LABEL, 0, new ItemStack(Blocks.cobblestone, 32));
         configureFilter(helper, busIO.importBus, Blocks.cobblestone);
         configureFilter(helper, busIO.exportBus, Blocks.dirt);
-        TickCallbackHandle fullNetworkPreservesSource = helper.onEachTick(() -> {
-            assertNetworkStoredAmount(helper, busIO.controller, Blocks.cobblestone, CELL_1K_ONE_TYPE_CAPACITY);
-            assertStoredAmount(helper, busIO.drive.getStackInSlot(0), Blocks.cobblestone, CELL_1K_ONE_TYPE_CAPACITY);
-            helper.assertInventoryCount(SOURCE_CHEST_LABEL, new ItemStack(Blocks.cobblestone), 32);
-            helper.assertInventoryCount(DESTINATION_CHEST_LABEL, new ItemStack(Blocks.cobblestone), 0);
-        });
-        fullNetworkPreservesSource.disable();
+        TickCallbackHandle fullNetworkPreservesSource = helper
+                .onEachTickDisabled("full network preserves source inventory", () -> {
+                    assertNetworkStoredAmount(helper, busIO.controller, Blocks.cobblestone, CELL_1K_ONE_TYPE_CAPACITY);
+                    assertStoredAmount(
+                            helper,
+                            busIO.drive.getStackInSlot(0),
+                            Blocks.cobblestone,
+                            CELL_1K_ONE_TYPE_CAPACITY);
+                    helper.assertInventoryCount(SOURCE_CHEST_LABEL, new ItemStack(Blocks.cobblestone), 32);
+                    helper.assertInventoryCount(DESTINATION_CHEST_LABEL, new ItemStack(Blocks.cobblestone), 0);
+                });
 
         helper.startSequence()
                 .thenWaitUntil("wait for bus network activation", 60, () -> assertBusIOActive(helper, busIO))
@@ -184,11 +189,14 @@ public class ImportExportBusTests {
         configureRedstone(busIO.exportBus, RedstoneMode.HIGH_SIGNAL);
         setRedstoneInput(helper, 0);
         long[] gatedAmounts = { 0, 0 };
-        TickCallbackHandle gatedBusDoesNotMoveItems = helper.onEachTick(() -> {
-            assertStoredAmount(helper, busIO.drive.getStackInSlot(0), Blocks.cobblestone, gatedAmounts[0]);
-            helper.assertInventoryCount(DESTINATION_CHEST_LABEL, new ItemStack(Blocks.cobblestone), gatedAmounts[1]);
-        });
-        gatedBusDoesNotMoveItems.disable();
+        TickCallbackHandle gatedBusDoesNotMoveItems = helper
+                .onEachTickDisabled("redstone-gated export bus does not move items", () -> {
+                    assertStoredAmount(helper, busIO.drive.getStackInSlot(0), Blocks.cobblestone, gatedAmounts[0]);
+                    helper.assertInventoryCount(
+                            DESTINATION_CHEST_LABEL,
+                            new ItemStack(Blocks.cobblestone),
+                            gatedAmounts[1]);
+                });
 
         helper.startSequence()
                 .thenWaitUntil("wait for bus network activation", 60, () -> assertBusIOActive(helper, busIO))

--- a/src/main/java/appeng/gametests/crafting/CraftingExecutionTests.java
+++ b/src/main/java/appeng/gametests/crafting/CraftingExecutionTests.java
@@ -285,19 +285,19 @@ public class CraftingExecutionTests {
         ItemStack driveCell = cell1k();
         insertItems(helper, driveCell, Blocks.cobblestone, 1);
         helper.setSlot(DRIVE_LABEL, 0, driveCell);
-        TickCallbackHandle cpuBreakDoesNotDuplicateOrProduceOutput = helper.onEachTick(() -> {
-            cpuBreakDrops.addAll(craftingCpuDrops(helper));
-            long accountedCobblestone = networkStoredAmount(network.controller, Blocks.cobblestone)
-                    + droppedItemAmount(cpuBreakDrops, Blocks.cobblestone);
-            long accountedStone = networkStoredAmount(network.controller, Blocks.stone)
-                    + droppedItemAmount(cpuBreakDrops, Blocks.stone);
-            helper.assertTrue(
-                    accountedCobblestone <= 1,
-                    "At most one ingredient may exist while CPU break cancellation settles; observed="
-                            + accountedCobblestone);
-            helper.assertEquals(0L, accountedStone, "CPU break must never produce the requested output");
-        });
-        cpuBreakDoesNotDuplicateOrProduceOutput.disable();
+        TickCallbackHandle cpuBreakDoesNotDuplicateOrProduceOutput = helper
+                .onEachTickDisabled("CPU break does not duplicate ingredients or produce output", () -> {
+                    cpuBreakDrops.addAll(craftingCpuDrops(helper));
+                    long accountedCobblestone = networkStoredAmount(network.controller, Blocks.cobblestone)
+                            + droppedItemAmount(cpuBreakDrops, Blocks.cobblestone);
+                    long accountedStone = networkStoredAmount(network.controller, Blocks.stone)
+                            + droppedItemAmount(cpuBreakDrops, Blocks.stone);
+                    helper.assertTrue(
+                            accountedCobblestone <= 1,
+                            "At most one ingredient may exist while CPU break cancellation settles; observed="
+                                    + accountedCobblestone);
+                    helper.assertEquals(0L, accountedStone, "CPU break must never produce the requested output");
+                });
 
         helper.startSequence()
                 .thenWaitUntil(

--- a/src/main/java/appeng/gametests/interfaces/InterfaceTests.java
+++ b/src/main/java/appeng/gametests/interfaces/InterfaceTests.java
@@ -232,11 +232,11 @@ public class InterfaceTests {
         ItemStack driveCell = cell1k();
         insertItems(helper, driveCell, Blocks.cobblestone, 64);
         helper.setSlot(DRIVE_LABEL, 0, driveCell);
-        TickCallbackHandle configuredStockDoesNotDrainNetwork = helper.onEachTick(() -> {
-            assertInterfaceStoredAmount(helper, network.blockInterface, Blocks.cobblestone, STOCK_AMOUNT);
-            assertStoredAmount(helper, network.drive.getStackInSlot(0), Blocks.cobblestone, 64);
-        });
-        configuredStockDoesNotDrainNetwork.disable();
+        TickCallbackHandle configuredStockDoesNotDrainNetwork = helper
+                .onEachTickDisabled("configured stock does not drain network", () -> {
+                    assertInterfaceStoredAmount(helper, network.blockInterface, Blocks.cobblestone, STOCK_AMOUNT);
+                    assertStoredAmount(helper, network.drive.getStackInSlot(0), Blocks.cobblestone, 64);
+                });
 
         helper.startSequence()
                 .thenWaitUntil(

--- a/src/main/java/appeng/gametests/network/NetworkCoreTests.java
+++ b/src/main/java/appeng/gametests/network/NetworkCoreTests.java
@@ -134,13 +134,13 @@ public class NetworkCoreTests {
         installCableLine(helper, DOWNSTREAM_CABLE_LINE);
         IPart upstreamDevice = placePart(helper, DEVICE_A_LABEL, ForgeDirection.UP, terminal());
         IPart downstreamDevice = placePart(helper, DEVICE_B_LABEL, ForgeDirection.UP, terminal());
-        TickCallbackHandle unpoweredToggleBusGatesDownstream = helper.onEachTick(() -> {
-            assertActive(helper, controller.getProxy(), "Controller side should remain active");
-            assertActive(helper, upstreamDevice, "Upstream device should remain active");
-            assertInactive(helper, drive.getProxy(), "Drive should remain gated");
-            assertInactive(helper, downstreamDevice, "Downstream device should remain gated");
-        });
-        unpoweredToggleBusGatesDownstream.disable();
+        TickCallbackHandle unpoweredToggleBusGatesDownstream = helper
+                .onEachTickDisabled("unpowered toggle bus gates downstream", () -> {
+                    assertActive(helper, controller.getProxy(), "Controller side should remain active");
+                    assertActive(helper, upstreamDevice, "Upstream device should remain active");
+                    assertInactive(helper, drive.getProxy(), "Drive should remain gated");
+                    assertInactive(helper, downstreamDevice, "Downstream device should remain gated");
+                });
 
         helper.startSequence().thenWaitUntil("wait for initial unpowered toggle-bus state", 40, () -> {
             assertActive(helper, controller.getProxy(), "Controller side should boot without redstone");

--- a/src/main/java/appeng/gametests/network/p2p/P2PTests.java
+++ b/src/main/java/appeng/gametests/network/p2p/P2PTests.java
@@ -131,12 +131,11 @@ public class P2PTests {
         TileController controller = helper.assertTileEntityPresent(TileController.class, CONTROLLER_LABEL);
         PartP2PRedstone input = inputTunnel(helper, PartP2PRedstone.class);
         PartP2PRedstone output = outputTunnel(helper, PartP2PRedstone.class);
-        TickCallbackHandle unpoweredOutputStaysLow = helper.onEachTick(() -> {
+        TickCallbackHandle unpoweredOutputStaysLow = helper.onEachTickDisabled("unpowered P2P output stays low", () -> {
             assertCarrierActive(helper, controller);
             assertLinkedPair(helper, input, output, REDSTONE_FREQUENCY);
             assertRedstonePower(helper, 0);
         });
-        unpoweredOutputStaysLow.disable();
 
         helper.startSequence().thenWaitUntil("wait for the linked redstone P2P pair to settle low", 60, () -> {
             assertCarrierActive(helper, controller);
@@ -165,12 +164,12 @@ public class P2PTests {
         PartP2PItems input = (PartP2PItems) inputTunnel(helper, PartP2PItems.class).unbind(null);
         PartP2PItems output = (PartP2PItems) outputTunnel(helper, PartP2PItems.class).unbind(null);
         helper.setSlot(SOURCE_CHEST_LABEL, 0, new ItemStack(Blocks.cobblestone));
-        TickCallbackHandle noUnboundTransfer = helper.onEachTick(() -> {
-            assertUnboundPairOnCarrier(helper, controller, input, output);
-            helper.assertInventoryCount(DESTINATION_CHEST_LABEL, new ItemStack(Blocks.cobblestone), 0);
-            assertInventoryTotal(helper, Blocks.cobblestone, 1);
-        });
-        noUnboundTransfer.disable();
+        TickCallbackHandle noUnboundTransfer = helper
+                .onEachTickDisabled("unbound P2P tunnels do not transfer items", () -> {
+                    assertUnboundPairOnCarrier(helper, controller, input, output);
+                    helper.assertInventoryCount(DESTINATION_CHEST_LABEL, new ItemStack(Blocks.cobblestone), 0);
+                    assertInventoryTotal(helper, Blocks.cobblestone, 1);
+                });
 
         helper.startSequence()
                 .thenWaitUntil(
@@ -434,10 +433,9 @@ public class P2PTests {
     }
 
     private static TickCallbackHandle watchItemConservation(GameTestHelper helper, long expectedTotal) {
-        TickCallbackHandle callback = helper
-                .onEachTick(() -> assertInventoryTotal(helper, Blocks.cobblestone, expectedTotal));
-        callback.disable();
-        return callback;
+        return helper.onEachTickDisabled(
+                "P2P item conservation",
+                () -> assertInventoryTotal(helper, Blocks.cobblestone, expectedTotal));
     }
 
     private static void assertInventoryTotal(GameTestHelper helper, Block block, long expectedTotal) {

--- a/src/main/java/appeng/gametests/network/power/NetworkPowerTests.java
+++ b/src/main/java/appeng/gametests/network/power/NetworkPowerTests.java
@@ -94,7 +94,7 @@ public class NetworkPowerTests {
     }
 
     private static TickCallbackHandle watchForPrematureExport(GameTestHelper helper, NetworkFixture network) {
-        return helper.onEachTick(() -> {
+        return helper.onEachTick("unpowered network does not export", () -> {
             if (!energyGrid(helper, network).isNetworkPowered()) {
                 helper.assertInventoryCount(DESTINATION_CHEST_LABEL, new ItemStack(Blocks.cobblestone), 0);
             }
@@ -102,7 +102,7 @@ public class NetworkPowerTests {
     }
 
     private static TickCallbackHandle watchCobblestoneConservation(GameTestHelper helper, NetworkFixture network) {
-        return helper.onEachTick(() -> {
+        return helper.onEachTick("cobblestone is conserved during export", () -> {
             long networkAmount = storedAmount(helper, network.drive().getStackInSlot(0), Blocks.cobblestone);
             long destinationAmount = helper.countItems(DESTINATION_CHEST_LABEL, new ItemStack(Blocks.cobblestone));
             helper.assertEquals(

--- a/src/main/java/appeng/gametests/storage/ioport/IOPortTests.java
+++ b/src/main/java/appeng/gametests/storage/ioport/IOPortTests.java
@@ -214,13 +214,13 @@ public class IOPortTests {
         configure(ioport, OperationMode.FILL, FullnessMode.EMPTY);
         ItemStack targetCell = cell1k();
         ItemStack driveCell = cell1k();
-        TickCallbackHandle emptyNetworkKeepsCell = helper.onEachTick(() -> {
-            helper.assertNotNull(ioport.getStackInSlot(0), "Cell should stay in input");
-            helper.assertNull(ioport.getStackInSlot(6), "Cell should not move to output");
-            assertStoredAmount(helper, ioport.getStackInSlot(0), Blocks.cobblestone, 0);
-            assertStoredAmount(helper, drive.getStackInSlot(0), Blocks.cobblestone, 0);
-        });
-        emptyNetworkKeepsCell.disable();
+        TickCallbackHandle emptyNetworkKeepsCell = helper
+                .onEachTickDisabled("empty network keeps cell in input", () -> {
+                    helper.assertNotNull(ioport.getStackInSlot(0), "Cell should stay in input");
+                    helper.assertNull(ioport.getStackInSlot(6), "Cell should not move to output");
+                    assertStoredAmount(helper, ioport.getStackInSlot(0), Blocks.cobblestone, 0);
+                    assertStoredAmount(helper, drive.getStackInSlot(0), Blocks.cobblestone, 0);
+                });
 
         helper.startSequence()
                 .thenWaitUntilAtEnd("wait for IO port network activation", () -> assertIOPortActive(helper, ioport))
@@ -268,13 +268,13 @@ public class IOPortTests {
         ItemStack driveCell = cell1k();
         insertItems(helper, sourceCell, Blocks.cobblestone, 300);
         AtomicReference<ItemStack> insertedSourceCell = new AtomicReference<>();
-        TickCallbackHandle nonEmptySourceStaysInInput = helper.onEachTick(() -> {
-            if (storedAmount(helper, insertedSourceCell.get(), Blocks.cobblestone) > 0) {
-                helper.assertNotNull(ioport.getStackInSlot(0), "Non-empty source cell should remain in input");
-                helper.assertNull(ioport.getStackInSlot(6), "Non-empty source cell should not reach output");
-            }
-        });
-        nonEmptySourceStaysInInput.disable();
+        TickCallbackHandle nonEmptySourceStaysInInput = helper
+                .onEachTickDisabled("non-empty source cell stays in input", () -> {
+                    if (storedAmount(helper, insertedSourceCell.get(), Blocks.cobblestone) > 0) {
+                        helper.assertNotNull(ioport.getStackInSlot(0), "Non-empty source cell should remain in input");
+                        helper.assertNull(ioport.getStackInSlot(6), "Non-empty source cell should not reach output");
+                    }
+                });
 
         helper.startSequence()
                 .thenWaitUntilAtEnd("wait for IO port network activation", () -> assertIOPortActive(helper, ioport))
@@ -347,12 +347,12 @@ public class IOPortTests {
     public static void multipleInputSlotsMoveToOutputSlots(GameTestHelper helper) {
         TileIOPort ioport = getIOPort(helper);
         getDrive(helper);
-        TickCallbackHandle cellConservation = helper.onEachTick(
+        TickCallbackHandle cellConservation = helper.onEachTickDisabled(
+                "IO port cell count is conserved",
                 () -> helper.assertEquals(
                         6,
                         countFilledSlots(ioport, 0, 12),
                         "Total IO port cell count should remain six"));
-        cellConservation.disable();
 
         helper.startSequence()
                 .thenWaitUntilAtEnd("wait for IO port network activation", () -> assertIOPortActive(helper, ioport))
@@ -378,11 +378,10 @@ public class IOPortTests {
         TileIOPort ioport = getIOPort(helper);
         getDrive(helper);
         ItemStack queuedCell = cell4k();
-        TickCallbackHandle fullOutputRetainsCell = helper.onEachTick(() -> {
+        TickCallbackHandle fullOutputRetainsCell = helper.onEachTickDisabled("full output retains queued cell", () -> {
             helper.assertNotNull(ioport.getStackInSlot(0), "Queued cell should remain in input");
             helper.assertEquals(6, countFilledSlots(ioport, 6, 12), "Output should remain full");
         });
-        fullOutputRetainsCell.disable();
 
         helper.startSequence()
                 .thenWaitUntilAtEnd("wait for IO port network activation", () -> assertIOPortActive(helper, ioport))
@@ -414,12 +413,12 @@ public class IOPortTests {
         ItemStack sourceCell = cell4k();
         ItemStack driveCell = cell1k();
         insertItems(helper, sourceCell, Blocks.cobblestone, 100);
-        TickCallbackHandle transferredCellRemainsQueued = helper.onEachTick(() -> {
-            helper.assertNotNull(ioport.getStackInSlot(0), "Transferred cell should remain in input");
-            assertStoredAmount(helper, ioport.getStackInSlot(0), Blocks.cobblestone, 0);
-            assertStoredAmount(helper, drive.getStackInSlot(0), Blocks.cobblestone, 100);
-        });
-        transferredCellRemainsQueued.disable();
+        TickCallbackHandle transferredCellRemainsQueued = helper
+                .onEachTickDisabled("transferred cell remains queued", () -> {
+                    helper.assertNotNull(ioport.getStackInSlot(0), "Transferred cell should remain in input");
+                    assertStoredAmount(helper, ioport.getStackInSlot(0), Blocks.cobblestone, 0);
+                    assertStoredAmount(helper, drive.getStackInSlot(0), Blocks.cobblestone, 100);
+                });
 
         helper.startSequence()
                 .thenWaitUntilAtEnd("wait for IO port network activation", () -> assertIOPortActive(helper, ioport))
@@ -453,13 +452,13 @@ public class IOPortTests {
         ItemStack sourceCell = cell4k();
         ItemStack driveCell = cell1k();
         insertItems(helper, sourceCell, Blocks.cobblestone, 100);
-        TickCallbackHandle inactivePortRetainsQueuedCell = helper.onEachTick(() -> {
-            helper.assertNotNull(ioport.getStackInSlot(0), "Queued cell should remain in input while inactive");
-            helper.assertNull(ioport.getStackInSlot(6), "Opened output should stay empty while inactive");
-            assertStoredAmount(helper, ioport.getStackInSlot(0), Blocks.cobblestone, 0);
-            assertStoredAmount(helper, drive.getStackInSlot(0), Blocks.cobblestone, 100);
-        });
-        inactivePortRetainsQueuedCell.disable();
+        TickCallbackHandle inactivePortRetainsQueuedCell = helper
+                .onEachTickDisabled("inactive IO port retains queued cell", () -> {
+                    helper.assertNotNull(ioport.getStackInSlot(0), "Queued cell should remain in input while inactive");
+                    helper.assertNull(ioport.getStackInSlot(6), "Opened output should stay empty while inactive");
+                    assertStoredAmount(helper, ioport.getStackInSlot(0), Blocks.cobblestone, 0);
+                    assertStoredAmount(helper, drive.getStackInSlot(0), Blocks.cobblestone, 100);
+                });
 
         helper.startSequence()
                 .thenWaitUntilAtEnd("wait for IO port network activation", () -> assertIOPortActive(helper, ioport))
@@ -510,13 +509,13 @@ public class IOPortTests {
         ItemStack fullDriveCell = cell1k();
         insertItems(helper, sourceCell, Blocks.cobblestone, 100);
         insertItems(helper, fullDriveCell, Blocks.cobblestone, 8128);
-        TickCallbackHandle fullDestinationPreservesSource = helper.onEachTick(() -> {
-            helper.assertNotNull(ioport.getStackInSlot(0), "Source cell should remain in input");
-            helper.assertNull(ioport.getStackInSlot(6), "Source cell should not move to output");
-            assertStoredAmount(helper, ioport.getStackInSlot(0), Blocks.cobblestone, 100);
-            assertStoredAmount(helper, drive.getStackInSlot(0), Blocks.cobblestone, 8128);
-        });
-        fullDestinationPreservesSource.disable();
+        TickCallbackHandle fullDestinationPreservesSource = helper
+                .onEachTickDisabled("full destination preserves source cell", () -> {
+                    helper.assertNotNull(ioport.getStackInSlot(0), "Source cell should remain in input");
+                    helper.assertNull(ioport.getStackInSlot(6), "Source cell should not move to output");
+                    assertStoredAmount(helper, ioport.getStackInSlot(0), Blocks.cobblestone, 100);
+                    assertStoredAmount(helper, drive.getStackInSlot(0), Blocks.cobblestone, 8128);
+                });
 
         helper.startSequence()
                 .thenWaitUntilAtEnd("wait for IO port network activation", () -> assertIOPortActive(helper, ioport))
@@ -606,11 +605,11 @@ public class IOPortTests {
     public static void redstoneHighSignalRequiresPower(GameTestHelper helper) {
         TileIOPort ioport = getIOPort(helper);
         getDrive(helper);
-        TickCallbackHandle unpoweredHighSignalDoesNotRun = helper.onEachTick(() -> {
-            helper.assertNotNull(ioport.getStackInSlot(0), "Unpowered cell should remain in input");
-            helper.assertNull(ioport.getStackInSlot(6), "Unpowered cell should not reach output");
-        });
-        unpoweredHighSignalDoesNotRun.disable();
+        TickCallbackHandle unpoweredHighSignalDoesNotRun = helper
+                .onEachTickDisabled("unpowered high signal does not run IO port", () -> {
+                    helper.assertNotNull(ioport.getStackInSlot(0), "Unpowered cell should remain in input");
+                    helper.assertNull(ioport.getStackInSlot(6), "Unpowered cell should not reach output");
+                });
 
         helper.startSequence()
                 .thenWaitUntilAtEnd("wait for IO port network activation", () -> assertIOPortActive(helper, ioport))
@@ -637,11 +636,11 @@ public class IOPortTests {
     public static void redstoneLowSignalRunsOnlyWithoutPower(GameTestHelper helper) {
         TileIOPort ioport = getIOPort(helper);
         getDrive(helper);
-        TickCallbackHandle poweredLowSignalDoesNotRun = helper.onEachTick(() -> {
-            helper.assertNotNull(ioport.getStackInSlot(0), "Powered cell should remain in input");
-            helper.assertNull(ioport.getStackInSlot(6), "Powered cell should not reach output");
-        });
-        poweredLowSignalDoesNotRun.disable();
+        TickCallbackHandle poweredLowSignalDoesNotRun = helper
+                .onEachTickDisabled("powered low signal does not run IO port", () -> {
+                    helper.assertNotNull(ioport.getStackInSlot(0), "Powered cell should remain in input");
+                    helper.assertNull(ioport.getStackInSlot(6), "Powered cell should not reach output");
+                });
 
         helper.startSequence()
                 .thenWaitUntilAtEnd("wait for IO port network activation", () -> assertIOPortActive(helper, ioport))
@@ -669,16 +668,14 @@ public class IOPortTests {
     public static void redstonePulseModeRunsAfterPulse(GameTestHelper helper) {
         TileIOPort ioport = getIOPort(helper);
         getDrive(helper);
-        TickCallbackHandle noPulseDoesNotRun = helper.onEachTick(() -> {
+        TickCallbackHandle noPulseDoesNotRun = helper.onEachTickDisabled("IO port does not run without a pulse", () -> {
             helper.assertEquals(2, countFilledSlots(ioport, 0, 6), "Both cells should remain in input");
             helper.assertEquals(0, countFilledSlots(ioport, 6, 12), "No cell should reach output");
         });
-        noPulseDoesNotRun.disable();
-        TickCallbackHandle onePulseMovesOnlyOneCell = helper.onEachTick(() -> {
+        TickCallbackHandle onePulseMovesOnlyOneCell = helper.onEachTickDisabled("one pulse moves only one cell", () -> {
             helper.assertEquals(1, countFilledSlots(ioport, 0, 6), "One cell should remain in input");
             helper.assertEquals(1, countFilledSlots(ioport, 6, 12), "Exactly one cell should be in output");
         });
-        onePulseMovesOnlyOneCell.disable();
 
         helper.startSequence()
                 .thenWaitUntilAtEnd("wait for IO port network activation", () -> assertIOPortActive(helper, ioport))
@@ -814,14 +811,14 @@ public class IOPortTests {
         ForgeDirection towardIOPort = directionBetween(helper, AUTOMATION_LABEL, IO_PORT_LABEL);
         helper.setBlock(AUTOMATION_LABEL, Blocks.hopper, towardIOPort.ordinal());
         TileEntityHopper hopper = helper.assertTileEntityPresent(TileEntityHopper.class, AUTOMATION_LABEL);
-        TickCallbackHandle rejectedItemStaysInHopper = helper.onEachTick(() -> {
-            helper.assertItemEqual(
-                    nonCell,
-                    hopper.getStackInSlot(0),
-                    "Automation input should still contain the rejected apple");
-            helper.assertNull(ioport.getStackInSlot(0), "IO port input should reject the apple");
-        });
-        rejectedItemStaysInHopper.disable();
+        TickCallbackHandle rejectedItemStaysInHopper = helper
+                .onEachTickDisabled("rejected item stays in automation hopper", () -> {
+                    helper.assertItemEqual(
+                            nonCell,
+                            hopper.getStackInSlot(0),
+                            "Automation input should still contain the rejected apple");
+                    helper.assertNull(ioport.getStackInSlot(0), "IO port input should reject the apple");
+                });
 
         helper.startSequence()
                 .thenWaitUntilAtEnd("wait for IO port network activation", () -> assertIOPortActive(helper, ioport))
@@ -844,12 +841,12 @@ public class IOPortTests {
         getDrive(helper);
         ItemStack sourceCell = cell1k();
         insertItems(helper, sourceCell, Blocks.cobblestone, 1);
-        TickCallbackHandle noDestinationPreservesSource = helper.onEachTick(() -> {
-            helper.assertNotNull(ioport.getStackInSlot(0), "Input cell should remain without a destination");
-            helper.assertNull(ioport.getStackInSlot(6), "Cell should not move without a destination");
-            assertStoredAmount(helper, ioport.getStackInSlot(0), Blocks.cobblestone, 1);
-        });
-        noDestinationPreservesSource.disable();
+        TickCallbackHandle noDestinationPreservesSource = helper
+                .onEachTickDisabled("missing destination preserves source cell", () -> {
+                    helper.assertNotNull(ioport.getStackInSlot(0), "Input cell should remain without a destination");
+                    helper.assertNull(ioport.getStackInSlot(6), "Cell should not move without a destination");
+                    assertStoredAmount(helper, ioport.getStackInSlot(0), Blocks.cobblestone, 1);
+                });
 
         helper.startSequence()
                 .thenWaitUntilAtEnd("wait for IO port network activation", () -> assertIOPortActive(helper, ioport))
@@ -867,11 +864,14 @@ public class IOPortTests {
         TileIOPort ioport = getIOPort(helper);
         getDrive(helper);
         ItemStack queuedCell = cell4k();
-        TickCallbackHandle queuedCellIsConserved = helper.onEachTick(() -> {
-            helper.assertNotNull(ioport.getStackInSlot(0), "Queued cell should remain in input");
-            helper.assertEquals(7, countFilledSlots(ioport, 0, 12), "Seven total cells should be accounted for");
-        });
-        queuedCellIsConserved.disable();
+        TickCallbackHandle queuedCellIsConserved = helper
+                .onEachTickDisabled("queued cell is conserved during setting change", () -> {
+                    helper.assertNotNull(ioport.getStackInSlot(0), "Queued cell should remain in input");
+                    helper.assertEquals(
+                            7,
+                            countFilledSlots(ioport, 0, 12),
+                            "Seven total cells should be accounted for");
+                });
 
         helper.startSequence()
                 .thenWaitUntilAtEnd("wait for IO port network activation", () -> assertIOPortActive(helper, ioport))


### PR DESCRIPTION
## Summary
Take advantage of the new named tick callback API introduced in HQA 0.14.0, and remove totally deprecated continious-invariant helper.


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
