### PR TITLE
Fix Annihilation Plane crash when loading Forge Multipart cable buses

### DIFF
--- a/src/main/java/appeng/parts/AEBasePart.java
+++ b/src/main/java/appeng/parts/AEBasePart.java
@@ -570,8 +570,9 @@ public abstract class AEBasePart implements IPart, IGridProxyable, IActionHost, 
     }
 
     private IBlockAccess getHostWorld() {
-        final TileEntity te = this.getTile();
-        return te == null ? null : te.getWorldObj();
+        final IPartHost host = this.getHost();
+        final TileEntity te = host != null ? host.getTile() : this.getTile();
+        return te != null ? te.getWorldObj() : null;
     }
 
     private static int getSideIndexFromDirection(ForgeDirection direction) {


### PR DESCRIPTION
## Summary
Fixes https://discord.com/channels/181078474394566657/522098956491030558/1546018975950049361

During chunk loading, Forge Multipart calls `getBoxes` before its cached TileEntity reference is initialized. This caused a null world reference.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
