### PR TITLE
fix multipart host bindings and placement validation

### DIFF
--- a/src/main/java/appeng/fmp/CableBusPart.java
+++ b/src/main/java/appeng/fmp/CableBusPart.java
@@ -63,6 +63,7 @@ import codechicken.multipart.JNormalOcclusion;
 import codechicken.multipart.NormalOcclusionTest;
 import codechicken.multipart.NormallyOccludedPart;
 import codechicken.multipart.TMultiPart;
+import codechicken.multipart.TileMultipart;
 import codechicken.multipart.scalatraits.TIInventoryTile;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -148,6 +149,12 @@ public class CableBusPart extends JCuboidPart implements JNormalOcclusion, IMask
     @Override
     public int getLightValue() {
         return this.getCableBus().getLightValue();
+    }
+
+    @Override
+    public void bind(final TileMultipart tile) {
+        super.bind(tile);
+        this.getCableBus().updatePartHostInfo();
     }
 
     @Override
@@ -459,6 +466,9 @@ public class CableBusPart extends JCuboidPart implements JNormalOcclusion, IMask
 
     @Override
     public ForgeDirection addPart(final ItemStack is, final ForgeDirection side, final EntityPlayer owner) {
+        if (!this.canAddPart(is, side)) {
+            return null;
+        }
         return this.getCableBus().addPart(is, side, owner);
     }
 

--- a/src/main/java/appeng/parts/CableBusContainer.java
+++ b/src/main/java/appeng/parts/CableBusContainer.java
@@ -82,6 +82,18 @@ public class CableBusContainer extends CableBusStorage implements AEMultiTile, I
     public void setHost(final IPartHost host) {
         this.tcb.clearContainer();
         this.tcb = host;
+        this.updatePartHostInfo();
+    }
+
+    /** Refreshes part bindings when the host or its backing tile changes, without restarting the parts. */
+    public void updatePartHostInfo() {
+        final TileEntity tile = this.getTile();
+        for (final ForgeDirection side : ForgeDirection.values()) {
+            final IPart part = this.getPart(side);
+            if (part != null) {
+                part.setPartHostInfo(side, this, tile);
+            }
+        }
     }
 
     public void rotateLeft() {
@@ -482,7 +494,7 @@ public class CableBusContainer extends CableBusStorage implements AEMultiTile, I
         this.inWorld = true;
         IS_LOADING.set(true);
 
-        final TileEntity te = this.getTile();
+        this.updatePartHostInfo();
 
         // start with the center, then install the side parts into the grid.
         for (int x = 6; x >= 0; x--) {
@@ -490,7 +502,6 @@ public class CableBusContainer extends CableBusStorage implements AEMultiTile, I
             final IPart part = this.getPart(s);
 
             if (part != null) {
-                part.setPartHostInfo(s, this, te);
                 part.addToWorld();
 
                 if (s != ForgeDirection.UNKNOWN) {


### PR DESCRIPTION
## Summary
refresh part host references when ForgeMultipart replaces the backing tile, and enforce multipart occlusion checks when adding AE2 parts

related to https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26750

merge with https://github.com/GTNewHorizons/ForgeMultipart/pull/58
merge with https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/469

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge

