### PR TITLE
Fix crashes when diffing read-only network item lists

### DIFF
--- a/src/functionalTest/java/appeng/test/util/PlatformFunctionalTest.java
+++ b/src/functionalTest/java/appeng/test/util/PlatformFunctionalTest.java
@@ -1,0 +1,60 @@
+package appeng.test.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
+
+import org.junit.jupiter.api.Test;
+
+import appeng.api.networking.security.BaseActionSource;
+import appeng.api.networking.storage.IBaseMonitor;
+import appeng.api.storage.IMEMonitorHandlerReceiver;
+import appeng.api.storage.data.IAEItemStack;
+import appeng.api.storage.data.IItemList;
+import appeng.util.Platform;
+import appeng.util.item.AEItemStack;
+import appeng.util.item.ItemList;
+import appeng.util.item.NetworkItemList;
+
+public class PlatformFunctionalTest {
+
+    @Test
+    void postListChangesSupportsReadOnlyNetworkItemLists() {
+        final IItemList<IAEItemStack> networkItems = new ItemList();
+        networkItems.add(AEItemStack.create(new ItemStack(Items.stick, 2)));
+
+        final NetworkItemList<IAEItemStack> before = new NetworkItemList<>(null, ItemList::new);
+        before.addNetworkItems(null, networkItems);
+
+        final IItemList<IAEItemStack> after = new ItemList();
+        after.add(AEItemStack.create(new ItemStack(Items.stick, 5)));
+
+        final List<IAEItemStack> changes = new ArrayList<>();
+        Platform.postListChanges(before, after, new IMEMonitorHandlerReceiver<IAEItemStack>() {
+
+            @Override
+            public boolean isValid(Object verificationToken) {
+                return true;
+            }
+
+            @Override
+            public void postChange(IBaseMonitor<IAEItemStack> monitor, Iterable<IAEItemStack> change,
+                    BaseActionSource actionSource) {
+                change.forEach(changes::add);
+            }
+
+            @Override
+            public void onListUpdate() {}
+        }, null);
+
+        assertFalse(before.hasWriteAccess());
+        assertEquals(2, before.getFirstItem().getStackSize());
+        assertEquals(1, changes.size());
+        assertEquals(3, changes.get(0).getStackSize());
+    }
+}

--- a/src/main/java/appeng/util/Platform.java
+++ b/src/main/java/appeng/util/Platform.java
@@ -1441,17 +1441,33 @@ public class Platform {
 
     public static <T extends IAEStack<T>> void postListChanges(final IItemList<T> before, final IItemList<T> after,
             final IMEMonitorHandlerReceiver meMonitorPassthrough, final BaseActionSource source) {
+        IItemList<T> changeList = before;
+        if (!changeList.hasWriteAccess()) {
+            IAEStackType<T> stackType = before.getStackType();
+            if (stackType == null) {
+                stackType = after.getStackType();
+            }
+            if (stackType == null) {
+                return;
+            }
+
+            changeList = stackType.createPrimitiveList();
+            for (final T is : before) {
+                changeList.add(is);
+            }
+        }
+
         final LinkedList<IAEStack<?>> changes = new LinkedList<>();
 
-        for (final T is : before) {
+        for (final T is : changeList) {
             is.setStackSize(-is.getStackSize());
         }
 
         for (final T is : after) {
-            before.add(is);
+            changeList.add(is);
         }
 
-        for (final T is : before) {
+        for (final T is : changeList) {
             if (is.getStackSize() != 0) {
                 changes.add(is);
             }

--- a/src/main/java/appeng/util/inv/ItemListIgnoreCrafting.java
+++ b/src/main/java/appeng/util/inv/ItemListIgnoreCrafting.java
@@ -89,6 +89,11 @@ public class ItemListIgnoreCrafting<T extends IAEStack> implements IItemList<T> 
     }
 
     @Override
+    public boolean hasWriteAccess() {
+        return target.hasWriteAccess();
+    }
+
+    @Override
     public @Nullable IAEStackType<T> getStackType() {
         return target.getStackType();
     }

--- a/src/main/java/appeng/util/item/LazyItemList.java
+++ b/src/main/java/appeng/util/item/LazyItemList.java
@@ -95,6 +95,11 @@ public final class LazyItemList<StackType extends IAEStack<StackType>> implement
     }
 
     @Override
+    public boolean hasWriteAccess() {
+        return getCachedOrCompute().hasWriteAccess();
+    }
+
+    @Override
     public StackType[] toArray(StackType[] zeroSizedArray) {
         return getCachedOrCompute().toArray(zeroSizedArray);
     }

--- a/src/main/java/appeng/util/item/NetworkItemList.java
+++ b/src/main/java/appeng/util/item/NetworkItemList.java
@@ -234,6 +234,11 @@ public class NetworkItemList<T extends IAEStack> implements IItemList<T> {
     }
 
     @Override
+    public boolean hasWriteAccess() {
+        return false;
+    }
+
+    @Override
     public void add(T option) {
         throw new UnsupportedOperationException();
     }


### PR DESCRIPTION
## Summary

Fixes https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/issues/1556

Fixes crashes caused by `Platform.postListChanges` attempting to mutate read-only network item lists during recursive network scans.

The change:

- Marks `NetworkItemList` as read-only.
- Copies read-only lists before calculating changes.
- Propagates write-access state through list wrappers.
- Adds a regression test verifying correct change calculation without modifying the source list.


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
