### PR TITLE
Fix empty custom name being kept on cable parts

### DIFF
--- a/src/main/java/appeng/parts/AEBasePart.java
+++ b/src/main/java/appeng/parts/AEBasePart.java
@@ -179,7 +179,12 @@ public abstract class AEBasePart implements IPart, IGridProxyable, IActionHost, 
 
     @Override
     public void setCustomName(String name) {
-        this.getItemStack().setStackDisplayName(name);
+        // An empty name has to clear the display tag, otherwise hasDisplayName() keeps reporting a name
+        if (name == null || name.isEmpty()) {
+            this.getItemStack().func_135074_t();
+        } else {
+            this.getItemStack().setStackDisplayName(name);
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary
Renaming a cable part with an empty text field stored an empty display tag on the part item stack. Vanilla hasDisplayName() only checks that the Name tag exists, so the part was still treated as named and its GUI title showed an empty string.

Clearing the field in the rename GUI now removes the custom name.


## Checklist
- [X] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
