### PR TITLE
test: cover export recovery after power loss

### DIFF
--- a/src/main/java/appeng/gametests/network/power/NetworkPowerTests.java
+++ b/src/main/java/appeng/gametests/network/power/NetworkPowerTests.java
@@ -9,6 +9,9 @@ import static appeng.gametests.AEGameTestHelpers.itemStack;
 import static appeng.gametests.AEGameTestHelpers.part;
 import static appeng.gametests.AEGameTestHelpers.storedAmount;
 
+import java.util.HashSet;
+
+import net.minecraft.entity.item.EntityItem;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -27,6 +30,7 @@ import appeng.api.networking.energy.IEnergyGrid;
 import appeng.api.parts.IPart;
 import appeng.api.storage.StorageName;
 import appeng.core.AppEng;
+import appeng.core.settings.TickRates;
 import appeng.parts.automation.PartExportBus;
 import appeng.tile.inventory.IAEStackInventory;
 import appeng.tile.networking.TileEnergyAcceptor;
@@ -41,10 +45,11 @@ public class NetworkPowerTests {
     private static final String DESTINATION_CHEST_LABEL = "destination_chest";
     private static final String POWER_PROBE_LABEL = "power_probe";
     private static final long COBBLESTONE_COUNT = 16;
+    private static final long RECOVERY_COBBLESTONE_COUNT = 4;
 
     @GameTest(template = "energy_acceptor_network", timeoutTicks = 1200)
     public static void energyAcceptorInjectionBootsGrid(GameTestHelper helper) {
-        NetworkFixture network = setUpNetwork(helper);
+        NetworkFixture network = setUpNetwork(helper, COBBLESTONE_COUNT);
         TickCallbackHandle noPrematureExport = watchForPrematureExport(helper, network);
         TickCallbackHandle conservation = watchCobblestoneConservation(helper, network);
 
@@ -66,7 +71,7 @@ public class NetworkPowerTests {
                         () -> assertExportBusActive(helper, network))
                 .thenWaitUntil(
                         "wait for all cobblestone to reach the destination",
-                        1000,
+                        exportTimeout(COBBLESTONE_COUNT),
                         () -> assertExportComplete(helper, network))
                 .thenExecute("stop continuous invariant checks", () -> {
                     noPrematureExport.disable();
@@ -74,7 +79,65 @@ public class NetworkPowerTests {
                 }).thenSucceed();
     }
 
-    private static NetworkFixture setUpNetwork(GameTestHelper helper) {
+    @GameTest(template = "energy_acceptor_network", timeoutTicks = 1400)
+    public static void powerLossPausesAndRecoveryResumesExport(GameTestHelper helper) {
+        NetworkFixture network = setUpNetwork(helper, RECOVERY_COBBLESTONE_COUNT);
+        TransferSnapshot[] pausedAt = new TransferSnapshot[1];
+        TickCallbackHandle conservation = watchCobblestoneConservation(helper, network);
+        TickCallbackHandle paused = helper.onEachTickDisabled(
+                "export remains paused without power",
+                () -> assertTransferPaused(helper, network, pausedAt[0]));
+        TickCallbackHandle complete = helper.onEachTickDisabled(
+                "completed export does not duplicate or lose items",
+                () -> assertTransferState(helper, network, 0, network.cobblestoneCount()));
+
+        assertTransferState(helper, network, network.cobblestoneCount(), 0);
+
+        helper.startSequence().thenExecuteAtStart("inject initial export power", () -> injectTestPower(helper, network))
+                .thenWaitUntil("wait for powered export bus", 300, () -> {
+                    assertGridPowered(helper, network);
+                    assertExportBusActive(helper, network);
+                    helper.assertTrue(
+                            transferSnapshot(helper, network).networkAmount() > 0,
+                            "Source cell should still contain cobblestone when export becomes ready");
+                }).thenWaitUntil("wait for a strict partial export", exportTimeout(1), () -> {
+                    TransferSnapshot current = transferSnapshot(helper, network);
+                    helper.assertTrue(
+                            current.destinationAmount() > 0 && current.destinationAmount() < network.cobblestoneCount(),
+                            "Expected a strict partial destination count below " + network.cobblestoneCount()
+                                    + "; observed="
+                                    + current.destinationAmount());
+                    assertConserved(helper, network, current);
+                    pausedAt[0] = current;
+                }).thenIdle(1).thenExecuteAtStart("drain all available grid power", () -> {
+                    drainGridPower(helper, network);
+                    paused.enable();
+                }).thenWaitUntil("wait for grid and export bus to become unpowered", 160, () -> {
+                    helper.assertFalse(
+                            energyGrid(helper, network).isNetworkPowered(),
+                            "Energy grid should report unpowered after draining all available power");
+                    assertInactive(helper, network.exportBus(), "Export bus should become inactive after power loss");
+                }).thenIdle(80).thenExecuteAtStart("restore export power", () -> {
+                    assertTransferPaused(helper, network, pausedAt[0]);
+                    paused.disable();
+                    injectTestPower(helper, network);
+                }).thenWaitUntil("wait for grid and export bus to recover", 240, () -> {
+                    assertGridPowered(helper, network);
+                    assertExportBusActive(helper, network);
+                })
+                .thenWaitUntil(
+                        "wait for export to resume and finish",
+                        exportTimeout(network.cobblestoneCount()),
+                        () -> assertTransferState(helper, network, 0, network.cobblestoneCount()))
+                .thenExecute("begin completed-export duplicate guard", complete::enable).thenIdle(60)
+                .thenExecute("stop continuous invariant checks", () -> {
+                    complete.disable();
+                    conservation.disable();
+                    assertTransferState(helper, network, 0, network.cobblestoneCount());
+                }).thenSucceed();
+    }
+
+    private static NetworkFixture setUpNetwork(GameTestHelper helper, long cobblestoneCount) {
         TileEnergyAcceptor energyAcceptor = helper
                 .assertTileEntityPresent(TileEnergyAcceptor.class, ENERGY_ACCEPTOR_LABEL);
         IAEPowerStorage acceptorPower = energyAcceptor;
@@ -82,7 +145,7 @@ public class NetworkPowerTests {
         PartExportBus exportBus = part(helper, EXPORT_BUS_LABEL, PartExportBus.class);
         IPart powerProbe = part(helper, POWER_PROBE_LABEL, ForgeDirection.UNKNOWN);
         ItemStack driveCell = cell1k();
-        insertItems(helper, driveCell, Blocks.cobblestone, COBBLESTONE_COUNT);
+        insertItems(helper, driveCell, Blocks.cobblestone, cobblestoneCount);
         helper.setSlot(DRIVE_LABEL, 0, driveCell);
         configureFilter(helper, exportBus);
 
@@ -90,7 +153,7 @@ public class NetworkPowerTests {
                 acceptorPower.isAEPublicPowerStorage(),
                 "Energy acceptor should expose its public AE power-storage interface");
 
-        return new NetworkFixture(acceptorPower, drive, exportBus, powerProbe);
+        return new NetworkFixture(acceptorPower, drive, exportBus, powerProbe, cobblestoneCount);
     }
 
     private static TickCallbackHandle watchForPrematureExport(GameTestHelper helper, NetworkFixture network) {
@@ -102,14 +165,61 @@ public class NetworkPowerTests {
     }
 
     private static TickCallbackHandle watchCobblestoneConservation(GameTestHelper helper, NetworkFixture network) {
-        return helper.onEachTick("cobblestone is conserved during export", () -> {
-            long networkAmount = storedAmount(helper, network.drive().getStackInSlot(0), Blocks.cobblestone);
-            long destinationAmount = helper.countItems(DESTINATION_CHEST_LABEL, new ItemStack(Blocks.cobblestone));
-            helper.assertEquals(
-                    COBBLESTONE_COUNT,
-                    networkAmount + destinationAmount,
-                    "Cobblestone should be conserved; network=" + networkAmount + ", destination=" + destinationAmount);
-        });
+        return helper.onEachTick(
+                "cobblestone is conserved during export",
+                () -> { assertConserved(helper, network, transferSnapshot(helper, network)); });
+    }
+
+    private static void assertTransferPaused(GameTestHelper helper, NetworkFixture network, TransferSnapshot expected) {
+        helper.assertNotNull(expected, "Partial export snapshot should exist before the pause window");
+        TransferSnapshot observed = transferSnapshot(helper, network);
+        helper.assertEquals(
+                expected.networkAmount(),
+                observed.networkAmount(),
+                "Unpowered export changed the source count; expected=" + expected + ", observed=" + observed);
+        helper.assertEquals(
+                expected.destinationAmount(),
+                observed.destinationAmount(),
+                "Unpowered export changed the destination count; expected=" + expected + ", observed=" + observed);
+        assertConserved(helper, network, observed);
+    }
+
+    private static void assertTransferState(GameTestHelper helper, NetworkFixture network, long expectedNetwork,
+            long expectedDestination) {
+        TransferSnapshot observed = transferSnapshot(helper, network);
+        helper.assertEquals(expectedNetwork, observed.networkAmount(), "Unexpected source count; observed=" + observed);
+        helper.assertEquals(
+                expectedDestination,
+                observed.destinationAmount(),
+                "Unexpected destination count; observed=" + observed);
+        assertConserved(helper, network, observed);
+    }
+
+    private static void assertConserved(GameTestHelper helper, NetworkFixture network, TransferSnapshot observed) {
+        helper.assertEquals(0L, observed.droppedAmount(), "Export must not drop cobblestone; observed=" + observed);
+        helper.assertEquals(
+                network.cobblestoneCount(),
+                observed.networkAmount() + observed.destinationAmount() + observed.droppedAmount(),
+                "Cobblestone should be conserved; observed=" + observed);
+    }
+
+    private static TransferSnapshot transferSnapshot(GameTestHelper helper, NetworkFixture network) {
+        return new TransferSnapshot(
+                storedAmount(helper, network.drive().getStackInSlot(0), Blocks.cobblestone),
+                helper.countItems(DESTINATION_CHEST_LABEL, new ItemStack(Blocks.cobblestone)),
+                droppedCobblestone(helper));
+    }
+
+    private static long droppedCobblestone(GameTestHelper helper) {
+        ItemStack expected = new ItemStack(Blocks.cobblestone);
+        long amount = 0;
+        for (EntityItem drop : helper.getEntities(EntityItem.class, -1, -1, -1, 4, 2, 2)) {
+            ItemStack stack = drop.getEntityItem();
+            if (stack != null && stack.isItemEqual(expected)) {
+                amount += stack.stackSize;
+            }
+        }
+        return amount;
     }
 
     private static void assertUnpoweredExportPreconditions(GameTestHelper helper, NetworkFixture network) {
@@ -123,7 +233,7 @@ public class NetworkPowerTests {
                 "Energy grid should report unpowered before injection");
         assertInactive(helper, network.exportBus(), "Export bus should remain inactive without grid power");
         helper.assertInventoryEmpty(DESTINATION_CHEST_LABEL);
-        assertStoredAmount(helper, network.drive().getStackInSlot(0), Blocks.cobblestone, COBBLESTONE_COUNT);
+        assertStoredAmount(helper, network.drive().getStackInSlot(0), Blocks.cobblestone, network.cobblestoneCount());
     }
 
     private static void injectTestPower(GameTestHelper helper, NetworkFixture network) {
@@ -134,6 +244,20 @@ public class NetworkPowerTests {
         helper.assertTrue(
                 acceptorPower.getAECurrentPower() > 0,
                 "Energy acceptor should contain injected power before the grid consumes it");
+    }
+
+    private static void drainGridPower(GameTestHelper helper, NetworkFixture network) {
+        IEnergyGrid grid = energyGrid(helper, network);
+        IAEPowerStorage acceptor = network.acceptorPower();
+        double available = acceptor.getAECurrentPower();
+        helper.assertTrue(available > 0, "Grid should have power available to drain during partial export");
+        double extracted = grid.extractAEPower(available, Actionable.MODULATE, new HashSet<>());
+        helper.assertEquals(available, extracted, 0.000001, "Grid should drain all available acceptor power");
+        helper.assertEquals(
+                0.0,
+                network.acceptorPower().getAECurrentPower(),
+                0.000001,
+                "Energy acceptor should contain no power after the drain");
     }
 
     private static void assertGridPowered(GameTestHelper helper, NetworkFixture network) {
@@ -147,7 +271,10 @@ public class NetworkPowerTests {
     }
 
     private static void assertExportComplete(GameTestHelper helper, NetworkFixture network) {
-        helper.assertInventoryCount(DESTINATION_CHEST_LABEL, new ItemStack(Blocks.cobblestone), COBBLESTONE_COUNT);
+        helper.assertInventoryCount(
+                DESTINATION_CHEST_LABEL,
+                new ItemStack(Blocks.cobblestone),
+                network.cobblestoneCount());
         assertStoredAmount(helper, network.drive().getStackInSlot(0), Blocks.cobblestone, 0);
     }
 
@@ -155,6 +282,10 @@ public class NetworkPowerTests {
         IAEStackInventory config = exportBus.getAEInventoryByName(StorageName.CONFIG);
         helper.assertNotNull(config, "Export bus config inventory should exist");
         config.putAEStackInSlot(0, itemStack(Blocks.cobblestone, 1));
+    }
+
+    private static int exportTimeout(long itemCount) {
+        return Math.toIntExact((itemCount + 1) * TickRates.ExportBus.getMax());
     }
 
     private static IEnergyGrid energyGrid(GameTestHelper helper, NetworkFixture network) {
@@ -169,5 +300,8 @@ public class NetworkPowerTests {
 
     @Desugar
     private record NetworkFixture(IAEPowerStorage acceptorPower, TileDrive drive, PartExportBus exportBus,
-            IPart powerProbe) {}
+            IPart powerProbe, long cobblestoneCount) {}
+
+    @Desugar
+    private record TransferSnapshot(long networkAmount, long destinationAmount, long droppedAmount) {}
 }


### PR DESCRIPTION
## Summary

- Add a GameTest covering export pause during power loss.
- Verify export resumes after power restoration without item loss or duplication.
- Track item conservation, dropped items, and partial transfer state.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
