### PR TITLE
Fixed a bug in submitting jobs #26770

### DIFF
--- a/src/main/java/appeng/me/cache/CraftingGridCache.java
+++ b/src/main/java/appeng/me/cache/CraftingGridCache.java
@@ -724,7 +724,7 @@ public class CraftingGridCache
         if (cpuCluster != null) {
             ICraftingLink submittedJob = cpuCluster.submitJob(this.grid, job, src, requestingMachine);
 
-            if (src instanceof PlayerSource playerSource && followCraft) {
+            if (submittedJob != null && src instanceof PlayerSource playerSource && followCraft) {
                 cpuCluster.togglePlayerFollowStatus(playerSource.player.getCommandSenderName());
             }
 


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
(Closes GTNewHorizons/GT-New-Horizons-Modpack#26770)

Added the submittedJob != null &&  line so if the level maintainer and the player consume the cpu in the same tick the followCraft will not follow a null type job.

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
