### PR TITLE
Reuse crafting pattern snapshots between requests

### DIFF
--- a/src/main/java/appeng/me/cache/CraftingGridCache.java
+++ b/src/main/java/appeng/me/cache/CraftingGridCache.java
@@ -127,6 +127,8 @@ public class CraftingGridCache
     protected final OreListMultiMap<ICraftingPatternDetails> craftableItemSubstitutes = new OreListMultiMap<>();
     protected final Map<IAEItemStack, ImmutableList<ICraftingPatternDetails>> craftableItemsLegacy = new HashMap<>();
     protected final Map<IAEStack<?>, ImmutableList<ICraftingPatternDetails>> craftableItems = new HashMap<>();
+    private ImmutableMap<IAEStack<?>, ImmutableList<ICraftingPatternDetails>> craftableItemsSnapshot = ImmutableMap
+            .of();
     protected final Map<UUID, ICraftingPatternDetails> inputOnlyPatterns = new HashMap<>();
     protected final Map<String, CraftingLinkNexus> craftingLinks = new HashMap<>();
     protected final Multimap<IAEStack, CraftingWatcher> interests = HashMultimap.create();
@@ -370,6 +372,8 @@ public class CraftingGridCache
             final IAEItemStack ais = stackConvert(e.getKey());
             if (ais != null) craftableItemsLegacy.put(ais, ImmutableList.copyOf(e.getValue()));
         }
+
+        this.craftableItemsSnapshot = ImmutableMap.copyOf(this.craftableItems);
     }
 
     public ICraftingPatternDetails getInputOnlyPattern(final UUID uuid) {
@@ -554,7 +558,7 @@ public class CraftingGridCache
 
     @Override
     public ImmutableMap<IAEStack<?>, ImmutableList<ICraftingPatternDetails>> getCraftingMultiPatterns() {
-        return ImmutableMap.copyOf(this.craftableItems);
+        return this.craftableItemsSnapshot;
     }
 
     @Override


### PR DESCRIPTION
## Summary

Builds the immutable crafting pattern snapshot once per cache rebuild and shares it between crafting requests instead of copying the complete map for every job.

The tradeoff is one retained immutable snapshot per grid and one copy per pattern rebuild, instead of one separately allocated snapshot per request.

### local microbenchmark 

_median of five forked JVM runs after warmup. Not actual server run but isolated on snapshot retrieval._

| Craftable outputs | Snapshot retrieval | Allocation per retrieval |
| ---: | ---: | ---: |
| 64 | 525 ns → 21 ns (-96.0%) | 2,392 B → 0 B |
| 512 | 4.42 µs → 69 ns (-98.4%) | 18,520 B → 0 B |
| 4,096 | 40.22 µs → 111 ns (-99.7%) | 147,544 B → effectively 0 B |


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
