### PR TITLE
Fix invalid pattern highlighting after slot updates

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiInterfaceTerminal.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiInterfaceTerminal.java
@@ -1819,6 +1819,7 @@ public class GuiInterfaceTerminal extends AEBaseGui
             final int newHasItem = stack != null ? 1 : 0;
 
             inv.setInventorySlotContents(idx, stack);
+            brokenRecipes[idx] = null;
             numItems += newHasItem - oldHasItem;
             assert numItems >= 0;
         }


### PR DESCRIPTION
## Summary

Fixes invalid pattern highlighting in the Interface Terminal by invalidating the cached recipe state whenever a slot’s contents change. This ensures the red background appears only on slots containing invalid patterns after patterns are moved or replaced.

<img width="186" height="102" alt="image" src="https://github.com/user-attachments/assets/771879df-e087-4af3-93bd-62f72aaa5c37" />



## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
