### PR TITLE
chore: bump Horizon-QA to 0.14.1

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -53,7 +53,7 @@ dependencies {
         exclude module: "waila"
     }
 
-    devOnlyNonPublishable("com.github.GTNewHorizons:Horizon-QA:0.14.0:dev")
+    devOnlyNonPublishable("com.github.GTNewHorizons:Horizon-QA:0.14.1:dev")
 
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:Postea:1.2.6:dev")
     runtimeOnlyNonPublishable('com.github.GTNewHorizons:waila:1.19.34:dev') {transitive = false}


### PR DESCRIPTION
## Summary

Bumps the Horizon-QA development dependency from version 0.14.0 to 0.14.1.


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge