### PR TITLE
Memory Card now copies patterns

### DIFF
--- a/src/main/java/appeng/block/AEBaseTileBlock.java
+++ b/src/main/java/appeng/block/AEBaseTileBlock.java
@@ -49,6 +49,7 @@ import appeng.core.features.AETileBlockFeatureHandler;
 import appeng.core.features.IAEFeature;
 import appeng.core.sync.GuiBridge;
 import appeng.helpers.ICustomCollision;
+import appeng.helpers.IInterfaceHost;
 import appeng.items.tools.ToolMemoryCard;
 import appeng.items.tools.ToolPriorityCard;
 import appeng.items.tools.quartz.ToolQuartzCuttingKnife;
@@ -270,6 +271,10 @@ public abstract class AEBaseTileBlock extends AEBaseBlock implements IAEFeature,
                                             (UpgradeInventory) iuh.getInventoryByName("upgrades"));
                                 }
 
+                                if (t instanceof IInterfaceHost iHost) {
+                                    ToolMemoryCard.savePatterns(data, iHost);
+                                }
+
                                 memoryCard.notifyUser(player, MemoryCardMessages.SETTINGS_SAVED);
                             }
                             return true;
@@ -289,6 +294,10 @@ public abstract class AEBaseTileBlock extends AEBaseBlock implements IAEFeature,
                             // Apply settings after insertUpgrades to preserve upgrade-gated settings, such as ore
                             // filters.
                             t.uploadSettings(SettingsFrom.MEMORY_CARD, data);
+
+                            if (t instanceof IInterfaceHost iHost) {
+                                ToolMemoryCard.insertPatterns(data, player, iHost);
+                            }
 
                             memoryCard.notifyUser(player, MemoryCardMessages.SETTINGS_LOADED);
                         } else {

--- a/src/main/java/appeng/items/tools/ToolMemoryCard.java
+++ b/src/main/java/appeng/items/tools/ToolMemoryCard.java
@@ -30,6 +30,9 @@ import org.jetbrains.annotations.Nullable;
 
 import com.gtnewhorizon.gtnhlib.item.ItemStackNBT;
 
+import appeng.api.AEApi;
+import appeng.api.definitions.IItemDefinition;
+import appeng.api.implementations.ICraftingPatternItem;
 import appeng.api.implementations.items.IMemoryCard;
 import appeng.api.implementations.items.INetworkToolItem;
 import appeng.api.implementations.items.MemoryCardMessages;
@@ -37,6 +40,7 @@ import appeng.core.features.AEFeature;
 import appeng.core.localization.ButtonToolTips;
 import appeng.core.localization.GuiText;
 import appeng.core.localization.PlayerMessages;
+import appeng.helpers.IInterfaceHost;
 import appeng.items.AEBaseItem;
 import appeng.items.contents.NetworkToolViewer;
 import appeng.parts.automation.UpgradeInventory;
@@ -165,6 +169,91 @@ public class ToolMemoryCard extends AEBaseItem implements IMemoryCard {
             }
             if (tagList.tagCount() > 0) data.setTag("upgradesList", tagList);
         }
+    }
+
+    private static final String PATTERNS_KEY = "interfacePatterns";
+
+    public static void savePatterns(final NBTTagCompound data, final IInterfaceHost iHost) {
+        final IInventory patterns = iHost.getInterfaceDuality().getPatterns();
+        final NBTTagList tagList = new NBTTagList();
+
+        for (int i = 0; i < patterns.getSizeInventory(); i++) {
+            final ItemStack is = patterns.getStackInSlot(i);
+            if (is == null || !(is.getItem() instanceof ICraftingPatternItem)) {
+                continue;
+            }
+
+            final NBTTagCompound tag = new NBTTagCompound();
+            is.writeToNBT(tag);
+            tag.setInteger("Slot", i);
+            tagList.appendTag(tag);
+        }
+
+        if (tagList.tagCount() > 0) {
+            data.setTag(PATTERNS_KEY, tagList);
+        }
+    }
+
+    public static void insertPatterns(final NBTTagCompound data, final EntityPlayer player,
+            final IInterfaceHost iHost) {
+        if (!data.hasKey(PATTERNS_KEY, NBT.TAG_LIST)) {
+            return;
+        }
+
+        final IInventory patterns = iHost.getInterfaceDuality().getPatterns();
+        final int enabled = Math.min(iHost.rows() * iHost.rowSize(), patterns.getSizeInventory());
+        final NBTTagList tagList = data.getTagList(PATTERNS_KEY, NBT.TAG_COMPOUND);
+
+        for (int i = 0; i < tagList.tagCount(); i++) {
+            final NBTTagCompound tag = tagList.getCompoundTagAt(i);
+            final ItemStack pattern = ItemStack.loadItemStackFromNBT(tag);
+            if (pattern == null) {
+                continue;
+            }
+
+            final int slot = findFreeSlot(patterns, enabled, tag.getInteger("Slot"));
+            if (slot < 0 || !consumeBlankPattern(player)) {
+                return;
+            }
+
+            patterns.setInventorySlotContents(slot, pattern);
+        }
+    }
+
+    /**
+     * Free slot below {@code enabled}, preferring the requested one. -1 when full.
+     */
+    private static int findFreeSlot(final IInventory patterns, final int enabled, final int preferred) {
+        if (preferred >= 0 && preferred < enabled && patterns.getStackInSlot(preferred) == null) {
+            return preferred;
+        }
+
+        for (int i = 0; i < enabled; i++) {
+            if (patterns.getStackInSlot(i) == null) {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private static boolean consumeBlankPattern(final EntityPlayer player) {
+        if (player.capabilities.isCreativeMode) {
+            return true;
+        }
+
+        final IItemDefinition blank = AEApi.instance().definitions().materials().blankPattern();
+
+        for (int i = 0; i < player.inventory.getSizeInventory(); i++) {
+            if (blank.isSameAs(player.inventory.getStackInSlot(i))) {
+                player.inventory.decrStackSize(i, 1);
+                player.inventory.markDirty();
+                player.inventoryContainer.detectAndSendChanges();
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public static void insertUpgrades(final NBTTagCompound data, final EntityPlayer player, final UpgradeInventory up) {

--- a/src/main/java/appeng/parts/AEBasePart.java
+++ b/src/main/java/appeng/parts/AEBasePart.java
@@ -60,6 +60,7 @@ import appeng.api.util.DimensionalCoord;
 import appeng.api.util.IConfigManager;
 import appeng.core.sync.GuiBridge;
 import appeng.helpers.ICustomNameObject;
+import appeng.helpers.IInterfaceHost;
 import appeng.helpers.IOreFilterable;
 import appeng.helpers.IPriorityHost;
 import appeng.items.tools.ToolMemoryCard;
@@ -443,6 +444,10 @@ public abstract class AEBasePart implements IPart, IGridProxyable, IActionHost, 
                     if (this.getInventoryByName("upgrades") instanceof UpgradeInventory ui)
                         ToolMemoryCard.setUpgradesInfo(data, ui);
 
+                    if (this instanceof IInterfaceHost iHost) {
+                        ToolMemoryCard.savePatterns(data, iHost);
+                    }
+
                     memoryCard.notifyUser(player, MemoryCardMessages.SETTINGS_SAVED);
                 }
             } else {
@@ -456,6 +461,11 @@ public abstract class AEBasePart implements IPart, IGridProxyable, IActionHost, 
 
                     // Apply settings after insertUpgrades to preserve upgrade-gated settings, such as ore filters.
                     this.uploadSettings(SettingsFrom.MEMORY_CARD, data);
+
+                    // After insertUpgrades for the same reason as above
+                    if (this instanceof IInterfaceHost iHost) {
+                        ToolMemoryCard.insertPatterns(data, player, iHost);
+                    }
 
                     memoryCard.notifyUser(player, MemoryCardMessages.SETTINGS_LOADED);
                 } else {


### PR DESCRIPTION
## Summary
The patterns and which slot they are in are saved on the card.
On paste, if the player has blank patterns in their inventory, it will try to match the slot the pattern is in first, falling back to the next blank one.


Preview:

https://github.com/user-attachments/assets/415abeeb-cb78-4908-8043-200dba376464

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge


