### PR TITLE
Add config options for cable channel limits

### DIFF
--- a/src/main/java/appeng/core/AEConfig.java
+++ b/src/main/java/appeng/core/AEConfig.java
@@ -149,6 +149,8 @@ public final class AEConfig extends Configuration implements IConfigurableObject
 
     public int maxRecursiveDepth = 100;
     public int maxMachineChecks = 10000;
+    public int normalCableChannelCapacity = 8;
+    public int denseCableChannelCapacity = 32;
     public boolean enableItemFlowTracking = true;
     public int itemFlowTrackingWindowMinutes = 2;
 
@@ -379,6 +381,30 @@ public final class AEConfig extends Configuration implements IConfigurableObject
                     .get("craftingCPU", "craftingCalculationTimePerTick", this.craftingCalculationTimePerTick)
                     .getInt(this.craftingCalculationTimePerTick);
         }
+
+        final Property pNormalCableChannels = this.get(
+                "Channels",
+                "normalCableChannelCapacity",
+                this.normalCableChannelCapacity,
+                "Number of channels a normal (non-dense) cable can carry. Default: 8. Min: 1. Max: 64",
+                1,
+                64);
+        final int clampedNormalCableChannelCapacity = Math
+                .max(1, Math.min(pNormalCableChannels.getInt(this.normalCableChannelCapacity), 64));
+        pNormalCableChannels.set(clampedNormalCableChannelCapacity);
+        this.normalCableChannelCapacity = clampedNormalCableChannelCapacity;
+
+        final Property pDenseCableChannels = this.get(
+                "Channels",
+                "denseCableChannelCapacity",
+                this.denseCableChannelCapacity,
+                "Number of channels a dense cable can carry. Default: 32. Min: 1. Max: 256",
+                1,
+                256);
+        final int clampedDenseCableChannelCapacity = Math
+                .max(1, Math.min(pDenseCableChannels.getInt(this.denseCableChannelCapacity), 256));
+        pDenseCableChannels.set(clampedDenseCableChannelCapacity);
+        this.denseCableChannelCapacity = clampedDenseCableChannelCapacity;
 
         this.updatable = true;
     }

--- a/src/main/java/appeng/me/GridNode.java
+++ b/src/main/java/appeng/me/GridNode.java
@@ -53,7 +53,6 @@ import appeng.util.ReadOnlyCollection;
 public class GridNode implements IGridNode, IPathItem {
 
     private static final MENetworkChannelsChanged EVENT = new MENetworkChannelsChanged();
-    private static final int[] CHANNEL_COUNT = { 0, 8, 32, Integer.MAX_VALUE };
 
     private final List<GridConnection> connections = new LinkedList<>();
     private final IGridBlock gridProxy;
@@ -567,7 +566,16 @@ public class GridNode implements IGridNode, IPathItem {
     }
 
     public int getMaxChannels() {
-        return CHANNEL_COUNT[this.compressedData & 0x3];
+        switch (this.compressedData & 0x3) {
+            case 1:
+                return AEConfig.instance.normalCableChannelCapacity;
+            case 2:
+                return AEConfig.instance.denseCableChannelCapacity;
+            case 3:
+                return Integer.MAX_VALUE;
+            default:
+                return 0;
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Adds a config option to adjust channel capacities.

Defaults to current behavior. Allows up to 64 normal cable channels, and up to 256 for dense cable (and wireless connector) channels.

Does not adjust the behavior or limit of ad-hoc networks, they remain at a static limit of 8 channels.

Closes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26521

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
