### PR TITLE
Reduce grid visitor traversal allocations

### DIFF
--- a/src/functionalTest/java/appeng/test/me/GridNodeTraversalFunctionalTest.java
+++ b/src/functionalTest/java/appeng/test/me/GridNodeTraversalFunctionalTest.java
@@ -1,0 +1,119 @@
+package appeng.test.me;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import appeng.api.networking.IGridConnection;
+import appeng.api.networking.IGridConnectionVisitor;
+import appeng.api.networking.IGridNode;
+import appeng.api.networking.IGridVisitor;
+import appeng.api.util.DimensionalCoord;
+import appeng.me.GridConnection;
+import appeng.me.GridNode;
+import appeng.test.mockme.MockGridBlock;
+
+public class GridNodeTraversalFunctionalTest {
+
+    private final List<GridNode> nodes = new ArrayList<>();
+    private final Map<Object, String> names = new IdentityHashMap<>();
+    private GridNode a;
+    private GridNode e;
+
+    @BeforeEach
+    public void createGraph() throws Exception {
+        // A-B-D-C-A is a cycle; B-E-F is a branch that can be pruned at E.
+        a = node("A");
+        GridNode b = node("B");
+        GridNode c = node("C");
+        GridNode d = node("D");
+        e = node("E");
+        GridNode f = node("F");
+        connect(a, b, "AB");
+        connect(a, c, "AC");
+        connect(b, e, "BE");
+        connect(b, d, "BD");
+        connect(c, d, "CD");
+        connect(e, f, "EF");
+    }
+
+    @AfterEach
+    public void destroyGraph() {
+        for (GridNode node : nodes) {
+            node.destroy();
+        }
+    }
+
+    @Test
+    public void nodesAreVisitedOnceInBreadthFirstOrder() {
+        assertTraversal(false, false, "A", "B", "C", "E", "D", "F");
+    }
+
+    @Test
+    public void connectionsAreVisitedOnceBeforeTheFollowingNodeLayer() {
+        assertTraversal(true, false, "A", "AB", "AC", "B", "C", "BE", "BD", "CD", "E", "D", "EF", "F");
+    }
+
+    @Test
+    public void nodeVisitorPrunesOnlyTheRejectedBranch() {
+        assertTraversal(false, true, "A", "B", "C", "E", "D");
+    }
+
+    @Test
+    public void connectionVisitorPrunesOnlyTheRejectedBranch() {
+        assertTraversal(true, true, "A", "AB", "AC", "B", "C", "BE", "BD", "CD", "E", "D");
+    }
+
+    private void assertTraversal(boolean visitConnections, boolean prune, String... expected) {
+        List<String> events = new ArrayList<>();
+        IGridVisitor nodeVisitor = node -> {
+            events.add(names.get(node));
+            return !prune || node != e;
+        };
+        IGridVisitor visitor = visitConnections ? new IGridConnectionVisitor() {
+
+            @Override
+            public boolean visitNode(IGridNode node) {
+                return nodeVisitor.visitNode(node);
+            }
+
+            @Override
+            public void visitConnection(IGridConnection connection) {
+                events.add(names.get(connection));
+            }
+        } : nodeVisitor;
+
+        // Reuse the graph and visitor to check that iteration markers are local to each traversal.
+        for (int run = 0; run < 2; run++) {
+            events.clear();
+            a.beginVisit(visitor);
+            // Assert after traversal so assertion failures cannot leave crafting rebuilds paused.
+            assertEquals(Arrays.asList(expected), events, "Traversal " + run);
+        }
+    }
+
+    private GridNode node(String name) {
+        GridNode node = new GridNode(new MockGridBlock() {
+
+            @Override
+            public DimensionalCoord getLocation() {
+                return new DimensionalCoord(0, 0, 0, 0);
+            }
+        });
+        nodes.add(node);
+        names.put(node, name);
+        return node;
+    }
+
+    private void connect(GridNode from, GridNode to, String name) throws Exception {
+        names.put(new GridConnection(from, to, null), name);
+    }
+}

