### PR TITLE
Reduce external inventory polling overhead

### DIFF
--- a/src/main/java/appeng/me/storage/MEMonitorIInventory.java
+++ b/src/main/java/appeng/me/storage/MEMonitorIInventory.java
@@ -126,7 +126,7 @@ public class MEMonitorIInventory implements IStorageBusMonitor<IAEItemStack> {
 
         final LinkedList<IAEStack<?>> changes = new LinkedList<>();
 
-        int high = 0;
+        int high = -1;
         boolean changed = false;
         for (final ItemSlot is : this.adaptor) {
             final CachedItemStack old = this.memory.get(is.getSlot());

--- a/src/main/java/appeng/me/storage/MEMonitorIInventory.java
+++ b/src/main/java/appeng/me/storage/MEMonitorIInventory.java
@@ -40,6 +40,8 @@ import appeng.util.item.ItemFilterList;
 
 public class MEMonitorIInventory implements IStorageBusMonitor<IAEItemStack> {
 
+    private static final int CACHE_REFRESH_INTERVAL = 256;
+
     private final InventoryAdaptor adaptor;
     private final IItemList<IAEItemStack> list = AEApi.instance().storage().createItemList();
     private final HashMap<IMEMonitorHandlerReceiver, Object> listeners = new HashMap<>();
@@ -47,6 +49,7 @@ public class MEMonitorIInventory implements IStorageBusMonitor<IAEItemStack> {
     private BaseActionSource mySource;
     private StorageFilter mode = StorageFilter.EXTRACTABLE_ONLY;
     private boolean init = false;
+    private int ticksSinceCacheRefresh = 0;
 
     public MEMonitorIInventory(final InventoryAdaptor adaptor) {
         this.adaptor = adaptor;
@@ -177,10 +180,19 @@ public class MEMonitorIInventory implements IStorageBusMonitor<IAEItemStack> {
             end.clear();
         }
 
-        if (!changes.isEmpty()) {
+        if (++this.ticksSinceCacheRefresh >= CACHE_REFRESH_INTERVAL) {
+            this.list.resetStatus();
+            for (final CachedItemStack cached : this.memory.values()) {
+                this.list.add(cached.aeStack);
+            }
+            this.ticksSinceCacheRefresh = 0;
+        } else {
             for (final IAEStack<?> change : changes) {
                 this.list.add((IAEItemStack) change);
             }
+        }
+
+        if (!changes.isEmpty()) {
             this.postDifference(changes);
         }
 

--- a/src/main/java/appeng/me/storage/MEMonitorIInventory.java
+++ b/src/main/java/appeng/me/storage/MEMonitorIInventory.java
@@ -123,7 +123,6 @@ public class MEMonitorIInventory implements IStorageBusMonitor<IAEItemStack> {
 
         final LinkedList<IAEStack<?>> changes = new LinkedList<>();
 
-        this.list.resetStatus();
         int high = 0;
         boolean changed = false;
         for (final ItemSlot is : this.adaptor) {
@@ -145,7 +144,6 @@ public class MEMonitorIInventory implements IStorageBusMonitor<IAEItemStack> {
 
                 if (cis.aeStack != null) {
                     changes.add(cis.aeStack);
-                    this.list.add(cis.aeStack);
                 }
 
                 changed = true;
@@ -153,19 +151,11 @@ public class MEMonitorIInventory implements IStorageBusMonitor<IAEItemStack> {
                 final int newSize = (newIS == null ? 0 : newIS.stackSize);
                 final int diff = newSize - (oldIS == null ? 0 : oldIS.stackSize);
 
-                final IAEItemStack stack = (old == null || old.aeStack == null
-                        ? AEApi.instance().storage().createItemStack(newIS)
-                        : old.aeStack.copy());
-                if (stack != null) {
-                    stack.setStackSize(newSize);
-                    this.list.add(stack);
-                }
-
-                if (diff != 0 && stack != null) {
+                if (diff != 0 && old != null && old.aeStack != null) {
                     final CachedItemStack cis = new CachedItemStack(is.getItemStack());
                     this.memory.put(is.getSlot(), cis);
 
-                    final IAEItemStack a = stack.copy();
+                    final IAEItemStack a = old.aeStack.copy();
                     a.setStackSize(diff);
                     changes.add(a);
                     changed = true;
@@ -188,6 +178,9 @@ public class MEMonitorIInventory implements IStorageBusMonitor<IAEItemStack> {
         }
 
         if (!changes.isEmpty()) {
+            for (final IAEStack<?> change : changes) {
+                this.list.add((IAEItemStack) change);
+            }
             this.postDifference(changes);
         }
 


### PR DESCRIPTION
## Summary

Change storage buses to update their cached view of external inventories using detected changes instead of rebuilding it on every poll.

Still rebuilt it occasionally (every 256 polls, so between 64s and ~13min depending on how often an inventory change) to prevent any possible long term cache corruption. It's a low risk but still possible over long period of time (can't make dupe but could make export/craft attempt fails).


## Micro benchmark

(medians from three interleaved baseline/candidate runs)

| Inventory state | Slots | Before | After | Time | Before allocation | After allocation | Allocation |
|---|---:|---:|---:|---:|---:|---:|---:|
| Stable | 9 | 271 ns/poll | 135 ns/poll | -50.2% | 184 B/poll | 96 B/poll | -47.5% |
| Stable | 54 | 1,888 ns/poll | 1,268 ns/poll | -32.8% | 360 B/poll | 97 B/poll | -73.0% |
| Stable | 256 | 11,274 ns/poll | 7,589 ns/poll | -32.7% | 3,280 B/poll | 2,164 B/poll | -34.0% |
| Changing | 54 | 2,100 ns/poll | 1,106 ns/poll | -47.3% | 664 B/poll | 401 B/poll | -39.6% |
| Changing | 256 | 12,058 ns/poll | 6,884 ns/poll | -42.9% | 3,624 B/poll | 2,436 B/poll | -32.8% |

_Note: This benchmark isolates inventory polling. The practical effect depends on the number and size of external inventories monitored by storage buses._


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
