### PR TITLE
Add null check for renaming connected TileWirelessBase

### DIFF
--- a/src/main/java/appeng/tile/networking/TileWirelessBase.java
+++ b/src/main/java/appeng/tile/networking/TileWirelessBase.java
@@ -415,7 +415,8 @@ public abstract class TileWirelessBase extends AENetworkTile implements IColorab
     public void setCustomName(final String name) {
         super.setCustomName(name);
         for (TileWirelessBase tile : getConnectedTiles()) {
-            if (name.isEmpty() && !tile.hasCustomName() || Objects.equals(tile.getCustomName(), name)) continue;
+            if ((name == null || name.isEmpty()) && !tile.hasCustomName() || Objects.equals(tile.getCustomName(), name))
+                continue;
             tile.setCustomName(name);
         }
     }


### PR DESCRIPTION
## Summary
This PR fixes a NPE that happens when the Matter Manipulator passes in `null` as the argument to rename a wireless connector that has active connections.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26574

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
