### PR TITLE
Avoid redundant stack copies in NetworkMonitor

### DIFF
--- a/src/main/java/appeng/me/cache/NetworkMonitor.java
+++ b/src/main/java/appeng/me/cache/NetworkMonitor.java
@@ -251,10 +251,7 @@ public class NetworkMonitor<T extends IAEStack<T>> implements IMEMonitor<T> {
         return this.listeners.entrySet().iterator();
     }
 
-    private T monitorDifference(final IAEStack original, final T leftOvers, final boolean extraction,
-            final BaseActionSource src) {
-        final T diff = (T) original.copy();
-
+    private T monitorDifference(final T diff, final T leftOvers, final boolean extraction, final BaseActionSource src) {
         if (extraction) {
             diff.setStackSize(leftOvers == null ? 0 : -leftOvers.getStackSize());
         } else if (leftOvers != null) {


### PR DESCRIPTION
## Summary

Avoid making an extra copy of the IAEStack, both call already make one.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
