### PR TITLE
Fix inverted fuzzy durability thresholds

### DIFF
--- a/src/main/java/appeng/util/Platform.java
+++ b/src/main/java/appeng/util/Platform.java
@@ -1136,10 +1136,8 @@ public class Platform {
                 } else if (mode == FuzzyMode.PERCENT_99) {
                     return (a.getItemDamageForDisplay() > 1) == (b.getItemDamageForDisplay() > 1);
                 } else {
-                    final float percentDamagedOfA = 1.0f
-                            - (float) a.getItemDamageForDisplay() / (float) a.getMaxDamage();
-                    final float percentDamagedOfB = 1.0f
-                            - (float) b.getItemDamageForDisplay() / (float) b.getMaxDamage();
+                    final float percentDamagedOfA = (float) a.getItemDamageForDisplay() / (float) a.getMaxDamage();
+                    final float percentDamagedOfB = (float) b.getItemDamageForDisplay() / (float) b.getMaxDamage();
 
                     return (percentDamagedOfA > mode.breakPoint) == (percentDamagedOfB > mode.breakPoint);
                 }

--- a/src/main/java/appeng/util/item/AEItemStack.java
+++ b/src/main/java/appeng/util/item/AEItemStack.java
@@ -287,8 +287,10 @@ public final class AEItemStack extends AEStack<IAEItemStack> implements IAEItemS
                         } else if (mode == FuzzyMode.PERCENT_99) {
                             return (a.getItemDamageForDisplay() > 1) == (b.getItemDamageForDisplay() > 1);
                         } else {
-                            final float percentDamageOfA = (float) a.getItemDamageForDisplay() / (float) a.getMaxDamage();
-                            final float percentDamageOfB = (float) b.getItemDamageForDisplay() / (float) b.getMaxDamage();
+                            final float percentDamageOfA = (float) a.getItemDamageForDisplay()
+                                    / (float) a.getMaxDamage();
+                            final float percentDamageOfB = (float) b.getItemDamageForDisplay()
+                                    / (float) b.getMaxDamage();
 
                             return (percentDamageOfA > mode.breakPoint) == (percentDamageOfB > mode.breakPoint);
                         }
@@ -325,8 +327,10 @@ public final class AEItemStack extends AEStack<IAEItemStack> implements IAEItemS
                         } else if (mode == FuzzyMode.PERCENT_99) {
                             return (a.getItemDamageForDisplay() > 1) == (o.getItemDamageForDisplay() > 1);
                         } else {
-                            final float percentDamageOfA = (float) a.getItemDamageForDisplay() / (float) a.getMaxDamage();
-                            final float percentDamageOfB = (float) o.getItemDamageForDisplay() / (float) o.getMaxDamage();
+                            final float percentDamageOfA = (float) a.getItemDamageForDisplay()
+                                    / (float) a.getMaxDamage();
+                            final float percentDamageOfB = (float) o.getItemDamageForDisplay()
+                                    / (float) o.getMaxDamage();
 
                             return (percentDamageOfA > mode.breakPoint) == (percentDamageOfB > mode.breakPoint);
                         }

--- a/src/main/java/appeng/util/item/AEItemStack.java
+++ b/src/main/java/appeng/util/item/AEItemStack.java
@@ -287,10 +287,8 @@ public final class AEItemStack extends AEStack<IAEItemStack> implements IAEItemS
                         } else if (mode == FuzzyMode.PERCENT_99) {
                             return (a.getItemDamageForDisplay() > 1) == (b.getItemDamageForDisplay() > 1);
                         } else {
-                            final float percentDamageOfA = 1.0f
-                                    - (float) a.getItemDamageForDisplay() / (float) a.getMaxDamage();
-                            final float percentDamageOfB = 1.0f
-                                    - (float) b.getItemDamageForDisplay() / (float) b.getMaxDamage();
+                            final float percentDamageOfA = (float) a.getItemDamageForDisplay() / (float) a.getMaxDamage();
+                            final float percentDamageOfB = (float) b.getItemDamageForDisplay() / (float) b.getMaxDamage();
 
                             return (percentDamageOfA > mode.breakPoint) == (percentDamageOfB > mode.breakPoint);
                         }
@@ -327,10 +325,8 @@ public final class AEItemStack extends AEStack<IAEItemStack> implements IAEItemS
                         } else if (mode == FuzzyMode.PERCENT_99) {
                             return (a.getItemDamageForDisplay() > 1) == (o.getItemDamageForDisplay() > 1);
                         } else {
-                            final float percentDamageOfA = 1.0f
-                                    - (float) a.getItemDamageForDisplay() / (float) a.getMaxDamage();
-                            final float percentDamageOfB = 1.0f
-                                    - (float) o.getItemDamageForDisplay() / (float) o.getMaxDamage();
+                            final float percentDamageOfA = (float) a.getItemDamageForDisplay() / (float) a.getMaxDamage();
+                            final float percentDamageOfB = (float) o.getItemDamageForDisplay() / (float) o.getMaxDamage();
 
                             return (percentDamageOfA > mode.breakPoint) == (percentDamageOfB > mode.breakPoint);
                         }


### PR DESCRIPTION
## Summary
Removes the inversion for fuzzy card’s durability thresholds. Fixes the #1559 issue.

Didn’t test the changes since it should work, it’s just an inversion.

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
