### PR TITLE
Fix Reshuffle progress bar end marker

### DIFF
--- a/src/main/java/appeng/client/gui/implementations/GuiStorageReshuffle.java
+++ b/src/main/java/appeng/client/gui/implementations/GuiStorageReshuffle.java
@@ -587,7 +587,14 @@ public class GuiStorageReshuffle extends AEBaseGui {
                     barY + 6,
                     ColorUtils.reshuffleProgressFillStart.getColor(),
                     (ColorUtils.reshuffleProgressFillEnd.getColor() & 0xFFFFFF00) | alpha);
-            drawRect(barX + fill - 1, barY, barX + fill + 1, barY + 6, ColorUtils.reshuffleProgressMarker.getColor());
+            if (progressPercent < 100) {
+                drawRect(
+                        barX + fill - 1,
+                        barY,
+                        barX + fill + 1,
+                        barY + 6,
+                        ColorUtils.reshuffleProgressMarker.getColor());
+            }
         }
         this.fontRendererObj
                 .drawString(progressPercent + "%", barX + barW + 3, barY, ColorUtils.guiTextColorGray.getColor());


### PR DESCRIPTION
## Summary
Remove the marker when the progress bar is at 100% making my ocd go to sleep


| Before | After |
| - | - |
| <img width="500" height="67" alt="image" src="https://github.com/user-attachments/assets/33542c1d-d4e1-417a-a10f-c18b86ef9eee" /> | <img width="558" height="90" alt="END" src="https://github.com/user-attachments/assets/bd1ffab8-ec6d-44c2-9cea-dbfe7941af70" /> |

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
