### PR TITLE
Support bookmark group drops in cell workbenches

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiCellWorkbench.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiCellWorkbench.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.entity.player.InventoryPlayer;
+import net.minecraft.item.ItemStack;
 
 import org.lwjgl.input.Mouse;
 
@@ -241,6 +242,27 @@ public class GuiCellWorkbench extends GuiUpgradeable {
                 super.actionPerformed(btn);
             }
         } catch (final IOException ignored) {}
+    }
+
+    public boolean handleBookmarkGroupDrop(int mouseX, int mouseY, Iterable<ItemStack> stacks) {
+        final int x = mouseX - this.guiLeft + 1;
+        final int y = mouseY - this.guiTop + 1;
+        this.handleButtonVisibility();
+
+        int slotIndex = -1;
+        for (VirtualMEPhantomSlot slot : this.configSlots) {
+            if (slot.isHovered(x, y)) {
+                slotIndex = slot.getSlotIndex();
+                break;
+            }
+        }
+        if (slotIndex < 0) return false;
+
+        for (ItemStack stack : stacks) {
+            if (slotIndex >= this.configSlots.length || this.configSlots[slotIndex].isHidden()) break;
+            this.configSlots[slotIndex++].handleMouseClicked(stack, false, 0);
+        }
+        return true;
     }
 
     private boolean acceptType(VirtualMEPhantomSlot slot, IAEStackType<?> type, int mouseButton) {

--- a/src/main/java/appeng/integration/modules/NEIHelpers/NEIInputHandler.java
+++ b/src/main/java/appeng/integration/modules/NEIHelpers/NEIInputHandler.java
@@ -10,6 +10,7 @@ import net.minecraft.item.ItemStack;
 
 import appeng.api.implementations.ICraftingPatternItem;
 import appeng.api.networking.crafting.ICraftingPatternDetails;
+import appeng.client.gui.implementations.GuiCellWorkbench;
 import appeng.client.gui.implementations.GuiStorageBus;
 import codechicken.nei.ItemPanels;
 import codechicken.nei.NEIClientConfig;
@@ -72,8 +73,12 @@ public class NEIInputHandler implements IContainerInputHandler {
     public void onMouseUp(GuiContainer gui, int mousex, int mousey, int button) {
         if (button != 0) return;
 
-        if (gui instanceof GuiStorageBus storageBus && this.draggedBookmarkGroup != null) {
-            storageBus.handleBookmarkGroupDrop(mousex, mousey, this.draggedBookmarkGroup);
+        if (this.draggedBookmarkGroup != null) {
+            if (gui instanceof GuiStorageBus storageBus) {
+                storageBus.handleBookmarkGroupDrop(mousex, mousey, this.draggedBookmarkGroup);
+            } else if (gui instanceof GuiCellWorkbench cellWorkbench) {
+                cellWorkbench.handleBookmarkGroupDrop(mousex, mousey, this.draggedBookmarkGroup);
+            }
         }
         this.draggedBookmarkGroup = null;
     }
@@ -89,7 +94,8 @@ public class NEIInputHandler implements IContainerInputHandler {
     @Override
     public void onMouseDragged(GuiContainer gui, int mousex, int mousey, int button, long heldTime) {
         final SortableGroup group = ItemPanels.bookmarkPanel.sortableGroup;
-        if (gui instanceof GuiStorageBus && group != null && this.draggedBookmarkGroup == null) {
+        if ((gui instanceof GuiStorageBus || gui instanceof GuiCellWorkbench) && group != null
+                && this.draggedBookmarkGroup == null) {
             this.draggedBookmarkGroup = group.getBookmarkItems().stream().map(BookmarkItem::getItemStack)
                     .collect(Collectors.toList());
         }


### PR DESCRIPTION
PR #1487 added bookmark group drops to ME Storage Buses. The same workflow is useful for partitioning item and fluid cells in the Cell Workbench and was part of the original request.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge