### PR TITLE
Fix WirelessKit connection

### DIFF
--- a/src/main/java/appeng/container/implementations/ContainerWirelessKit.java
+++ b/src/main/java/appeng/container/implementations/ContainerWirelessKit.java
@@ -456,7 +456,7 @@ public class ContainerWirelessKit extends AEBaseContainer implements IConfigMana
                     if (w.getTileEntity(network.x, network.y, network.z) instanceof IGridHost gh) {
                         if (subCommand.includeConnectors) {
                             for (IGridNode gn : gh.getGridNode(ForgeDirection.UNKNOWN).getGrid()
-                                    .getMachines(TileWirelessBase.class)) {
+                                    .getMachines(TileWirelessConnector.class)) {
                                 TileWirelessBase wc = (TileWirelessBase) gn.getMachine();
                                 if (!wc.isLinked()) {
                                     if (isColor && wc.getColor() != subCommand.color) continue;


### PR DESCRIPTION
## Summary
`getMachines` search for machines whose type is exactly equavilant to the arg (subclasses do not work).
So using abstract class `TileWirelessBase.class` will always get an empty set.


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
