### PR TITLE
add client setting to cable anchor's ladder ability

### DIFF
--- a/src/main/java/appeng/core/AEConfig.java
+++ b/src/main/java/appeng/core/AEConfig.java
@@ -104,7 +104,7 @@ public final class AEConfig extends Configuration implements IConfigurableObject
     public boolean highlightPatternTypeMismatchInGUI = true;
     public int screenColor = 0xFFFFFF;
     private boolean useLiteCraftingMode = false;
-    public boolean anchorsFunctionAsLadders = true;
+    public boolean anchorsFunctionAsLadders = false;
 
     /** Max rows for crafting pins section (1-16). Caps the cycle button options. */
     public int maxCraftingPinRows = 16;
@@ -431,7 +431,7 @@ public final class AEConfig extends Configuration implements IConfigurableObject
         this.visualiserWidthNormal = (float) this.get("Client", "visualiserWidthNormal", 1.0f).getDouble(1.0f);
         this.useLiteCraftingMode = this.get("Client", "isLiteCraftingEnabled", this.useLiteCraftingMode)
                 .getBoolean(this.useLiteCraftingMode);
-        this.anchorsFunctionAsLadders = this.get("Client", "anchorsFunctionAsLadders", true).getBoolean(true);
+        this.anchorsFunctionAsLadders = this.get("Client", "anchorsFunctionAsLadders", false).getBoolean(true);
 
         // Pin options (under Client category)
         Property pMaxCraft = this.get("Client", "maxCraftingPinRows", this.maxCraftingPinRows);

--- a/src/main/java/appeng/core/AEConfig.java
+++ b/src/main/java/appeng/core/AEConfig.java
@@ -104,6 +104,7 @@ public final class AEConfig extends Configuration implements IConfigurableObject
     public boolean highlightPatternTypeMismatchInGUI = true;
     public int screenColor = 0xFFFFFF;
     private boolean useLiteCraftingMode = false;
+    public boolean anchorsFunctionAsLadders = true;
 
     /** Max rows for crafting pins section (1-16). Caps the cycle button options. */
     public int maxCraftingPinRows = 16;
@@ -430,6 +431,7 @@ public final class AEConfig extends Configuration implements IConfigurableObject
         this.visualiserWidthNormal = (float) this.get("Client", "visualiserWidthNormal", 1.0f).getDouble(1.0f);
         this.useLiteCraftingMode = this.get("Client", "isLiteCraftingEnabled", this.useLiteCraftingMode)
                 .getBoolean(this.useLiteCraftingMode);
+        this.anchorsFunctionAsLadders = this.get("Client", "anchorsFunctionAsLadders", true).getBoolean(true);
 
         // Pin options (under Client category)
         Property pMaxCraft = this.get("Client", "maxCraftingPinRows", this.maxCraftingPinRows);

--- a/src/main/java/appeng/parts/misc/PartCableAnchor.java
+++ b/src/main/java/appeng/parts/misc/PartCableAnchor.java
@@ -34,6 +34,7 @@ import appeng.api.parts.IPartHost;
 import appeng.api.parts.IPartRenderHelper;
 import appeng.api.parts.ISimplifiedBundle;
 import appeng.api.parts.PartItemStack;
+import appeng.core.AEConfig;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import io.netty.buffer.ByteBuf;
@@ -126,7 +127,8 @@ public class PartCableAnchor implements IPart {
 
     @Override
     public boolean isLadder(final EntityLivingBase entity) {
-        return this.mySide.offsetY == 0 && (entity.isCollidedHorizontally || !entity.onGround);
+        return AEConfig.instance.anchorsFunctionAsLadders && this.mySide.offsetY == 0
+                && (entity.isCollidedHorizontally || !entity.onGround);
     }
 
     @Override


### PR DESCRIPTION
player will only climb cable anchors if this option is enabled (off by default)
it's called `anchorsFunctionAsLadders` in the `client` section

closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26743

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
