### PR TITLE
fix: creative essentia appearance of existance

### DIFF
--- a/src/main/java/appeng/me/storage/CreativeCellInventory.java
+++ b/src/main/java/appeng/me/storage/CreativeCellInventory.java
@@ -235,7 +235,7 @@ public class CreativeCellInventory<StackType extends IAEStack<StackType>>
 
     @Override
     public int getStatusForCell() {
-        return 0;
+        return 2;
     }
 
     @Override

--- a/src/main/java/appeng/tile/storage/TileDrive.java
+++ b/src/main/java/appeng/tile/storage/TileDrive.java
@@ -127,7 +127,7 @@ public class TileDrive extends AENetworkInvTile
             return (this.state >> (slot * 3)) & 0b111;
         }
 
-        final ItemStack cell = this.inv.getStackInSlot(2);
+        final ItemStack cell = this.inv.getStackInSlot(slot);
         final ICellHandler ch = this.handlersBySlot[slot];
 
         final MEInventoryHandler<IAEItemStack> handler = this.invBySlot[slot];


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
currently this cell would hide from showing its existance, although it could just work
the root cause of this issue is that there is no override func for the creative essentia cell to correctly tell the render its status, thus fallback to the default handler, and the status is hardcoded 0 here.

for the symantic, doc says that:
```
IChestOrDrive
0 - cell is missing.
1 - green, ( usually means the cell is 100% free )
2 - blue, ( usually means available room for types or items. )
3 - orange, ( usually means available room for items, but not types. )
4 - red, ( usually means the cell is 100% full )
```
so that 0 is just telling the ae2 there is 0 cell in the slot and just renders as 0 cell here

then i have verified that the creative essentia cell is just behaving as void excess, and it is not good enough to just make another handler for that, also void excess is just the default behavior of the creative cells, so i just changed the value to 2 and it is now fixed.

effect:
<img width="856" height="512" alt="屏幕截图 2026-09-09 232812" src="https://github.com/user-attachments/assets/382baad2-7901-4cf3-931b-b10e0a374b16" />

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
