### PR TITLE
Fix Mad Chameleon mode

### DIFF
--- a/src/main/java/appeng/container/implementations/ContainerWirelessKit.java
+++ b/src/main/java/appeng/container/implementations/ContainerWirelessKit.java
@@ -339,7 +339,7 @@ public class ContainerWirelessKit extends AEBaseContainer implements IConfigMana
                                 if (!WireLessToolHelper
                                         .securityCheck(tw, new PlayerSource(this.getPlayerInv().player, null)))
                                     continue;
-                                if (subCommand.coord != null)
+                                if (command.color != null)
                                     tw.recolourBlock(ForgeDirection.UNKNOWN, command.color, this.getPlayerInv().player);
                                 else tw.madChameleonRecolor();
                             }
@@ -358,7 +358,7 @@ public class ContainerWirelessKit extends AEBaseContainer implements IConfigMana
                                     continue;
 
                                 if (isColor) if (sd.color != subCommand.color) continue;
-                                if (subCommand.color != null) {
+                                if (command.color != null) {
                                     tw.recolourBlock(ForgeDirection.UNKNOWN, command.color, this.getPlayerInv().player);
                                 } else {
                                     tw.madChameleonRecolor();


### PR DESCRIPTION
## Summary
The Mad Chameleon button sends `RECOLOR` with `command.color = null`, which is the
signal to auto-pick a colour instead of applying a chosen one.

The server process the packet in a wrong way: 
`command.color` is the colour to apply 
`subCommand.color` is the group filter(`if (isColor) if (sd.color != subCommand.color) continue;`).
But the code check `subCommand.color` for Mad Chameleon mode.


To fix:

Both branches now check `command.color` now.

To reproduce:
1. Grab a wireless kit.
2. Switch to super mode.
3. Click a connector to bind it.
4. Open GUI, click the connector on the left side to select it.
5. Click  'mad Chameleon'
6. Game crashes:
<details>
  <summary>spoiler</summary>
[22:29:34] [Server thread/ERROR] [FML]: A TileEntity type appeng.tile.networking.TileWirelessConnector has throw an exception trying to write state. It will not persist. Report this to the mod author
java.lang.IllegalStateException: java.lang.reflect.InvocationTargetException
	at appeng.tile.events.AETileEventHandler.writeToNBT(AETileEventHandler.java:45) ~[AETileEventHandler.class:?]
	at appeng.tile.AEBaseTile.writeToNBT(AEBaseTile.java:143) ~[AEBaseTile.class:?]
	at net.minecraft.world.chunk.storage.AnvilChunkLoader.writeEntities(AnvilChunkLoader.java:770) [AnvilChunkLoader.class:?]
	at net.minecraft.world.chunk.storage.AnvilChunkLoader.handler$zzj000$chunkapi$writeChunkToNBT(AnvilChunkLoader.java:670) [AnvilChunkLoader.class:?]
	at net.minecraft.world.chunk.storage.AnvilChunkLoader.writeChunkToNBT(AnvilChunkLoader.java) [AnvilChunkLoader.class:?]
	at net.minecraft.world.chunk.storage.AnvilChunkLoader.saveChunk(AnvilChunkLoader.java:204) [AnvilChunkLoader.class:?]
	at net.minecraft.world.gen.ChunkProviderServer.safeSaveChunk(ChunkProviderServer.java:287) [ChunkProviderServer.class:?]
	at net.minecraft.world.gen.ChunkProviderServer.saveChunks(ChunkProviderServer.java:340) [ChunkProviderServer.class:?]
	at net.minecraft.world.WorldServer.saveAllChunks(WorldServer.java:863) [WorldServer.class:?]
	at net.minecraft.server.MinecraftServer.saveAllWorlds(MinecraftServer.java:370) [MinecraftServer.class:?]
	at net.minecraft.server.MinecraftServer.stopServer(MinecraftServer.java:405) [MinecraftServer.class:?]
	at net.minecraft.server.integrated.IntegratedServer.stopServer(IntegratedServer.java:266) [IntegratedServer.class:?]
	at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:538) [MinecraftServer.class:?]
	at net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:752) [MinecraftServer$2.class:?]
Caused by: java.lang.reflect.InvocationTargetException
	at sun.reflect.GeneratedMethodAccessor38.invoke(Unknown Source) ~[?:?]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_492]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_492]
	at appeng.tile.events.AETileEventHandler.writeToNBT(AETileEventHandler.java:43) ~[AETileEventHandler.class:?]
	... 13 more
Caused by: java.lang.NullPointerException
	at appeng.tile.networking.TileWirelessBase.writeToNBT_TileWirelessConnector(TileWirelessBase.java:304) ~[TileWirelessBase.class:?]
	at sun.reflect.GeneratedMethodAccessor38.invoke(Unknown Source) ~[?:?]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_492]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_492]
	at appeng.tile.events.AETileEventHandler.writeToNBT(AETileEventHandler.java:43) ~[AETileEventHandler.class:?]
	... 13 more

</details>



## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge