### PR TITLE
Fix color applicator shift-right-click GUI

### DIFF
--- a/src/main/java/appeng/parts/PartPlacement.java
+++ b/src/main/java/appeng/parts/PartPlacement.java
@@ -361,7 +361,6 @@ public class PartPlacement {
             final IItems items = AEApi.instance().definitions().items();
 
             boolean supportedItem = items.memoryCard().isSameAs(held);
-            supportedItem |= items.colorApplicator().isSameAs(held);
 
             if (event.entityPlayer.isSneaking() && held != null && supportedItem) {
                 event.setCanceled(true);


### PR DESCRIPTION
## Summary

Fixes regresion from https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/1402

Restores the Color Applicator’s GUI when shift-right-clicking in the air by preventing `PartPlacement` from canceling the interaction before `ToolColorApplicator#onItemRightClick` runs. 

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