--- a/src/main/java/appeng/me/GridNode.java
+++ b/src/main/java/appeng/me/GridNode.java
@@ -10,6 +10,8 @@
 
 package appeng.me;
 
+import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Deque;
 import java.util.EnumSet;
 import java.util.LinkedList;
@@ -159,33 +161,30 @@ public class GridNode implements IGridNode, IPathItem {
 
         CraftingGridCache.pauseRebuilds();
 
-        LinkedList<GridNode> nextRun = new LinkedList<>();
+        final Deque<GridNode> nextRun = new ArrayDeque<>();
         nextRun.add(this);
 
         this.visitorIterationNumber = tracker;
 
         if (g instanceof IGridConnectionVisitor gcv) {
-            final LinkedList<IGridConnection> nextConn = new LinkedList<>();
+            final List<IGridConnection> nextConn = new ArrayList<>(this.connections.size());
 
             while (!nextRun.isEmpty()) {
-                while (!nextConn.isEmpty()) {
-                    gcv.visitConnection(nextConn.poll());
+                for (final IGridConnection connection : nextConn) {
+                    gcv.visitConnection(connection);
                 }
+                nextConn.clear();
 
-                final Iterable<GridNode> thisRun = nextRun;
-                nextRun = new LinkedList<>();
-
-                for (final GridNode n : thisRun) {
-                    n.visitorConnection(tracker, g, nextRun, nextConn);
+                final int nodesThisRun = nextRun.size();
+                for (int i = 0; i < nodesThisRun; i++) {
+                    nextRun.removeFirst().visitorConnection(tracker, g, nextRun, nextConn);
                 }
             }
         } else {
             while (!nextRun.isEmpty()) {
-                final Iterable<GridNode> thisRun = nextRun;
-                nextRun = new LinkedList<>();
-
-                for (final GridNode n : thisRun) {
-                    n.visitorNode(tracker, g, nextRun);
+                final int nodesThisRun = nextRun.size();
+                for (int i = 0; i < nodesThisRun; i++) {
+                    nextRun.removeFirst().visitorNode(tracker, g, nextRun);
                 }
             }
         }
@@ -461,7 +460,7 @@ public class GridNode implements IGridNode, IPathItem {
     }
 
     private void visitorConnection(final Object tracker, final IGridVisitor g, final Deque<GridNode> nextRun,
-            final Deque<IGridConnection> nextConnections) {
+            final List<IGridConnection> nextConnections) {
         if (g.visitNode(this)) {
             for (final IGridConnection gc : this.getConnections()) {
                 final GridNode gn = (GridNode) gc.getOtherSide(this);


### PR DESCRIPTION
## Summary

Reduces temporary object creation when walking through an AE network while keeping the traversal behavior unchanged.
Replaces LinkedList queues with ArrayDeque and reuses the connection list between traversal steps.



### Local microbenchmark
_median of five forked JVM runs after warmup. Not actual server run but isolated on beginVisit()._

| Topology and visitor | Time per traversal | Allocation per traversal |
| --- | ---: | ---: |
| 64-node line, nodes | 783 ns → 579 ns (-26.1%) | 3,632 B → 104 B (-97.1%) |
| 255-node tree, nodes | 4.01 µs → 3.21 µs (-19.8%) | 6,424 B → 1,744 B (-72.9%) |
| 32×32 grid, nodes | 18.77 µs → 18.56 µs (-1.1%) | 26,640 B → 288 B (-98.9%) |
| 255-node tree, connections | 4.85 µs → 4.73 µs (-2.4%) | 12,552 B → 3,680 B (-70.7%) |
| 32×32 grid, connections | 28.88 µs → 23.09 µs (-20.0%) | 74,288 B → 1,248 B (-98.3%) |
| 257-node star, connections | 4.78 µs → 4.74 µs (-0.8%) | 12,456 B → 5,336 B (-57.2%) |


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)