### PR TITLE
Fix color applicator cleaning

### DIFF
--- a/src/main/java/appeng/integration/abstraction/IGT.java
+++ b/src/main/java/appeng/integration/abstraction/IGT.java
@@ -10,11 +10,15 @@
 
 package appeng.integration.abstraction;
 
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.ForgeDirection;
 
 public interface IGT {
 
     boolean isGTMachine(TileEntity te);
 
     int getGTMachineHash(TileEntity te);
+
+    boolean removeColor(EntityPlayer player, int x, int y, int z, ForgeDirection side);
 }

--- a/src/main/java/appeng/integration/modules/GT.java
+++ b/src/main/java/appeng/integration/modules/GT.java
@@ -1,6 +1,8 @@
 package appeng.integration.modules;
 
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.ForgeDirection;
 
 import appeng.api.AEApi;
 import appeng.api.exceptions.ModNotInstalled;
@@ -13,6 +15,7 @@ import appeng.integration.abstraction.IGT;
 import appeng.spatial.NBTSpatialHandler;
 import cpw.mods.fml.common.Loader;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+import gregtech.api.util.ColoredBlockContainer;
 
 public class GT implements IIntegrationModule, IGT {
 
@@ -52,5 +55,10 @@ public class GT implements IIntegrationModule, IGT {
         // PartStorageBus uses 0 to represent 'no hash' so we offset the numbers up one here. They just need to be
         // distinct. This controls when the item IO is reset.
         return igte.canAccessData() ? 2 : 1;
+    }
+
+    @Override
+    public boolean removeColor(EntityPlayer player, int x, int y, int z, ForgeDirection side) {
+        return ColoredBlockContainer.getInstance(player, x, y, z, side).removeColor();
     }
 }

--- a/src/main/java/appeng/items/tools/powered/ToolColorApplicator.java
+++ b/src/main/java/appeng/items/tools/powered/ToolColorApplicator.java
@@ -68,6 +68,9 @@ import appeng.core.sync.packets.PacketColorSelect;
 import appeng.helpers.IMouseWheelItem;
 import appeng.hooks.DispenserBlockTool;
 import appeng.hooks.IBlockTool;
+import appeng.integration.IntegrationRegistry;
+import appeng.integration.IntegrationType;
+import appeng.integration.abstraction.IGT;
 import appeng.items.contents.CellConfig;
 import appeng.items.contents.CellConfigLegacy;
 import appeng.items.contents.CellUpgrades;
@@ -216,16 +219,13 @@ public class ToolColorApplicator extends AEBasePoweredItem
         }
 
         if (success) {
-            if (this.consumePowerAndItemsForTe(targetTe)) {
-                inv.extractItems(AEItemStack.create(paintSource), Actionable.MODULATE, new BaseActionSource());
-                this.extractAEPower(stack, POWER_PER_USE);
+            inv.extractItems(AEItemStack.create(paintSource), Actionable.MODULATE, new BaseActionSource());
+            this.extractAEPower(stack, POWER_PER_USE);
 
-                final IAEItemStack newStack = inv
-                        .extractItems(AEItemStack.create(activeConfig), Actionable.SIMULATE, new BaseActionSource());
-                if (newStack == null) {
-                    this.cycleColors(stack, this.getColor(stack), 1);
-
-                }
+            final IAEItemStack newStack = inv
+                    .extractItems(AEItemStack.create(activeConfig), Actionable.SIMULATE, new BaseActionSource());
+            if (newStack == null) {
+                this.cycleColors(stack, this.getColor(stack), 1);
             }
 
             // Retuning false when using offhand means only the normal hand animation will play
@@ -255,6 +255,22 @@ public class ToolColorApplicator extends AEBasePoweredItem
             }
         }
 
+        final IGT gt = IntegrationRegistry.INSTANCE.getInstanceIfEnabled(IntegrationType.GT);
+        if (gt != null && gt.removeColor(player, x, y, z, side)) {
+            return true;
+        }
+
+        final Block block = world.getBlock(x, y, z);
+        if (block == Blocks.stained_glass) {
+            return world.setBlock(x, y, z, Blocks.glass, 0, 3);
+        }
+        if (block == Blocks.stained_glass_pane) {
+            return world.setBlock(x, y, z, Blocks.glass_pane, 0, 3);
+        }
+        if (block == Blocks.stained_hardened_clay) {
+            return world.setBlock(x, y, z, Blocks.hardened_clay, 0, 3);
+        }
+
         int tx = x + side.offsetX;
         int ty = y + side.offsetY;
         int tz = z + side.offsetZ;
@@ -277,10 +293,6 @@ public class ToolColorApplicator extends AEBasePoweredItem
         }
 
         return this.recolourBlock(block, side, world, x, y, z, side, color, player);
-    }
-
-    private boolean consumePowerAndItemsForTe(TileEntity tileEntity) {
-        return (tileEntity instanceof IColorableTile);
     }
 
     @Override


### PR DESCRIPTION
## Summary

Adds GT-backed color removal to the AE2 Color Applicator, with vanilla block-cleaning fallbacks. Ensures snowballs and AE power are consumed after every successful cleaning operation.

Closes #1375

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
