### PR TITLE
Optimize power injection across Quartz Fiber subnetworks

### DIFF
--- a/src/main/java/appeng/me/cache/EnergyGridCache.java
+++ b/src/main/java/appeng/me/cache/EnergyGridCache.java
@@ -45,6 +45,7 @@ import appeng.me.Grid;
 import appeng.me.GridNode;
 import appeng.me.energy.EnergyThreshold;
 import appeng.me.energy.EnergyWatcher;
+import appeng.parts.networking.PartQuartzFiber;
 
 public class EnergyGridCache implements IEnergyGrid {
 
@@ -338,6 +339,10 @@ public class EnergyGridCache implements IEnergyGrid {
             final Iterator<IEnergyGridProvider> i = this.energyGridProviders.iterator();
             while (amt > 0 && i.hasNext()) {
                 final IEnergyGridProvider what = i.next();
+                if (what.getClass() == PartQuartzFiber.class && seen.getClass() == HashSet.class
+                        && !((PartQuartzFiber) what).hasUnvisitedEnergyGrid(seen)) {
+                    continue;
+                }
                 final Set<IEnergyGrid> listCopy = new HashSet<>(seen);
 
                 final double cannotHold = what.injectAEPower(amt, Actionable.SIMULATE, listCopy);

--- a/src/main/java/appeng/parts/networking/PartQuartzFiber.java
+++ b/src/main/java/appeng/parts/networking/PartQuartzFiber.java
@@ -188,6 +188,15 @@ public class PartQuartzFiber extends AEBasePart implements IEnergyGridProvider {
         return acquiredPower;
     }
 
+    /** True unless both accessible endpoints are already visited. Lookup failures retain the normal path. */
+    public boolean hasUnvisitedEnergyGrid(final Set<IEnergyGrid> seen) {
+        try {
+            return !seen.contains(this.getProxy().getEnergy()) || !seen.contains(this.outerProxy.getEnergy());
+        } catch (final GridAccessException e) {
+            return true;
+        }
+    }
+
     @Override
     public double injectAEPower(final double amt, final Actionable mode, final Set<IEnergyGrid> seen) {
 


### PR DESCRIPTION
## Summary

Skip redundant Quartz Fiber provider work when both endpoint grids have already been visited.

Should reduce both CPU time and temporary allocation when power is injected across Quartz Fiber subnetworks.

### Benchmarks
_Note: Not ingame bench, it's simulated load_

| Workload | Master time | Branch time | Time change | Master allocation | Branch allocation | Allocation change |
|---|---:|---:|---:|---:|---:|---:|
| 4-fiber backlink chain | 1.167 µs/op | 0.970 µs/op | **16.9% less** | 3,656 B/op | 2,816 B/op | **23.0% less** |
| 8-fiber backlink chain | 3.430 µs/op | 2.949 µs/op | **14.0% less** | 9,928 B/op | 7,520 B/op | **24.3% less** |
| 32-fiber backlink chain | 51.894 µs/op | 43.577 µs/op | **16.0% less** | 114,152 B/op | 89,088 B/op | **22.0% less** |
| Partial acceptance and cell drain, 32 fibers | 51.133 µs/op | 44.157 µs/op | **13.6% less** | 114,152 B/op | 89,088 B/op | **22.0% less** |
| Disconnect/reconnect cycle, 32 fibers | 54.094 µs/op | 47.737 µs/op | **11.8% less** | 117,336 B/op | 92,272 B/op | **21.4% less** |
| Forward-first traversal, 32 fibers | 34.917 µs/op | 35.631 µs/op | 2.0% more | 89,088 B/op | 89,088 B/op | No change |
| Single fiber | 0.178 µs/op | 0.185 µs/op | 4.0% more | 632 B/op | 632 B/op | No change |


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
